### PR TITLE
Adding mysqlAttributes to default connection

### DIFF
--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -76,15 +76,15 @@ trait ConfigurationTrait
 
         $connection = $this->getConnectionName($this->input);
 
-       	$config = ConnectionManager::config($connection);
-       	$configArray = [
+        $config = ConnectionManager::config($connection);
+        $configArray = [
             'paths' => [
-               	'migrations' => $dir
+                'migrations' => $dir
             ],
             'environments' => [
-               	'default_migration_table' => $plugin . 'phinxlog',
+                'default_migration_table' => $plugin . 'phinxlog',
                 'default_database' => 'default',
-               	'default' => [
+                'default' => [
                     'adapter' => $this->getAdapterName($config['driver']),
                     'host' => isset($config['host']) ? $config['host'] : null,
                     'user' => isset($config['username']) ? $config['username'] : null,
@@ -92,19 +92,19 @@ trait ConfigurationTrait
                     'port' => isset($config['port']) ? $config['port'] : null,
                     'name' => $config['database'],
                     'charset' => isset($config['encoding']) ? $config['encoding'] : null,
-               	]
+                ]
             ]
         ];
 
-	$mysqlAttributesArray = [ 'ssl_ca', 'ssl_cert', 'ssl_key' ];
+        $mysqlAttributesArray = [ 'ssl_ca', 'ssl_cert', 'ssl_key' ];
 
-	foreach ($mysqlAttributesArray as $value) {
-		if (isset($config[$value])) {
-			$configArray['environments']['default']['mysql_attr'.$value] = $config[$value];
-		}
-	}
+        foreach ($mysqlAttributesArray as $value) {
+                if (isset($config[$value])) {
+                    $configArray['environments']['default']['mysql_attr'.$value] = $config[$value];
+                }
+        }
 
-	return $this->configuration = new Config($configArray);
+        return $this->configuration = new Config($configArray);
     }
 
     /**

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -99,9 +99,9 @@ trait ConfigurationTrait
         $mysqlAttributesArray = [ 'ssl_ca', 'ssl_cert', 'ssl_key' ];
 
         foreach ($mysqlAttributesArray as $value) {
-                if (isset($config[$value])) {
-                    $configArray['environments']['default']['mysql_attr'.$value] = $config[$value];
-                }
+            if (isset($config[$value])) {
+                $configArray['environments']['default']['mysql_attr'.$value] = $config[$value];
+            }
         }
 
         return $this->configuration = new Config($configArray);

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -76,15 +76,15 @@ trait ConfigurationTrait
 
         $connection = $this->getConnectionName($this->input);
 
-        $config = ConnectionManager::config($connection);
-        return $this->configuration = new Config([
+       	$config = ConnectionManager::config($connection);
+       	$configArray = [
             'paths' => [
-                'migrations' => $dir
+               	'migrations' => $dir
             ],
             'environments' => [
-                'default_migration_table' => $plugin . 'phinxlog',
+               	'default_migration_table' => $plugin . 'phinxlog',
                 'default_database' => 'default',
-                'default' => [
+               	'default' => [
                     'adapter' => $this->getAdapterName($config['driver']),
                     'host' => isset($config['host']) ? $config['host'] : null,
                     'user' => isset($config['username']) ? $config['username'] : null,
@@ -92,10 +92,20 @@ trait ConfigurationTrait
                     'port' => isset($config['port']) ? $config['port'] : null,
                     'name' => $config['database'],
                     'charset' => isset($config['encoding']) ? $config['encoding'] : null,
-                    'unix_socket' => isset($config['unix_socket']) ? $config['unix_socket'] : null,
-                ]
+               	]
             ]
-        ]);
+        ];
+
+	if (($config['datasource'] == 'Database/Mysql') {
+		$mysqlAttributesArray = [ 'ssl_ca', 'ssl_cert', 'ssl_key' ];
+
+		foreach ($mysqlAttributesArray as $value) {
+			if (isset($config[$value])) {
+				$configArray['environments']['default']['mysql_attr'.$value] = $config[$value];
+			}
+		}
+	}
+	return $this->configuration = new Config($configArray);
     }
 
     /**

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -96,7 +96,7 @@ trait ConfigurationTrait
             ]
         ];
 
-	if (($config['datasource'] == 'Database/Mysql') {
+	if (($config['datasource'] == 'Database/Mysql')) {
 		$mysqlAttributesArray = [ 'ssl_ca', 'ssl_cert', 'ssl_key' ];
 
 		foreach ($mysqlAttributesArray as $value) {

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -96,15 +96,14 @@ trait ConfigurationTrait
             ]
         ];
 
-	if (($config['datasource'] == 'Database/Mysql')) {
-		$mysqlAttributesArray = [ 'ssl_ca', 'ssl_cert', 'ssl_key' ];
+	$mysqlAttributesArray = [ 'ssl_ca', 'ssl_cert', 'ssl_key' ];
 
-		foreach ($mysqlAttributesArray as $value) {
-			if (isset($config[$value])) {
-				$configArray['environments']['default']['mysql_attr'.$value] = $config[$value];
-			}
+	foreach ($mysqlAttributesArray as $value) {
+		if (isset($config[$value])) {
+			$configArray['environments']['default']['mysql_attr'.$value] = $config[$value];
 		}
 	}
+
 	return $this->configuration = new Config($configArray);
     }
 


### PR DESCRIPTION
Here is a fix that allows ssl_cert, ssl_ca and ssl_key parameters to be added to the mysql connection string. A developer could add additional parameters as needed.

This is pull request to issue #99 