### PR TITLE
Tables need to be ordered to respect foreign keys constraints dependencies

### DIFF
--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -196,13 +196,23 @@ class MigrationSnapshotTask extends SimpleMigrationTask
 
                     if ($refIndex === false && $tableIndex === false) {
                         array_unshift($orderedTables, $refTable, $table);
-                    } elseif ($refIndex === false) {
+                        continue;
+                    }
+
+                    if ($refIndex === false) {
                         array_splice($orderedTables, $tableIndex, 0, $refTable);
-                    } elseif ($tableIndex === false) {
-                        array_splice($orderedTables, $refIndex+1, 0, $table);
-                    } elseif ($refIndex > $tableIndex) {
+                        continue;
+                    }
+
+                    if ($tableIndex === false) {
+                        array_splice($orderedTables, $refIndex + 1, 0, $table);
+                        continue;
+                    }
+
+                    if ($refIndex > $tableIndex) {
                         unset($orderedTables[$refIndex]);
                         array_splice($orderedTables, $tableIndex, 0, $refTable);
+                        continue;
                     }
                 }
             }

--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -126,7 +126,7 @@ class MigrationSnapshotTask extends SimpleMigrationTask
         }
 
         $collection = $this->getCollection($this->connection);
-        $tables = $collection->listTables();
+        $tables = $this->orderTables($collection->listTables());
 
         if ($this->params['require-table'] === true) {
             $tableNamesInModel = $this->getTableNames($this->plugin);
@@ -161,10 +161,65 @@ class MigrationSnapshotTask extends SimpleMigrationTask
     }
 
     /**
+     * Order tables based on foreign key dependencies so tables that are foreign keys
+     * to other are created first
+     *
+     * @param array $tables Tables to order.
+     * @return array Tables ordered.
+     */
+    public function orderTables($tables)
+    {
+        if (empty($tables)) {
+            return $tables;
+        }
+
+        $orderedTables = [];
+        foreach ($tables as $table) {
+            $tableSchema = $this->getCollection($this->connection)->describe($table);
+            $tableConstraints = $tableSchema->constraints();
+            if (isset($tableConstraints[0]) && $tableConstraints[0] === 'primary') {
+                unset($tableConstraints[0]);
+            }
+
+            if (!empty($tableConstraints)) {
+                foreach ($tableConstraints as $tableConstraint) {
+                    $constraint = $tableSchema->constraint($tableConstraint);
+
+                    if ($constraint['type'] !== 'foreign') {
+                        continue;
+                    }
+
+                    $refTable = $constraint['references'][0];
+
+                    $refIndex = array_search($refTable, $orderedTables);
+                    $tableIndex = array_search($table, $orderedTables);
+
+                    if ($refIndex === false && $tableIndex === false) {
+                        array_unshift($orderedTables, $refTable, $table);
+                    } elseif ($refIndex === false) {
+                        array_splice($orderedTables, $tableIndex, 0, $refTable);
+                    } elseif ($tableIndex === false) {
+                        array_splice($orderedTables, $refIndex+1, 0, $table);
+                    } elseif ($refIndex > $tableIndex) {
+                        unset($orderedTables[$refIndex]);
+                        array_splice($orderedTables, $tableIndex, 0, $refTable);
+                    }
+                }
+            }
+
+            if (!in_array($table, $orderedTables)) {
+                $orderedTables[] = $table;
+            }
+        }
+
+        return $orderedTables;
+    }
+
+    /**
      * Get a collection from a database
      *
      * @param string $connection Database connection name.
-     * @return obj schemaCollection
+     * @return \Cake\Database\Schema\Collection
      */
     public function getCollection($connection)
     {

--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -106,7 +106,8 @@ class <%= $name %> extends AbstractMigration
 
     public function down()
     {
-        <%- foreach ($tables as $table): %>
+        <%- $tables = array_reverse($tables);
+            foreach ($tables as $table): %>
         $this->dropTable('<%= $table%>');
         <%- endforeach; %>
     }

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Class CategoriesFixture
+ *
+ */
+class ArticlesFixture extends TestFixture
+{
+
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'title' => ['type' => 'string', 'null' => true, 'length' => 255],
+        'category_id' => ['type' => 'integer', 'length' => 11],
+        'created' => ['type' => 'timestamp', 'null' => true, 'default' => null],
+        'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+            'category_idx' => [
+                'type' => 'foreign',
+                'columns' => ['category_id'],
+                'references' => ['categories', 'id'],
+                'update' => 'cascade',
+                'delete' => 'cascade'
+            ]
+        ]
+    ];
+}

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -16,7 +16,7 @@ namespace Migrations\Test\Fixture;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
- * Class CategoriesFixture
+ * Class ArticlesFixture
  *
  */
 class ArticlesFixture extends TestFixture
@@ -35,7 +35,7 @@ class ArticlesFixture extends TestFixture
         'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
-            'category_idx' => [
+            'category_article_idx' => [
                 'type' => 'foreign',
                 'columns' => ['category_id'],
                 'references' => ['categories', 'id'],

--- a/tests/Fixture/ProductsFixture.php
+++ b/tests/Fixture/ProductsFixture.php
@@ -16,7 +16,7 @@ namespace Migrations\Test\Fixture;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
- * Class CategoriesFixture
+ * Class ProductsFixture
  *
  */
 class ProductsFixture extends TestFixture

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -33,6 +33,7 @@ class MigrationSnapshotTaskTest extends TestCase
         'plugin.migrations.composite_pk',
         'plugin.migrations.products',
         'plugin.migrations.categories',
+        'plugin.migrations.articles',
         'plugin.migrations.orders'
     ];
 
@@ -69,7 +70,8 @@ class MigrationSnapshotTaskTest extends TestCase
             'SpecialPk',
             'CompositePk',
             'Categories',
-            'Products'
+            'Products',
+            'Articles'
         );
 
         $this->Task->params['require-table'] = false;

--- a/tests/comparisons/Migration/testCompositeConstraintsSnapshot.php
+++ b/tests/comparisons/Migration/testCompositeConstraintsSnapshot.php
@@ -110,6 +110,38 @@ class CompositeConstraintsSnapshot extends AbstractMigration
                 ]
             )
             ->create();
+        $table = $this->table('articles');
+        $table
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->create();
         $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
         $table
             ->addColumn('id', 'uuid', [
@@ -201,6 +233,7 @@ class CompositeConstraintsSnapshot extends AbstractMigration
         $this->dropTable('special_tags');
         $this->dropTable('special_pks');
         $this->dropTable('composite_pks');
+        $this->dropTable('articles');
         $this->dropTable('orders');
         $this->dropTable('products');
         $this->dropTable('categories');

--- a/tests/comparisons/Migration/testCompositeConstraintsSnapshot.php
+++ b/tests/comparisons/Migration/testCompositeConstraintsSnapshot.php
@@ -39,47 +39,6 @@ class CompositeConstraintsSnapshot extends AbstractMigration
                 ['unique' => true]
             )
             ->create();
-        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
-        $table
-            ->addColumn('id', 'uuid', [
-                'default' => '',
-                'limit' => null,
-                'null' => false,
-            ])
-            ->addColumn('name', 'string', [
-                'default' => '',
-                'limit' => 50,
-                'null' => false,
-            ])
-            ->create();
-        $table = $this->table('orders');
-        $table
-            ->addColumn('product_category', 'integer', [
-                'default' => null,
-                'limit' => 11,
-                'null' => false,
-            ])
-            ->addColumn('product_id', 'integer', [
-                'default' => null,
-                'limit' => 11,
-                'null' => false,
-            ])
-            ->addForeignKey(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                'products',
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
-                ]
-            )
-            ->create();
         $table = $this->table('products');
         $table
             ->addColumn('title', 'string', [
@@ -122,6 +81,47 @@ class CompositeConstraintsSnapshot extends AbstractMigration
                     'delete' => 'CASCADE'
                 ]
             )
+            ->create();
+        $table = $this->table('orders');
+        $table
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ],
+                'products',
+                [
+                    'category_id',
+                    'id',
+                ],
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->create();
+        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
+        $table
+            ->addColumn('id', 'uuid', [
+                'default' => '',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => '',
+                'limit' => 50,
+                'null' => false,
+            ])
             ->create();
         $table = $this->table('special_pks', ['id' => false, 'primary_key' => ['id']]);
         $table
@@ -197,12 +197,12 @@ class CompositeConstraintsSnapshot extends AbstractMigration
 
     public function down()
     {
-        $this->dropTable('categories');
+        $this->dropTable('users');
+        $this->dropTable('special_tags');
+        $this->dropTable('special_pks');
         $this->dropTable('composite_pks');
         $this->dropTable('orders');
         $this->dropTable('products');
-        $this->dropTable('special_pks');
-        $this->dropTable('special_tags');
-        $this->dropTable('users');
+        $this->dropTable('categories');
     }
 }

--- a/tests/comparisons/Migration/testNotEmptySnapshot.php
+++ b/tests/comparisons/Migration/testNotEmptySnapshot.php
@@ -39,19 +39,6 @@ class NotEmptySnapshot extends AbstractMigration
                 ['unique' => true]
             )
             ->create();
-        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
-        $table
-            ->addColumn('id', 'uuid', [
-                'default' => '',
-                'limit' => null,
-                'null' => false,
-            ])
-            ->addColumn('name', 'string', [
-                'default' => '',
-                'limit' => 50,
-                'null' => false,
-            ])
-            ->create();
         $table = $this->table('products');
         $table
             ->addColumn('title', 'string', [
@@ -94,6 +81,19 @@ class NotEmptySnapshot extends AbstractMigration
                     'delete' => 'CASCADE'
                 ]
             )
+            ->create();
+        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
+        $table
+            ->addColumn('id', 'uuid', [
+                'default' => '',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => '',
+                'limit' => 50,
+                'null' => false,
+            ])
             ->create();
         $table = $this->table('special_pks', ['id' => false, 'primary_key' => ['id']]);
         $table
@@ -169,11 +169,11 @@ class NotEmptySnapshot extends AbstractMigration
 
     public function down()
     {
-        $this->dropTable('categories');
+        $this->dropTable('users');
+        $this->dropTable('special_tags');
+        $this->dropTable('special_pks');
         $this->dropTable('composite_pks');
         $this->dropTable('products');
-        $this->dropTable('special_pks');
-        $this->dropTable('special_tags');
-        $this->dropTable('users');
+        $this->dropTable('categories');
     }
 }

--- a/tests/comparisons/Migration/testNotEmptySnapshot.php
+++ b/tests/comparisons/Migration/testNotEmptySnapshot.php
@@ -82,6 +82,38 @@ class NotEmptySnapshot extends AbstractMigration
                 ]
             )
             ->create();
+        $table = $this->table('articles');
+        $table
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->create();
         $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
         $table
             ->addColumn('id', 'uuid', [
@@ -173,6 +205,7 @@ class NotEmptySnapshot extends AbstractMigration
         $this->dropTable('special_tags');
         $this->dropTable('special_pks');
         $this->dropTable('composite_pks');
+        $this->dropTable('articles');
         $this->dropTable('products');
         $this->dropTable('categories');
     }


### PR DESCRIPTION
When tables are fetched from the database, they need to be ordered following foreign keys constraints dependencies to avoid table creation referencing tables that do not exist yet.

When dropping tables, their order needs to be reversed to avoid constraints failure.

I added a new ``ArticlesFixture`` to test the behaviour which has a constraint on ``CategoriesFixture``. Since it is alphabetically before and the ``categories`` table should be created before the ``articles`` table is, it allows to check the good ordering.

I also fixed a docblock along the way

Refs #100 