### PR TITLE
Add composite foreign key constraints generation when baking a snapshot

### DIFF
--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -57,11 +57,22 @@ class <%= $name %> extends AbstractMigration
             $constraintColumns = $constraint['columns'];
             sort($constraintColumns);
             if ($constraint['type'] !== 'unique'):
-                $foreignKeys[] = $constraint['columns'][0]; %>
+                $foreignKeys += $constraint['columns'];
+
+                $columnsList = '\'' . $constraint['columns'][0] . '\'';
+                if (count($constraint['columns']) > 1):
+                    $columnsList = '[' . $this->Migration->stringifyList($constraint['columns'], ['indent' => 5]) . ']';
+                endif;
+
+                if (is_array($constraint['references'][1])):
+                    $columnsReference = '[' . $this->Migration->stringifyList($constraint['references'][1], ['indent' => 5]) . ']';
+                else:
+                    $columnsReference = '\'' . $constraint['references'][1] . '\'';
+                endif; %>
             ->addForeignKey(
-                '<%= $constraint['columns'][0] %>',
+                <%= $columnsList %>,
                 '<%= $constraint['references'][0] %>',
-                '<%= $constraint['references'][1] %>',
+                <%= $columnsReference %>,
                 [
                     'update' => '<%= $constraint['update'] %>',
                     'delete' => '<%= $constraint['delete'] %>'

--- a/tests/Fixture/OrdersFixture.php
+++ b/tests/Fixture/OrdersFixture.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Class OrdersFixture
+ *
+ */
+class OrdersFixture extends TestFixture
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public $table = 'orders';
+
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'product_category' => ['type' => 'integer', 'null' => false],
+        'product_id' => ['type' => 'integer', 'null' => false],
+        '_indexes' => [
+            'product_category' => [
+                'type' => 'index',
+                'columns' => ['product_category', 'product_id']
+            ]
+        ],
+        '_constraints' => [
+            'primary' => [
+                'type' => 'primary', 'columns' => ['id']
+            ],
+            'product_id_fk' => [
+                'type' => 'foreign',
+                'columns' => ['product_category', 'product_id'],
+                'references' => ['products', ['category_id', 'id']],
+                'update' => 'cascade',
+                'delete' => 'cascade',
+            ]
+        ]
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['product_category' => 1, 'product_id' => 1]
+    ];
+}

--- a/tests/Fixture/OrdersFixture.php
+++ b/tests/Fixture/OrdersFixture.php
@@ -55,13 +55,4 @@ class OrdersFixture extends TestFixture
             ]
         ]
     ];
-
-    /**
-     * records property
-     *
-     * @var array
-     */
-    public $records = [
-        ['product_category' => 1, 'product_id' => 1]
-    ];
 }

--- a/tests/Fixture/OrdersFixture.php
+++ b/tests/Fixture/OrdersFixture.php
@@ -34,8 +34,8 @@ class OrdersFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'integer'],
-        'product_category' => ['type' => 'integer', 'null' => false],
-        'product_id' => ['type' => 'integer', 'null' => false],
+        'product_category' => ['type' => 'integer', 'null' => false, 'length' => 11],
+        'product_id' => ['type' => 'integer', 'null' => false, 'length' => 11],
         '_indexes' => [
             'product_category' => [
                 'type' => 'index',

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -12,6 +12,7 @@
 namespace Migrations\Test\TestCase\Shell\Task;
 
 use Bake\Shell\Task\BakeTemplateTask;
+use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\StringCompareTrait;
 use Cake\TestSuite\TestCase;
@@ -34,6 +35,8 @@ class MigrationSnapshotTaskTest extends TestCase
         'plugin.migrations.products',
         'plugin.migrations.orders'
     ];
+
+    public $autoFixtures = false;
 
     /**
      * setup method
@@ -60,6 +63,15 @@ class MigrationSnapshotTaskTest extends TestCase
 
     public function testNotEmptySnapshot()
     {
+        $this->loadFixtures(
+            'Users',
+            'SpecialTags',
+            'SpecialPk',
+            'CompositePk',
+            'Categories',
+            'Products'
+        );
+
         $this->Task->params['require-table'] = false;
         $this->Task->params['connection'] = 'test';
         $this->Task->params['plugin'] = 'BogusPlugin';
@@ -76,6 +88,24 @@ class MigrationSnapshotTaskTest extends TestCase
             );
 
         $result = $this->Task->bake('NotEmptySnapshot');
+        $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+
+    public function testCompositeConstraintsSnapshot()
+    {
+        $cakeVersion = intval(str_replace('.', '', Configure::version()));
+        $this->skipIf(
+            $cakeVersion < 308,
+            'Cannot run "testCompositeConstraintsSnapshot" because CakePHP Core feature is not implemented in this version'
+        );
+
+        $this->loadFixtures(
+            'Orders'
+        );
+
+        $this->Task->params['require-table'] = false;
+        $this->Task->params['connection'] = 'test';
+        $result = $this->Task->bake('CompositeConstraintsSnapshot');
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
     }
 }

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -31,8 +31,8 @@ class MigrationSnapshotTaskTest extends TestCase
         'plugin.migrations.special_tags',
         'plugin.migrations.special_pk',
         'plugin.migrations.composite_pk',
-        'plugin.migrations.categories',
         'plugin.migrations.products',
+        'plugin.migrations.categories',
         'plugin.migrations.orders'
     ];
 
@@ -96,7 +96,8 @@ class MigrationSnapshotTaskTest extends TestCase
         $cakeVersion = intval(str_replace('.', '', Configure::version()));
         $this->skipIf(
             $cakeVersion < 308,
-            'Cannot run "testCompositeConstraintsSnapshot" because CakePHP Core feature is not implemented in this version'
+            'Cannot run "testCompositeConstraintsSnapshot" because CakePHP Core feature' .
+            'is not implemented in this version'
         );
 
         $this->loadFixtures(

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -31,7 +31,8 @@ class MigrationSnapshotTaskTest extends TestCase
         'plugin.migrations.special_pk',
         'plugin.migrations.composite_pk',
         'plugin.migrations.categories',
-        'plugin.migrations.products'
+        'plugin.migrations.products',
+        'plugin.migrations.orders'
     ];
 
     /**

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -93,9 +93,8 @@ class MigrationSnapshotTaskTest extends TestCase
 
     public function testCompositeConstraintsSnapshot()
     {
-        $cakeVersion = intval(str_replace('.', '', Configure::version()));
         $this->skipIf(
-            $cakeVersion < 308,
+            version_compare(Configure::version(), '3.0.8', '<'),
             'Cannot run "testCompositeConstraintsSnapshot" because CakePHP Core feature' .
             'is not implemented in this version'
         );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,6 +31,7 @@ chdir($root);
 require_once 'vendor/cakephp/cakephp/src/basics.php';
 require_once 'vendor/autoload.php';
 
+define('CORE_PATH', $root . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp' . DS);
 define('ROOT', $root . DS . 'tests' . DS . 'test_app' . DS);
 define('APP', ROOT . 'App' . DS);
 define('TMP', sys_get_temp_dir() . DS);

--- a/tests/comparisons/Migration/testCompositeConstraintsSnapshot.php
+++ b/tests/comparisons/Migration/testCompositeConstraintsSnapshot.php
@@ -1,7 +1,7 @@
 <?php
 use Phinx\Migration\AbstractMigration;
 
-class NotEmptySnapshot extends AbstractMigration
+class CompositeConstraintsSnapshot extends AbstractMigration
 {
     public function up()
     {
@@ -51,6 +51,34 @@ class NotEmptySnapshot extends AbstractMigration
                 'limit' => 50,
                 'null' => false,
             ])
+            ->create();
+        $table = $this->table('orders');
+        $table
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ],
+                'products',
+                [
+                    'category_id',
+                    'id',
+                ],
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
             ->create();
         $table = $this->table('products');
         $table
@@ -171,6 +199,7 @@ class NotEmptySnapshot extends AbstractMigration
     {
         $this->dropTable('categories');
         $this->dropTable('composite_pks');
+        $this->dropTable('orders');
         $this->dropTable('products');
         $this->dropTable('special_pks');
         $this->dropTable('special_tags');

--- a/tests/comparisons/Migration/testNotEmptySnapshot.php
+++ b/tests/comparisons/Migration/testNotEmptySnapshot.php
@@ -52,6 +52,34 @@ class NotEmptySnapshot extends AbstractMigration
                 'null' => false,
             ])
             ->create();
+        $table = $this->table('orders');
+        $table
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ],
+                'products',
+                [
+                    'category_id',
+                    'id',
+                ],
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->create();
         $table = $this->table('products');
         $table
             ->addColumn('title', 'string', [
@@ -171,6 +199,7 @@ class NotEmptySnapshot extends AbstractMigration
     {
         $this->dropTable('categories');
         $this->dropTable('composite_pks');
+        $this->dropTable('orders');
         $this->dropTable('products');
         $this->dropTable('special_pks');
         $this->dropTable('special_tags');

--- a/tests/comparisons/Migration/testNotEmptySnapshot.php
+++ b/tests/comparisons/Migration/testNotEmptySnapshot.php
@@ -56,12 +56,12 @@ class NotEmptySnapshot extends AbstractMigration
         $table
             ->addColumn('product_category', 'integer', [
                 'default' => null,
-                'limit' => null,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => null,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addForeignKey(


### PR DESCRIPTION
Since composite foreign keys constraints support was added in CakePHP schema reflection, baked migrations should support them as well. 