### PR TITLE
Correct template and add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Define the line ending behavior of the different file extensions
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+* text eol=lf

--- a/src/Template/Bake/config/migration.ctp
+++ b/src/Template/Bake/config/migration.ctp
@@ -24,9 +24,7 @@ class <%= $name %> extends AbstractMigration {
      * More information on this method is available here:
      * http://docs.phinx.org/en/latest/migrations.html#the-change-method
      *
-     * Uncomment this method if you would like to use it.
      * @return void
-     *
      */
     public function change()
     {


### PR DESCRIPTION
Fix the baked output on WIN.
Without the gitattributes file the output is scrambled, as different types of newline in the same document mess it up.
