### PR TITLE
Fix baking snapshots

### DIFF
--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -77,10 +77,7 @@ class MigrationsShell extends Shell
      */
     public function main()
     {
-        array_shift($_SERVER['argv']);
-        $_SERVER['argv']--;
         $app = new MigrationsDispatcher(PHINX_VERSION);
-
         $input = new ArgvInput($this->argv);
         $app->run($input);
     }

--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -13,6 +13,7 @@ namespace Migrations\Shell;
 
 use Cake\Console\Shell;
 use Migrations\MigrationsDispatcher;
+use Symfony\Component\Console\Input\ArgvInput;
 
 /**
  * A wrapper shell for phinx migrations, used to inject our own
@@ -21,6 +22,8 @@ use Migrations\MigrationsDispatcher;
  */
 class MigrationsShell extends Shell
 {
+
+    public $argv;
 
     /**
      * Defines what options can be passed to the shell.
@@ -62,6 +65,9 @@ class MigrationsShell extends Shell
      * responsible for parsing the command line from phinx and gives full control of
      * the rest of the flow to it.
      *
+     * The input parameter of the ``MigrationDispatcher::run()`` method is manually built
+     * in case a MigrationsShell is dispatched using ``Shell::dispatch()``.
+     *
      * @return void
      */
     public function main()
@@ -69,7 +75,22 @@ class MigrationsShell extends Shell
         array_shift($_SERVER['argv']);
         $_SERVER['argv']--;
         $app = new MigrationsDispatcher(PHINX_VERSION);
-        $app->run();
+
+        $input = new ArgvInput($this->argv);
+        $app->run($input);
+    }
+
+    /**
+     * Override the default behavior to save the command called
+     * in order to pass it to the command dispatcher
+     *
+     * {@inheritDoc}
+     */
+    public function runCommand($argv, $autoMethod = false)
+    {
+        array_unshift($argv, 'migrations');
+        $this->argv = $argv;
+        return parent::runCommand($argv, $autoMethod);
     }
 
     /**

--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -23,7 +23,12 @@ use Symfony\Component\Console\Input\ArgvInput;
 class MigrationsShell extends Shell
 {
 
-    public $argv;
+    /**
+     * Array of arguments to run the shell with.
+     *
+     * @var array
+     */
+    public $argv = [];
 
     /**
      * Defines what options can be passed to the shell.

--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -99,8 +99,21 @@ class MigrationSnapshotTask extends SimpleMigrationTask
             $version
         ];
 
+        $dispatchCommand = 'migrations mark_migrated ' . $version;
+        if (!empty($this->params['connection'])) {
+            $_SERVER['argv'][] = '-c';
+            $_SERVER['argv'][] = $this->params['connection'];
+            $dispatchCommand .= ' -c ' . $this->params['connection'];
+        }
+
+        if (!empty($this->params['plugin'])) {
+            $_SERVER['argv'][] = '-p';
+            $_SERVER['argv'][] = $this->params['plugin'];
+            $dispatchCommand .= ' -p ' . $this->params['plugin'];
+        }
+
         $this->_io->out('Marking the snapshot ' . $fileName . ' as migrated...');
-        $result = $this->dispatchShell('migrations', 'mark_migrated', $version);
+        $result = $this->dispatchShell($dispatchCommand);
         $_SERVER['argv'] = $argv;
     }
 

--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -91,30 +91,18 @@ class MigrationSnapshotTask extends SimpleMigrationTask
         $fileName = pathinfo($path, PATHINFO_FILENAME);
         list($version, ) = explode('_', $fileName, 2);
 
-        $argv = $_SERVER['argv'];
-        $_SERVER['argv'] = [
-            '',
-            'migrations',
-            'mark_migrated',
-            $version
-        ];
 
         $dispatchCommand = 'migrations mark_migrated ' . $version;
         if (!empty($this->params['connection'])) {
-            $_SERVER['argv'][] = '-c';
-            $_SERVER['argv'][] = $this->params['connection'];
             $dispatchCommand .= ' -c ' . $this->params['connection'];
         }
 
         if (!empty($this->params['plugin'])) {
-            $_SERVER['argv'][] = '-p';
-            $_SERVER['argv'][] = $this->params['plugin'];
             $dispatchCommand .= ' -p ' . $this->params['plugin'];
         }
 
         $this->_io->out('Marking the snapshot ' . $fileName . ' as migrated...');
-        $result = $this->dispatchShell($dispatchCommand);
-        $_SERVER['argv'] = $argv;
+        $this->dispatchShell($dispatchCommand);
     }
 
     /**

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -67,7 +67,12 @@ class MigrationSnapshotTaskTest extends TestCase
 
         $this->Task->expects($this->once())
             ->method('dispatchShell')
-            ->with('migrations mark_migrated ' . $version . ' -c test -p BogusPlugin');
+            ->with(
+                $this->logicalAnd(
+                    $this->stringContains('migrations mark_migrated'),
+                    $this->stringContains('-c test -p BogusPlugin')
+                )
+            );
 
         $result = $this->Task->bake('NotEmptySnapshot');
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -60,12 +60,14 @@ class MigrationSnapshotTaskTest extends TestCase
     public function testNotEmptySnapshot()
     {
         $this->Task->params['require-table'] = false;
+        $this->Task->params['connection'] = 'test';
+        $this->Task->params['plugin'] = 'BogusPlugin';
 
         $version = Util::getCurrentTimestamp();
 
         $this->Task->expects($this->once())
             ->method('dispatchShell')
-            ->with('migrations', 'mark_migrated', $version);
+            ->with('migrations mark_migrated ' . $version . ' -c test -p BogusPlugin');
 
         $result = $this->Task->bake('NotEmptySnapshot');
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);


### PR DESCRIPTION
After a snapshot was baked, the ``connection`` and the ``plugin`` options should be propagated to the ``mark_migrated`` dispatched Shell.
Not doing so resulted in the ``mark_migrated`` call to be executed with the default connection which was unexpected and caused problems.

I know the tests and the mark_migrated shell dispatching seems weird but I actually can put anything in place of the ``$dispatchCommand`` and it would work. What matters is the content of the ``$_SERVER['argv']`` variable (if anyone knows why and would care to explain, I'll be glad).
But I still need to build a correct string for the tests.

Should fix #88 