### PR TITLE
Update phinx version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "robmorgan/phinx": "~0.4",
+        "robmorgan/phinx": "^0.4.2",
         "cakephp/cakephp": "~3.0"
     },
     "require-dev": {


### PR DESCRIPTION
We depend on a constant which had been added in 0.4.2, hence bumping required version to `^0.4.2` which is short for: `>=0.4.2 <1.0`