### PR TITLE
Prevent the Postgres build from triggering a fatal error

### DIFF
--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -170,8 +170,12 @@ class MigrationHelper extends Helper
     {
         $tableSchema = $this->schema($table);
 
-        $tableConstraints = $tableSchema->constraints();
         $constraints = [];
+        $tableConstraints = $tableSchema->constraints();
+        if (empty($tableConstraints)) {
+            return $constraints;
+        }
+
         if ($tableConstraints[0] === 'primary') {
             unset($tableConstraints[0]);
         }

--- a/tests/Fixture/CategoriesFixture.php
+++ b/tests/Fixture/CategoriesFixture.php
@@ -36,7 +36,7 @@ class CategoriesFixture extends TestFixture
         'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
-            'UNIQUE_SLUG' => ['type' => 'unique', 'columns' => ['slug']]
+            'categories_unique_slug' => ['type' => 'unique', 'columns' => ['slug']]
         ]
     ];
 }

--- a/tests/Fixture/CompositePkFixture.php
+++ b/tests/Fixture/CompositePkFixture.php
@@ -14,6 +14,7 @@
 namespace Migrations\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
+use Cake\Utility\Text;
 
 /**
  * Class CompositePkFixture
@@ -27,7 +28,7 @@ class CompositePkFixture extends TestFixture
      * @var array
      */
     public $fields = [
-        'id' => ['type' => 'uuid', 'default' => '', 'null' => false ],
+        'id' => ['type' => 'uuid', 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7', 'null' => false ],
         'name' => ['type' => 'string', 'length' => 50, 'default' => '', 'null' => false],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'name']]]
     ];

--- a/tests/Fixture/CompositePkFixture.php
+++ b/tests/Fixture/CompositePkFixture.php
@@ -14,7 +14,6 @@
 namespace Migrations\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
-use Cake\Utility\Text;
 
 /**
  * Class CompositePkFixture

--- a/tests/Fixture/ProductsFixture.php
+++ b/tests/Fixture/ProductsFixture.php
@@ -37,6 +37,7 @@ class ProductsFixture extends TestFixture
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
             'products_unique_slug' => ['type' => 'unique', 'columns' => ['slug']],
+            'products_category_unique' => ['type' => 'unique', 'columns' => ['category_id', 'id']],
             'category_idx' => [
                 'type' => 'foreign',
                 'columns' => ['category_id'],

--- a/tests/Fixture/ProductsFixture.php
+++ b/tests/Fixture/ProductsFixture.php
@@ -36,7 +36,7 @@ class ProductsFixture extends TestFixture
         'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
-            'UNIQUE_SLUG' => ['type' => 'unique', 'columns' => ['slug']],
+            'products_unique_slug' => ['type' => 'unique', 'columns' => ['slug']],
             'category_idx' => [
                 'type' => 'foreign',
                 'columns' => ['category_id'],

--- a/tests/Fixture/SpecialPkFixture.php
+++ b/tests/Fixture/SpecialPkFixture.php
@@ -14,6 +14,7 @@
 namespace Migrations\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
+use Cake\Utility\Text;
 
 /**
  * Class SpecialPkFixture
@@ -27,7 +28,7 @@ class SpecialPkFixture extends TestFixture
      * @var array
      */
     public $fields = [
-        'id' => ['type' => 'uuid', 'default' => ''],
+        'id' => ['type' => 'uuid', 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7'],
         'name' => ['type' => 'string', 'null' => true, 'length' => 256],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
     ];

--- a/tests/Fixture/SpecialPkFixture.php
+++ b/tests/Fixture/SpecialPkFixture.php
@@ -14,7 +14,6 @@
 namespace Migrations\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
-use Cake\Utility\Text;
 
 /**
  * Class SpecialPkFixture

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -78,8 +78,6 @@ class MigrationSnapshotTaskTest extends TestCase
         $this->Task->params['connection'] = 'test';
         $this->Task->params['plugin'] = 'BogusPlugin';
 
-        $version = Util::getCurrentTimestamp();
-
         $this->Task->expects($this->once())
             ->method('dispatchShell')
             ->with(

--- a/tests/comparisons/Migration/testCompositeConstraintsSnapshot.php
+++ b/tests/comparisons/Migration/testCompositeConstraintsSnapshot.php
@@ -82,7 +82,7 @@ class CompositeConstraintsSnapshot extends AbstractMigration
         $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
         $table
             ->addColumn('id', 'uuid', [
-                'default' => '',
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
                 'limit' => null,
                 'null' => false,
             ])
@@ -156,7 +156,7 @@ class CompositeConstraintsSnapshot extends AbstractMigration
         $table = $this->table('special_pks', ['id' => false, 'primary_key' => ['id']]);
         $table
             ->addColumn('id', 'uuid', [
-                'default' => '',
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
                 'limit' => null,
                 'null' => false,
             ])

--- a/tests/comparisons/Migration/testCompositeConstraintsSnapshot.php
+++ b/tests/comparisons/Migration/testCompositeConstraintsSnapshot.php
@@ -149,6 +149,13 @@ class CompositeConstraintsSnapshot extends AbstractMigration
             ->addIndex(
                 [
                     'category_id',
+                    'id',
+                ],
+                ['unique' => true]
+            )
+            ->addIndex(
+                [
+                    'category_id',
                 ]
             )
             ->create();

--- a/tests/comparisons/Migration/testNotEmptySnapshot.php
+++ b/tests/comparisons/Migration/testNotEmptySnapshot.php
@@ -129,6 +129,13 @@ class NotEmptySnapshot extends AbstractMigration
             ->addIndex(
                 [
                     'category_id',
+                    'id',
+                ],
+                ['unique' => true]
+            )
+            ->addIndex(
+                [
+                    'category_id',
                 ]
             )
             ->create();

--- a/tests/comparisons/Migration/testNotEmptySnapshot.php
+++ b/tests/comparisons/Migration/testNotEmptySnapshot.php
@@ -82,7 +82,7 @@ class NotEmptySnapshot extends AbstractMigration
         $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
         $table
             ->addColumn('id', 'uuid', [
-                'default' => '',
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
                 'limit' => null,
                 'null' => false,
             ])
@@ -136,7 +136,7 @@ class NotEmptySnapshot extends AbstractMigration
         $table = $this->table('special_pks', ['id' => false, 'primary_key' => ['id']]);
         $table
             ->addColumn('id', 'uuid', [
-                'default' => '',
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
                 'limit' => null,
                 'null' => false,
             ])


### PR DESCRIPTION
Currently, the Postgres build is triggering a fatal error when creating the Fixtures for the tests.
This PR aims to prevents it.

Even if the Postgres build has errors around integer length when reflected by Cake Schema system (see https://github.com/cakephp/cakephp/issues/5901 & https://github.com/cakephp/migrations/commit/a57b25e5e3ac6d144441f4ebba0c0d4f80c46275), having failing assertions at least allow us to see if some additions does not trigger fixable mistakes with Postgres.