### PR TITLE
Checks if a migration has already been marked as migrated before marking it migrated

### DIFF
--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -142,5 +142,18 @@ class MarkMigratedTest extends TestCase
 
         $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->fetch('assoc');
         $this->assertEquals('20150416223600', $result['version']);
+
+        $commandTester->execute([
+            'command' => $this->command->getName(),
+            'version' => '20150416223600',
+            '--connection' => 'test'
+        ]);
+
+        $this->assertContains(
+            'The migration with version number `20150416223600` has already been marked as migrated.',
+            $commandTester->getDisplay()
+        );
+        $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->count();
+        $this->assertEquals(1, $result);
     }
 }


### PR DESCRIPTION
Before marking a migration as migrated when ``mark_migrated`` is called, it would be nice to check if the migration has not already been migrated (or marked as such).

This does not really change anything and does not fix a bug :
- phinx already deals with the case where a migration is marked migrated multiple times (when a migration is rollbacked, it just deletes everything with the version number). 
- when the ``status`` command is called, it uses the files in the migration path to build the migrations list.

But I figured it would be nicer to have this as it would help to keep a clean ``phinxlog`` table.

I also changed the concatenations in the outputed messages by ``sprintf()`` calls.