### PR TITLE
Indexes and constraints are now baked with the snapshot

### DIFF
--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -26,7 +26,9 @@ class <%= $name %> extends AbstractMigration
     public function up()
     {
     <%- foreach ($tables as $table): %>
-        <%- $primaryKeys = $this->Migration->primaryKeys($table);
+        <%- $foreignKeys = [];
+        $primaryKeysColumns = $this->Migration->primaryKeysColumnsList($table);
+        $primaryKeys = $this->Migration->primaryKeys($table);
         $specialPk = count($primaryKeys) > 1 || $primaryKeys[0]['name'] !== 'id' || $primaryKeys[0]['info']['columnType'] !== 'integer';
         if ($specialPk) {
         %>
@@ -51,22 +53,11 @@ class <%= $name %> extends AbstractMigration
                 echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
             %>])
         <%- endforeach; %>
-        <%- foreach($this->Migration->indexes($table) as $index): %>
-            ->addIndex(
-                [<%
-                    echo $this->Migration->stringifyList($index['columns'], ['indent' => 5]);
-                %>]
-            )
-        <%- endforeach; %>
-        <%- foreach ($this->Migration->constraints($table) as $constraint): %>
-            <%- if ($constraint['type'] === 'unique'): %>
-            ->addIndex(
-                [<%
-                    echo $this->Migration->stringifyList($constraint['columns'], ['indent' => 5]);
-                %>],
-                ['unique' => true]
-            )
-            <%- else: %>
+        <%- foreach ($this->Migration->constraints($table) as $constraint):
+            $constraintColumns = $constraint['columns'];
+            sort($constraintColumns);
+            if ($constraint['type'] !== 'unique'):
+                $foreignKeys[] = $constraint['columns'][0]; %>
             ->addForeignKey(
                 '<%= $constraint['columns'][0] %>',
                 '<%= $constraint['references'][0] %>',
@@ -76,8 +67,28 @@ class <%= $name %> extends AbstractMigration
                     'delete' => '<%= $constraint['delete'] %>'
                 ]
             )
+            <%- elseif ($constraintColumns !== $primaryKeysColumns): %>
+            ->addIndex(
+                [<%
+                    echo $this->Migration->stringifyList($constraint['columns'], ['indent' => 5]);
+                %>],
+                ['unique' => true]
+            )
             <%- endif; %>
-        <%- endforeach; %>
+            <%- endforeach; %>
+        <%- foreach($this->Migration->indexes($table) as $index):
+            sort($foreignKeys);
+            $indexColumns = $index['columns'];
+            sort($indexColumns);
+            if ($foreignKeys !== $indexColumns):
+            %>
+            ->addIndex(
+                [<%
+                    echo $this->Migration->stringifyList($index['columns'], ['indent' => 5]);
+                %>]
+            )
+        <%- endif;
+            endforeach; %>
             -><%= $tableMethod %>();
     <%- endforeach; %>
     }

--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -19,7 +19,6 @@ $columnMethod = $this->Migration->columnMethod($action);
 $indexMethod = $this->Migration->indexMethod($action);
 %>
 <?php
-use Cake\Utility\Inflector;
 use Phinx\Migration\AbstractMigration;
 
 class <%= $name %> extends AbstractMigration

--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -19,6 +19,7 @@ $columnMethod = $this->Migration->columnMethod($action);
 $indexMethod = $this->Migration->indexMethod($action);
 %>
 <?php
+use Cake\Utility\Inflector;
 use Phinx\Migration\AbstractMigration;
 
 class <%= $name %> extends AbstractMigration
@@ -50,6 +51,33 @@ class <%= $name %> extends AbstractMigration
                 $columnOptions = array_intersect_key($config['options'], $wantedOptions);
                 echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
             %>])
+        <%- endforeach; %>
+        <%- foreach($this->Migration->indexes($table) as $index): %>
+            ->addIndex(
+                [<%
+                    echo $this->Migration->stringifyList($index['columns'], ['indent' => 5]);
+                %>]
+            )
+        <%- endforeach; %>
+        <%- foreach ($this->Migration->constraints($table) as $constraint): %>
+            <%- if ($constraint['type'] === 'unique'): %>
+            ->addIndex(
+                [<%
+                    echo $this->Migration->stringifyList($constraint['columns'], ['indent' => 5]);
+                %>],
+                ['unique' => true]
+            )
+            <%- else: %>
+            ->addForeignKey(
+                '<%= $constraint['columns'][0] %>',
+                '<%= $constraint['references'][0] %>',
+                '<%= $constraint['references'][1] %>',
+                [
+                    'update' => '<%= $constraint['update'] %>',
+                    'delete' => '<%= $constraint['delete'] %>'
+                ]
+            )
+            <%- endif; %>
         <%- endforeach; %>
             -><%= $tableMethod %>();
     <%- endforeach; %>

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -150,8 +150,7 @@ class MigrationHelper extends Helper
         $indexes = [];
         if (!empty($tableIndexes)) {
             foreach ($tableIndexes as $name) {
-                $index = $tableSchema->index($name);
-                $indexes[$name] = $index;
+                $indexes[$name] = $tableSchema->index($name);
             }
         }
 
@@ -176,7 +175,6 @@ class MigrationHelper extends Helper
         if (!empty($tableConstraints)) {
             foreach ($tableConstraints as $name) {
                 $constraint = $tableSchema->constraint($name);
-//                debug($constraint);
                 if (isset($constraint['update'])) {
                     $constraint['update'] = strtoupper(Inflector::underscore($constraint['update']));
                     $constraint['delete'] = strtoupper(Inflector::underscore($constraint['delete']));

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -12,6 +12,7 @@
 namespace Migrations\View\Helper;
 
 use Cake\Database\Schema\Collection;
+use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Cake\View\Helper;
 use Cake\View\View;
@@ -206,6 +207,19 @@ class MigrationHelper extends Helper
         return $primaryKeys;
     }
 
+    /**
+     * Returns the primary key columns name for a given table
+     *
+     * @param string $table Name of the table ot retrieve primary key for
+     * @return array
+     */
+    public function primaryKeysColumnsList($table)
+    {
+        $primaryKeys = $this->primaryKeys($table);
+        $primaryKeysColumns = Hash::extract($primaryKeys, '{n}.name');
+        sort($primaryKeysColumns);
+        return $primaryKeysColumns;
+    }
 
     /**
      * Returns an array of column data for a single column

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -12,6 +12,7 @@
 namespace Migrations\View\Helper;
 
 use Cake\Database\Schema\Collection;
+use Cake\Utility\Inflector;
 use Cake\View\Helper;
 use Cake\View\View;
 use InvalidArgumentException;
@@ -23,6 +24,14 @@ use InvalidArgumentException;
  */
 class MigrationHelper extends Helper
 {
+
+    /**
+     * Schemas list for tables analyzed during migration baking
+     *
+     * @var array
+     */
+    protected $schemas = [];
+
     /**
      * Constructor
      *
@@ -72,7 +81,6 @@ class MigrationHelper extends Helper
         return 'addIndex';
     }
 
-
     /**
      * Returns the method to be used for the column manipulation
      *
@@ -89,6 +97,25 @@ class MigrationHelper extends Helper
     }
 
     /**
+     * Returns the Cake\Database\Schema\Table for $table
+     *
+     * @param string $table Name of the table to get the Schema for
+     * @return Cake\Database\Schema\Table
+     */
+    protected function schema($table)
+    {
+        if (isset($this->schemas[$table])) {
+            return $this->schemas[$table];
+        }
+
+        $collection = $this->config('collection');
+        $schema = $collection->describe($table);
+        $this->schemas[$table] = $schema;
+
+        return $schema;
+    }
+
+    /**
      * Returns an array of column data for a given table
      *
      * @param string $table Name of the table to retrieve columns for
@@ -96,8 +123,7 @@ class MigrationHelper extends Helper
      */
     public function columns($table)
     {
-        $collection = $this->config('collection');
-        $tableSchema = $collection->describe($table);
+        $tableSchema = $this->schema($table);
         $columns = [];
         $tablePrimaryKeys = $tableSchema->primaryKey();
         foreach ($tableSchema->columns() as $column) {
@@ -108,6 +134,58 @@ class MigrationHelper extends Helper
         }
 
         return $columns;
+    }
+
+    /**
+     * Returns an array of indexes for a given table
+     *
+     * @param string $table Name of the table to retrieve indexes for
+     * @return array
+     */
+    public function indexes($table)
+    {
+        $tableSchema = $this->schema($table);
+
+        $tableIndexes = $tableSchema->indexes();
+        $indexes = [];
+        if (!empty($tableIndexes)) {
+            foreach ($tableIndexes as $name) {
+                $index = $tableSchema->index($name);
+                $indexes[$name] = $index;
+            }
+        }
+
+        return $indexes;
+    }
+
+    /**
+     * Returns an array of constraints for a given table
+     *
+     * @param string $table Name of the table to retrieve constraints for
+     * @return array
+     */
+    public function constraints($table)
+    {
+        $tableSchema = $this->schema($table);
+
+        $tableConstraints = $tableSchema->constraints();
+        $constraints = [];
+        if ($tableConstraints[0] === 'primary') {
+            unset($tableConstraints[0]);
+        }
+        if (!empty($tableConstraints)) {
+            foreach ($tableConstraints as $name) {
+                $constraint = $tableSchema->constraint($name);
+//                debug($constraint);
+                if (isset($constraint['update'])) {
+                    $constraint['update'] = strtoupper(Inflector::underscore($constraint['update']));
+                    $constraint['delete'] = strtoupper(Inflector::underscore($constraint['delete']));
+                }
+                $constraints[$name] = $constraint;
+            }
+        }
+
+        return $constraints;
     }
 
     /**

--- a/tests/Fixture/CategoriesFixture.php
+++ b/tests/Fixture/CategoriesFixture.php
@@ -29,7 +29,7 @@ class CategoriesFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'integer'],
-        'parent_id' => ['type' => 'integer'],
+        'parent_id' => ['type' => 'integer', 'length' => 11],
         'title' => ['type' => 'string', 'null' => true, 'length' => 255],
         'slug' => ['type' => 'string', 'null' => true, 'length' => 255],
         'created' => ['type' => 'timestamp', 'null' => true, 'default' => null],

--- a/tests/Fixture/CategoriesFixture.php
+++ b/tests/Fixture/CategoriesFixture.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Class CategoriesFixture
+ *
+ */
+class CategoriesFixture extends TestFixture
+{
+
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'parent_id' => ['type' => 'integer'],
+        'title' => ['type' => 'string', 'null' => true, 'length' => 255],
+        'slug' => ['type' => 'string', 'null' => true, 'length' => 255],
+        'created' => ['type' => 'timestamp', 'null' => true, 'default' => null],
+        'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+            'UNIQUE_SLUG' => ['type' => 'unique', 'columns' => ['slug']]
+        ]
+    ];
+}

--- a/tests/Fixture/ProductsFixture.php
+++ b/tests/Fixture/ProductsFixture.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Class CategoriesFixture
+ *
+ */
+class ProductsFixture extends TestFixture
+{
+
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'title' => ['type' => 'string', 'null' => true, 'length' => 255],
+        'slug' => ['type' => 'string', 'null' => true, 'length' => 255],
+        'category_id' => ['type' => 'integer'],
+        'created' => ['type' => 'timestamp', 'null' => true, 'default' => null],
+        'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+            'UNIQUE_SLUG' => ['type' => 'unique', 'columns' => ['slug']],
+            'category_idx' => [
+                'type' => 'foreign',
+                'columns' => ['category_id'],
+                'references' => ['categories', 'id'],
+                'update' => 'cascade',
+                'delete' => 'cascade'
+            ]
+        ]
+    ];
+}

--- a/tests/Fixture/ProductsFixture.php
+++ b/tests/Fixture/ProductsFixture.php
@@ -31,7 +31,7 @@ class ProductsFixture extends TestFixture
         'id' => ['type' => 'integer'],
         'title' => ['type' => 'string', 'null' => true, 'length' => 255],
         'slug' => ['type' => 'string', 'null' => true, 'length' => 255],
-        'category_id' => ['type' => 'integer'],
+        'category_id' => ['type' => 'integer', 'length' => 11],
         'created' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         '_constraints' => [

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -30,6 +30,8 @@ class MigrationSnapshotTaskTest extends TestCase
         'plugin.migrations.special_tags',
         'plugin.migrations.special_pk',
         'plugin.migrations.composite_pk',
+        'plugin.migrations.categories',
+        'plugin.migrations.products'
     ];
 
     /**

--- a/tests/comparisons/Migration/testNotEmptySnapshot.php
+++ b/tests/comparisons/Migration/testNotEmptySnapshot.php
@@ -51,13 +51,6 @@ class NotEmptySnapshot extends AbstractMigration
                 'limit' => 50,
                 'null' => false,
             ])
-            ->addIndex(
-                [
-                    'id',
-                    'name',
-                ],
-                ['unique' => true]
-            )
             ->create();
         $table = $this->table('products');
         $table
@@ -114,12 +107,6 @@ class NotEmptySnapshot extends AbstractMigration
                 'limit' => 256,
                 'null' => true,
             ])
-            ->addIndex(
-                [
-                    'id',
-                ],
-                ['unique' => true]
-            )
             ->create();
         $table = $this->table('special_tags');
         $table

--- a/tests/comparisons/Migration/testNotEmptySnapshot.php
+++ b/tests/comparisons/Migration/testNotEmptySnapshot.php
@@ -5,6 +5,40 @@ class NotEmptySnapshot extends AbstractMigration
 {
     public function up()
     {
+        $table = $this->table('categories');
+        $table
+            ->addColumn('parent_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'slug',
+                ],
+                ['unique' => true]
+            )
+            ->create();
         $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
         $table
             ->addColumn('id', 'uuid', [
@@ -17,6 +51,56 @@ class NotEmptySnapshot extends AbstractMigration
                 'limit' => 50,
                 'null' => false,
             ])
+            ->addIndex(
+                [
+                    'id',
+                    'name',
+                ],
+                ['unique' => true]
+            )
+            ->create();
+        $table = $this->table('products');
+        $table
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'slug',
+                ],
+                ['unique' => true]
+            )
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
             ->create();
         $table = $this->table('special_pks', ['id' => false, 'primary_key' => ['id']]);
         $table
@@ -30,6 +114,12 @@ class NotEmptySnapshot extends AbstractMigration
                 'limit' => 256,
                 'null' => true,
             ])
+            ->addIndex(
+                [
+                    'id',
+                ],
+                ['unique' => true]
+            )
             ->create();
         $table = $this->table('special_tags');
         $table
@@ -58,6 +148,12 @@ class NotEmptySnapshot extends AbstractMigration
                 'limit' => null,
                 'null' => true,
             ])
+            ->addIndex(
+                [
+                    'article_id',
+                ],
+                ['unique' => true]
+            )
             ->create();
         $table = $this->table('users');
         $table
@@ -86,7 +182,9 @@ class NotEmptySnapshot extends AbstractMigration
 
     public function down()
     {
+        $this->dropTable('categories');
         $this->dropTable('composite_pks');
+        $this->dropTable('products');
         $this->dropTable('special_pks');
         $this->dropTable('special_tags');
         $this->dropTable('users');

--- a/tests/comparisons/Migration/testNotEmptySnapshot.php
+++ b/tests/comparisons/Migration/testNotEmptySnapshot.php
@@ -9,7 +9,7 @@ class NotEmptySnapshot extends AbstractMigration
         $table
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
-                'limit' => null,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('title', 'string', [
@@ -73,7 +73,7 @@ class NotEmptySnapshot extends AbstractMigration
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => null,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [


### PR DESCRIPTION
When baking a snapshot, indexes and constraints where not baked and thus, lost.
This PR aims to correct that.

The only thing I could not do was to support composite foreign keys as Cake doesn't seem to support them. Am I correct ? From what I gathered, when a table has a multi-columns foreign key defined and is reflected, the last column within the list is the one that persists.
Should I create an issue in the main repo with what I used to test and conclude this ?

More details on #80 