### PR TITLE
Fix exception "Serialization of 'Closure' is not allowed" when running tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <phpunit backupGlobals="false"
-         backupStaticAttributes="true"
+         backupStaticAttributes="false"
 		 bootstrap="./tests/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"


### PR DESCRIPTION
PHPUnit has an issue serializing closures, and `Doctrine\Instantiator\Instantiator` contains a closure. The `$backupStaticAttributesBlacklist` property canot be configured on the fly and must be configured as a class property.
