### PR TITLE
Class 'AbstractMigration' not found

### DIFF
--- a/src/Template/Bake/classes/migration.ctp
+++ b/src/Template/Bake/classes/migration.ctp
@@ -12,9 +12,10 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-use Phinx\Migration\AbstractMigration;
 %>
 <?php
+use Phinx\Migration\AbstractMigration;
+
 class <%= $name %> extends AbstractMigration {
 
 /**


### PR DESCRIPTION
when calling 

``` php
php cake.php bake migration Initial -c default
```

the migration file is created with the correct table datas. but, when calling

``` php
php cake.php migrations migrate
```

i'm receiving an error. 

```
Class 'AbstractMigration' not found in /vagrant/APP_NAME/config/Migrations/20141204113546_initial.php on line 2
```

it looks like "use"-statement wasn't correctly placed inside the generated <?php tag.
