### PR TITLE
Make runCommand method compatible with parent

### DIFF
--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -88,7 +88,7 @@ class MigrationsShell extends Shell
      *
      * {@inheritDoc}
      */
-    public function runCommand($argv, $autoMethod = false)
+    public function runCommand($argv, $autoMethod = false, $extra = [])
     {
         array_unshift($argv, 'migrations');
         $this->argv = $argv;

--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -92,7 +92,7 @@ class MigrationsShell extends Shell
     {
         array_unshift($argv, 'migrations');
         $this->argv = $argv;
-        return parent::runCommand($argv, $autoMethod);
+        return parent::runCommand($argv, $autoMethod, $extra);
     }
 
     /**


### PR DESCRIPTION
Make the runCommand method compatible with the parent method https://github.com/cakephp/cakephp/blob/3.1/src/Console/Shell.php#L402

Not sure if it can be directly merged to master, since this is a problem of Cake 3.1.