### PR TITLE
Add a note on the README about collations

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,29 @@ $table->addColumn('id', 'char', ['limit' => 36])
 
 > Phinx automatically creates an auto-increment `id` field for *every* table. This will hopefully be fixed in the future.
 
+#### Collations
+
+If you need to create a table with a different collation than the database default one, you can define it
+with the ``table`` method, as an option : 
+
+```php
+$table = $this
+    ->table('categories', [
+        'collation' => 'latin1_german1_ci'
+    ])
+    ->addColumn('title', 'string', [
+        'default' => null,
+        'limit' => 255,
+        'null' => false,
+    ])
+    ->create();
+```
+
+Note however this can only be done on table creation : there is currently
+no way of adding a column to an existing table with a different collation than the table or
+the database.
+Only MySQL and SqlServer supports this configuration key for the time being.
+
 #### Generating Migrations from the CLI
 
 > When using this option, you can still modify the migration before running them if so desired.


### PR DESCRIPTION
This adds a note on the README about collations.
It is currently only possible to have a different collation than the database default one on table creation and only for MySQL and SqlServer.

I thought this should be written somewhere.

Refs #63 