### PR TITLE
Allow generating migrations without a db connection

### DIFF
--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -14,6 +14,9 @@
 namespace Migrations\Shell\Task;
 
 use Cake\Core\Configure;
+use Cake\Datasource\ConnectionManager;
+use Cake\Event\Event;
+use Cake\Event\EventManager;
 use Cake\Core\Plugin;
 use Cake\Filesystem\File;
 use Cake\Utility\Inflector;

--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -41,6 +41,21 @@ class MigrationSnapshotTask extends SimpleMigrationTask
     /**
      * {@inheritDoc}
      */
+    public function bake($name)
+    {
+        $collection = $this->getCollection($this->connection);
+        EventManager::instance()->on('Bake.initialize', function (Event $event) use ($collection) {
+            $event->subject->loadHelper('Migrations.Migration', [
+                'collection' => $collection
+            ]);
+        });
+
+        return parent::bake($name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function template()
     {
         return 'Migrations.config/snapshot';
@@ -82,6 +97,18 @@ class MigrationSnapshotTask extends SimpleMigrationTask
             'action' => 'create_table',
             'name' => $this->BakeTemplate->viewVars['name'],
         ];
+    }
+
+    /**
+     * Get a collection from a database
+     *
+     * @param string $connection : database connection name
+     * @return obj schemaCollection
+     */
+    public function getCollection($connection)
+    {
+        $connection = ConnectionManager::get($connection);
+        return $connection->schemaCollection();
     }
 
     /**

--- a/src/Shell/Task/MigrationTask.php
+++ b/src/Shell/Task/MigrationTask.php
@@ -26,6 +26,18 @@ class MigrationTask extends SimpleMigrationTask
     /**
      * {@inheritDoc}
      */
+    public function bake($name)
+    {
+        EventManager::instance()->on('Bake.initialize', function (Event $event) {
+            $event->subject->loadHelper('Migrations.Migration');
+        });
+
+        return parent::bake($name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function template()
     {
         return 'Migrations.config/skeleton';
@@ -44,7 +56,6 @@ class MigrationTask extends SimpleMigrationTask
             $pluginPath = $this->plugin . '.';
         }
 
-        $collection = $this->getCollection($this->connection);
         $action = $this->detectAction($className);
 
         if ($action === null) {
@@ -52,7 +63,6 @@ class MigrationTask extends SimpleMigrationTask
                 'plugin' => $this->plugin,
                 'pluginPath' => $pluginPath,
                 'namespace' => $namespace,
-                'collection' => $collection,
                 'tables' => [],
                 'action' => null,
                 'name' => $className
@@ -70,7 +80,6 @@ class MigrationTask extends SimpleMigrationTask
             'plugin' => $this->plugin,
             'pluginPath' => $pluginPath,
             'namespace' => $namespace,
-            'collection' => $collection,
             'tables' => [$table],
             'action' => $action,
             'columns' => [

--- a/src/Shell/Task/MigrationTask.php
+++ b/src/Shell/Task/MigrationTask.php
@@ -14,6 +14,8 @@
 namespace Migrations\Shell\Task;
 
 use Cake\Core\Configure;
+use Cake\Event\Event;
+use Cake\Event\EventManager;
 use Cake\Utility\Inflector;
 use Migrations\Shell\Task\SimpleMigrationTask;
 use Migrations\Util\ColumnParser;

--- a/src/Shell/Task/SimpleMigrationTask.php
+++ b/src/Shell/Task/SimpleMigrationTask.php
@@ -70,11 +70,11 @@ abstract class SimpleMigrationTask extends SimpleBakeTask
     {
         $this->params['no-test'] = true;
         $collection = $this->getCollection($this->connection);
-        EventManager::instance()->attach(function (Event $event) use ($collection) {
+        EventManager::instance()->on('Bake.initialize', function (Event $event) use ($collection) {
             $event->subject->loadHelper('Migrations.Migration', [
                 'collection' => $collection
             ]);
-        }, 'Bake.initialize');
+        });
 
 
         return parent::bake($name);

--- a/src/Shell/Task/SimpleMigrationTask.php
+++ b/src/Shell/Task/SimpleMigrationTask.php
@@ -16,9 +16,6 @@ namespace Migrations\Shell\Task;
 use Bake\Shell\Task\SimpleBakeTask;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Plugin;
-use Cake\Datasource\ConnectionManager;
-use Cake\Event\Event;
-use Cake\Event\EventManager;
 use Cake\Utility\Inflector;
 use Phinx\Migration\Util;
 

--- a/src/Shell/Task/SimpleMigrationTask.php
+++ b/src/Shell/Task/SimpleMigrationTask.php
@@ -69,27 +69,7 @@ abstract class SimpleMigrationTask extends SimpleBakeTask
     public function bake($name)
     {
         $this->params['no-test'] = true;
-        $collection = $this->getCollection($this->connection);
-        EventManager::instance()->on('Bake.initialize', function (Event $event) use ($collection) {
-            $event->subject->loadHelper('Migrations.Migration', [
-                'collection' => $collection
-            ]);
-        });
-
-
         return parent::bake($name);
-    }
-
-    /**
-     * Get a collection from a database
-     *
-     * @param string $connection : database connection name
-     * @return obj schemaCollection
-     */
-    public function getCollection($connection)
-    {
-        $connection = ConnectionManager::get($connection);
-        return $connection->schemaCollection();
     }
 
     /**

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -36,10 +36,6 @@ class MigrationHelper extends Helper
     public function __construct(View $View, array $config = [])
     {
         parent::__construct($View, $config);
-        $collection = $this->config('collection');
-        if (empty($collection) || !($collection instanceof Collection)) {
-            throw new InvalidArgumentException('Missing Collection object');
-        }
     }
 
     /**

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -86,15 +86,6 @@ class MigrationHelperTest extends TestCase
     }
 
     /**
-     * @covers Migrations\View\Helper\MigrationHelper::__construct
-     * @expectedException \InvalidArgumentException
-     */
-    public function testConstruct()
-    {
-        new MigrationHelper($this->View);
-    }
-
-    /**
      * @covers Migrations\View\Helper\MigrationHelper::tableMethod
      */
     public function testTableMethod()


### PR DESCRIPTION
This can be useful in cases where the database hasn't yet been setup. For instance, on a fresh `composer create-project`, I hadn't yet created the database `my_app`, so my cli migration generation failed, even though a db connection was not required.