### PR TITLE
if a unix_socket is set, it will now be passed on in the config-array

### DIFF
--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -92,6 +92,7 @@ trait ConfigurationTrait
                     'port' => isset($config['port']) ? $config['port'] : null,
                     'name' => $config['database'],
                     'charset' => isset($config['encoding']) ? $config['encoding'] : null,
+                    'unix_socket' => isset($config['unix_socket']) ? $config['unix_socket'] : null,
                 ]
             ]
         ]);


### PR DESCRIPTION
I have to use a unix-socket in my local setup to be able to connect to the database. This socket-setting was not passed on to phinx, which led to following error:

`[InvalidArgumentException]`
`There was a problem connecting to the database: SQLSTATE[HY000] [1045] Access denied for user 'username'@'localhost' (using password: YES)`

This patch passes the socket info on to phinx, thus enabling migrations on systems that use sockets.