### PR TITLE
Marking snapshot migrated after bake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ before_script:
 
 script:
   - sh -c "if [ '$DEFAULT' = '1' ]; then phpunit --stderr; fi"
-  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p --extensions=php --standard=psr2 --ignore=tests/bootstrap.php,tests/comparisons/* ./src ./tests ; fi"
+  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p --extensions=php --standard=psr2 --ignore=tests/bootstrap.php,tests/comparisons/*,tests/test_app/* ./src ./tests ; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/coveralls -c .coveralls.yml -v; fi"
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ bin/cake migrations status -p PluginName
 
 # You can also scope a command to a connection via the `--connection` or `-c` option
 bin/cake migrations status -c my_datasource
+
+# The following will mark targeted migration as marked without actually running it.
+# The expected argument is the migration version number
+bin/cake migrations mark_migrated 20150417223600
 ```
 
 ### Creating Migrations

--- a/src/Command/MarkMigrated.php
+++ b/src/Command/MarkMigrated.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Command;
+
+use Migrations\ConfigurationTrait;
+use Phinx\Console\Command\AbstractCommand;
+use Symfony\Component\Config\Definition\Exception\Exception;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MarkMigrated extends AbstractCommand
+{
+
+    use ConfigurationTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('mark_migrated')
+            ->setDescription('Mark a migration as migrated')
+            ->addArgument('version', InputArgument::REQUIRED, 'What is the version of the migration?')
+            ->setHelp(sprintf(
+                '%sMark a migration migrated based on its version number%s',
+                PHP_EOL,
+                PHP_EOL
+            ));
+        $this->addOption('plugin', 'p', InputArgument::OPTIONAL, 'The plugin the file should be created for')
+            ->addOption('connection', 'c', InputArgument::OPTIONAL, 'The datasource connection to use')
+            ->addOption('source', 's', InputArgument::OPTIONAL, 'The folder where migrations are in');
+    }
+
+    /**
+     * Mark a migration migrated
+     *
+     * @param Symfony\Component\Console\Input\Inputnterface $input the input object
+     * @param Symfony\Component\Console\Input\OutputInterface $output the output object
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->setInput($input);
+        $this->bootstrap($input, $output);
+
+        $path = $this->getConfig()->getMigrationPath();
+        $version = $input->getArgument('version');
+
+        $migrationFile = glob($path . DS . $version . '*');
+        if (!empty($migrationFile)) {
+            $migrationFile = $migrationFile[0];
+            $className = $this->getMigrationClassName($migrationFile);
+            require_once $migrationFile;
+            $Migration = new $className($version);
+
+            $time = date('Y-m-d H:i:s', time());
+
+            try {
+                $this->getManager()->getEnvironment('default')->getAdapter()->migrated($Migration, 'up', $time, $time);
+                $output->writeln('<info>Migration successfully marked migrated !</info>');
+            } catch (Exception $e) {
+                $output->writeln('<error>An error occurred : ' . $e->getMessage() . '</error>');
+            }
+        } else {
+            $output->writeln('<error>A migration file matching version number `' . $version . '` could not be found</error>');
+        }
+    }
+
+    /**
+     * Resolves a migration class name based on $path
+     *
+     * @param string $path Path to the migration file of which we want the class name
+     * @return string Migration class name
+     */
+    protected function getMigrationClassName($path)
+    {
+        $class = preg_replace('/^[0-9]+_/', '', basename($path));
+        $class = str_replace('_', ' ', $class);
+        $class = ucwords($class);
+        $class = str_replace(' ', '', $class);
+        if (strpos($class, '.') !== false) {
+            $class = substr($class, 0, strpos($class, '.'));
+        }
+
+        return $class;
+    }
+}

--- a/src/Command/MarkMigrated.php
+++ b/src/Command/MarkMigrated.php
@@ -73,7 +73,9 @@ class MarkMigrated extends AbstractCommand
                 $output->writeln('<error>An error occurred : ' . $e->getMessage() . '</error>');
             }
         } else {
-            $output->writeln('<error>A migration file matching version number `' . $version . '` could not be found</error>');
+            $output->writeln(
+                '<error>A migration file matching version number `' . $version . '` could not be found</error>'
+            );
         }
     }
 

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -128,9 +128,9 @@ trait ConfigurationTrait
 
     /**
      * Overrides the action execute method in order to vanish the idea of environments
-     * from phinx. CakePHP does not beleive in the idea of having in-app environments
+     * from phinx. CakePHP does not believe in the idea of having in-app environments
      *
-     * @param Symfony\Component\Console\Input\Inputnterface $input the input object
+     * @param Symfony\Component\Console\Input\InputInterface $input the input object
      * @param Symfony\Component\Console\Input\OutputInterface $output the output object
      * @return void
      */
@@ -146,7 +146,7 @@ trait ConfigurationTrait
      * Sets the input object that should be used for the command class. This object
      * is used to inspect the extra options that are needed for CakePHP apps.
      *
-     * @param Symfony\Component\Console\Input\Inputnterface $input the input object
+     * @param Symfony\Component\Console\Input\InputInterface $input the input object
      * @return void
      */
     public function setInput(InputInterface $input)
@@ -159,7 +159,7 @@ trait ConfigurationTrait
      * the CakePHP connection. This is needed in case the user decides to use tables
      * from the ORM and executes queries.
      *
-     * @param Symfony\Component\Console\Input\Inputnterface $input the input object
+     * @param Symfony\Component\Console\Input\InputInterface $input the input object
      * @param Symfony\Component\Console\Input\OutputInterface $output the output object
      * @return void
      */
@@ -174,7 +174,7 @@ trait ConfigurationTrait
     /**
      * Returns the connection name that should be used for the migrations.
      *
-     * @param Symfony\Component\Console\Input\Inputnterface $input the input object
+     * @param Symfony\Component\Console\Input\InputInterface $input the input object
      * @return string
      */
     protected function getConnectionName(InputInterface $input)

--- a/src/MigrationsDispatcher.php
+++ b/src/MigrationsDispatcher.php
@@ -37,5 +37,6 @@ class MigrationsDispatcher extends Application
         $this->add(new Command\Migrate());
         $this->add(new Command\Rollback());
         $this->add(new Command\Status());
+        $this->add(new Command\MarkMigrated());
     }
 }

--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -13,7 +13,6 @@
  */
 namespace Migrations\Shell\Task;
 
-use Cake\Console\ShellDispatcher;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;

--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -74,7 +74,7 @@ class MigrationSnapshotTask extends SimpleMigrationTask
         $createFile = parent::createFile($path, $contents);
 
         if ($createFile) {
-            $this->_markSnapshotApplied($path);
+            $this->markSnapshotApplied($path);
         }
 
         return $createFile;
@@ -87,7 +87,7 @@ class MigrationSnapshotTask extends SimpleMigrationTask
      * @param string $path Path to the newly created snapshot
      * @return void
      */
-    protected function _markSnapshotApplied($path)
+    protected function markSnapshotApplied($path)
     {
         $fileName = pathinfo($path, PATHINFO_FILENAME);
         list($version, ) = explode('_', $fileName, 2);

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -81,7 +81,7 @@ class MarkMigratedTest extends TestCase
     }
 
     /**
-     * Test executing "mark_migration" with no file matching the version number
+     * Test executing "mark_migration"
      *
      * @return void
      */

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -1,5 +1,14 @@
 <?php
-
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
 namespace Migrations\Test\Command;
 
 use Cake\Datasource\ConnectionManager;
@@ -9,16 +18,39 @@ use Phinx\Migration\Manager\Environment;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Output\StreamOutput;
 use Phinx\Config\Config;
-use Phinx\Console\Command\Status;
 
+/**
+ * MarkMigratedTest class
+ */
 class MarkMigratedTest extends TestCase
 {
-    protected $Connection;
 
-    protected $config = [];
-
+    /**
+     * Instance of a Symfony Command object
+     *
+     * @var \Symfony\Component\Console\Command\Command
+     */
     protected $command;
 
+    /**
+     * Instance of a Phinx Config object
+     *
+     * @var \Phinx\Config\Config
+     */
+    protected $config = [];
+
+    /**
+     * Instance of a Cake Connection object
+     *
+     * @var \Cake\Database\Connection
+     */
+    protected $Connection;
+
+    /**
+     * setup method
+     *
+     * @return void
+     */
     public function setUp()
     {
         parent::setUp();
@@ -59,6 +91,11 @@ class MarkMigratedTest extends TestCase
         $this->command->setManager($Manager);
     }
 
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
     public function tearDown()
     {
         parent::tearDown();
@@ -73,9 +110,16 @@ class MarkMigratedTest extends TestCase
     public function testExecuteNoFile()
     {
         $commandTester = new CommandTester($this->command);
-        $commandTester->execute(['command' => $this->command->getName(), 'version' => '2000000', '--connection' => 'test']);
+        $commandTester->execute([
+            'command' => $this->command->getName(),
+            'version' => '2000000',
+            '--connection' => 'test'
+        ]);
 
-        $this->assertContains('A migration file matching version number `2000000` could not be found', $commandTester->getDisplay());
+        $this->assertContains(
+            'A migration file matching version number `2000000` could not be found',
+            $commandTester->getDisplay()
+        );
         $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->fetch('assoc');
         $this->assertFalse($result);
     }
@@ -88,7 +132,11 @@ class MarkMigratedTest extends TestCase
     public function testExecute()
     {
         $commandTester = new CommandTester($this->command);
-        $commandTester->execute(['command' => $this->command->getName(), 'version' => '20150416223600', '--connection' => 'test']);
+        $commandTester->execute([
+            'command' => $this->command->getName(),
+            'version' => '20150416223600',
+            '--connection' => 'test'
+        ]);
 
         $this->assertContains('Migration successfully marked migrated !', $commandTester->getDisplay());
 

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Migrations\Test\Command;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+use Migrations\MigrationsDispatcher;
+use Phinx\Migration\Manager\Environment;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Output\StreamOutput;
+use Phinx\Config\Config;
+use Phinx\Console\Command\Status;
+
+class MarkMigratedTest extends TestCase
+{
+    protected $Connection;
+
+    protected $config = [];
+
+    protected $command;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->Connection = ConnectionManager::get('test');
+        $connectionConfig = $this->Connection->config();
+        $this->Connection->execute('DROP TABLE IF EXISTS phinxlog');
+
+        $this->config = new Config([
+            'paths' => [
+                'migrations' => __FILE__,
+            ],
+            'environments' => [
+                'default_migration_table' => 'phinxlog',
+                'default_database' => 'cakephp_test',
+                'default' => [
+                    'adapter' => getenv('DB'),
+                    'host' => '127.0.0.1',
+                    'name' => !empty($connectionConfig['database']) ? $connectionConfig['database'] : '',
+                    'user' => !empty($connectionConfig['username']) ? $connectionConfig['username'] : '',
+                    'pass' => !empty($connectionConfig['password']) ? $connectionConfig['password'] : ''
+                ]
+            ]
+        ]);
+
+        $application = new MigrationsDispatcher('testing');
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+        $this->command = $application->find('mark_migrated');
+
+        $Environment = new Environment('default', $this->config['environments']['default']);
+
+        $Manager = $this->getMock('\Phinx\Migration\Manager', [], [$this->config, $output]);
+        $Manager->expects($this->any())
+            ->method('getEnvironment')
+            ->will($this->returnValue($Environment));
+
+        $this->command->setManager($Manager);
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        unset($this->Connection, $this->config, $this->command);
+    }
+
+    /**
+     * Test executing "mark_migration" with no file matching the version number
+     *
+     * @return void
+     */
+    public function testExecuteNoFile()
+    {
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(['command' => $this->command->getName(), 'version' => '2000000', '--connection' => 'test']);
+
+        $this->assertContains('A migration file matching version number `2000000` could not be found', $commandTester->getDisplay());
+        $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->fetch('assoc');
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test executing "mark_migration" with no file matching the version number
+     *
+     * @return void
+     */
+    public function testExecute()
+    {
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(['command' => $this->command->getName(), 'version' => '20150416223600', '--connection' => 'test']);
+
+        $this->assertContains('Migration successfully marked migrated !', $commandTester->getDisplay());
+
+        $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->fetch('assoc');
+        $this->assertEquals('20150416223600', $result['version']);
+    }
+}

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -16,6 +16,7 @@ use Cake\Core\Plugin;
 use Cake\TestSuite\StringCompareTrait;
 use Cake\TestSuite\TestCase;
 use Migrations\Shell\Task\MigrationSnapshotTask;
+use Phinx\Migration\Util;
 
 /**
  * MigrationSnapshotTaskTest class
@@ -44,7 +45,7 @@ class MigrationSnapshotTaskTest extends TestCase
 
         $this->Task = $this->getMock(
             'Migrations\Shell\Task\MigrationSnapshotTask',
-            ['in', 'err', 'createFile', '_stop'],
+            ['in', 'err', 'dispatchShell', '_stop'],
             [$inputOutput]
         );
         $this->Task->name = 'Migration';
@@ -57,6 +58,13 @@ class MigrationSnapshotTaskTest extends TestCase
     public function testNotEmptySnapshot()
     {
         $this->Task->params['require-table'] = false;
+
+        $version = Util::getCurrentTimestamp();
+
+        $this->Task->expects($this->once())
+            ->method('dispatchShell')
+            ->with('migrations', 'mark_migrated', $version);
+
         $result = $this->Task->bake('NotEmptySnapshot');
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
     }

--- a/tests/test_app/config/Migrations/20150416223600_mark_migrated_test.php
+++ b/tests/test_app/config/Migrations/20150416223600_mark_migrated_test.php
@@ -1,0 +1,13 @@
+<?php
+use Phinx\Migration\AbstractMigration;
+
+class MarkMigratedTest extends AbstractMigration
+{
+    public function up()
+    {
+    }
+
+    public function down()
+    {
+    }
+}


### PR DESCRIPTION
When a snapshot is baked, the matching migration should be marked as migrated.
This PR adds a new command "MarkMigrated". This command takes the version number of the migrations to be marked as migrated :

`./bin/cake migrations mark_migrated {version}`

When a snapshot is baked and the file has successfully been written, this command is dispatch with dispatchShell().

If you're on board with the idea behind this change, I'll start digging to find out how to test all that.
I'll also probably need to propagate potential arguments used with bake (such as connection or plugin) to the dispatchShell() call.

More details on #65 