### PR TITLE
plugin installer is required by cakephp/app

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": ">=5.4",
-        "cakephp/plugin-installer": "*",
         "robmorgan/phinx": "*",
         "cakephp/cakephp": "3.0.x-dev"
     },


### PR DESCRIPTION
Plugins themselves don't actually depend on the plugin installer, only
apps using plugins do (arguably, even then they don't)

Would be a good idea to let some time pass after 216 is merged, so that users still have a reference to the plugin installer.

Depends on cakephp/app#216