### PR TITLE
Indexes columns stringification should not be enclosed in double quotes when baking

### DIFF
--- a/src/Template/Bake/config/skeleton.ctp
+++ b/src/Template/Bake/config/skeleton.ctp
@@ -51,7 +51,9 @@ class <%= $name %> extends AbstractMigration
             %>]);
 <% endforeach; %>
 <% foreach ($columns['indexes'] as $column => $config): %>
-        $table-><%= $indexMethod %>(["<%= $this->Migration->stringifyList($config['columns']) %>"], [<%
+        $table-><%= $indexMethod %>([<%=
+                $this->Migration->stringifyList($config['columns'], ['indent' => 3])
+                %>], [<%
                 $options = [];
                 echo $this->Migration->stringifyList($config['options'], ['indent' => 3]);
             %>]);


### PR DESCRIPTION
As reported in #74, if you bake a migration with an index creation, the index column name in enclosed in double quotes, which it should not.

Currently rendering :

```php
// [...]
        $table->addIndex(["
        'status_id',
    "], [
            'name' => 'status_id',
            'unique' => false,
        ]);
// [...]
```

With this fix, renders as :

```php
        $table->addIndex([
            'status_id',
        ], [
            'name' => 'status_id',
            'unique' => false,
        ]);
```

Should solve #74 