### PR TITLE
The "--format" option should be define in the MigrationsShell options parser

### DIFF
--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -24,7 +24,7 @@ class MigrationsShell extends Shell
 
     /**
      * Defines what options can be passed to the shell.
-     * This is required becuase CakePHP validates the passed options
+     * This is required because CakePHP validates the passed options
      * and would complain if something not configured here is present
      *
      * @return Cake\Console\ConsoleOptionParser
@@ -40,7 +40,8 @@ class MigrationsShell extends Shell
             ->addOption('no-ansi')
             ->addOption('version', ['short' => 'V'])
             ->addOption('no-interaction', ['short' => 'n'])
-            ->addOption('template', ['short' => 't']);
+            ->addOption('template', ['short' => 't'])
+            ->addOption('format', ['short' => 'f']);
     }
 
     /**


### PR DESCRIPTION
The problem described in #82 occurred because the MigrationsShell ``getOptionParser()`` method did not define the format option.
The --format option should now work correctly :

``bin/cake migrations status`` =>
```bash
 Status  Migration ID    Migration Name 
-----------------------------------------
     up  20150522230848  AlterUsers
```
---------------------
``bin/cake migrations status -f json``
```bash
using format json

 Status  Migration ID    Migration Name 
-----------------------------------------
     up  20150522230848  AlterUsers

[{"migration_status":"up","migration_id":"20150522230848","migration_name":"AlterUsers"}]
```

Resolves #82 