### PR TITLE
Update the Travis build matrix with PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
 
 sudo: false
 
@@ -17,14 +18,12 @@ env:
 matrix:
   allow_failures:
     - php: hhvm
+    - env: COVERALLS=1 DEFAULT=0
     - env: DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
 
   fast_finish: true
 
   include:
-    - php: 5.4
-      env: PHPCS=1 DEFAULT=0
-
     - php: 5.4
       env: COVERALLS=1 DEFAULT=0
 
@@ -39,6 +38,9 @@ matrix:
 
     - php: 5.6
       env: DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
+      
+    - php: 7.0
+      env: PHPCS=1 DEFAULT=0
 
     - php: hhvm
       env: HHVM=1 DB=sqlite db_dsn='sqlite:///:memory:'

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ matrix:
       env: DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
       
     - php: 7.0
+      env: DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
+      
+    - php: 7.0
       env: PHPCS=1 DEFAULT=0
 
     - php: hhvm


### PR DESCRIPTION
- Add PHP7 tests
- Make PHPCS runs on PHP7 (it should be faster)
- Allow coveralls.io to fail