### PR TITLE
The check for different migrations paths should only be done if a migrations path was already defined

### DIFF
--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -11,6 +11,7 @@
  */
 namespace Migrations;
 
+use Phinx\Config\Config;
 use Phinx\Config\ConfigInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -171,12 +172,14 @@ class Migrations
      */
     protected function run($method, $params, $input)
     {
-        $migrationPath = $this->getConfig()->getMigrationPath();
+        if ($this->configuration instanceof Config) {
+            $migrationPath = $this->getConfig()->getMigrationPath();
+        }
 
         $this->setInput($input);
         $newConfig = $this->getConfig(true);
         $manager = $this->getManager($newConfig);
-        if ($newConfig->getMigrationPath() !== $migrationPath) {
+        if (isset($migrationPath) && $newConfig->getMigrationPath() !== $migrationPath) {
             $manager->resetMigrations();
         }
 

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -49,15 +49,23 @@ class MigrationsTest extends TestCase
             'connection' => 'test',
             'source' => 'TestsMigrations'
         ];
-        $this->migrations = new Migrations($params);
 
-        $input = $this->migrations->getInput('Migrate', [], $params);
-        $this->migrations->setInput($input);
-        $this->migrations->getManager($this->migrations->getConfig());
-
+        // Get the PDO connection to have the same across the various objects needed to run the tests
+        $migrations = new Migrations();
+        $input = $migrations->getInput('Migrate', [], $params);
+        $migrations->setInput($input);
+        $migrations->getManager($migrations->getConfig());
         $this->Connection = ConnectionManager::get('test');
-        $connection = $this->migrations->getManager()->getEnvironment('default')->getAdapter()->getConnection();
+        $connection = $migrations->getManager()->getEnvironment('default')->getAdapter()->getConnection();
         $this->Connection->driver()->connection($connection);
+
+        // Get an instance of the Migrations object on which we will run the tests
+        $this->migrations = new Migrations($params);
+        $this->migrations
+            ->getManager($migrations->getConfig())
+            ->getEnvironment('default')
+            ->getAdapter()
+            ->setConnection($connection);
 
         $tables = (new Collection($this->Connection))->listTables();
         if (in_array('phinxlog', $tables)) {
@@ -194,6 +202,21 @@ class MigrationsTest extends TestCase
      */
     public function testOverrideOptions()
     {
+        $result = $this->migrations->status();
+        $expectedStatus = [
+            [
+                'status' => 'down',
+                'id' => '20150704160200',
+                'name' => 'CreateNumbersTable'
+            ],
+            [
+                'status' => 'down',
+                'id' => '20150724233100',
+                'name' => 'UpdateNumbersTable'
+            ]
+        ];
+        $this->assertEquals($expectedStatus, $result);
+
         $result = $this->migrations->status(['source' => 'Migrations']);
         $expected = [
             [


### PR DESCRIPTION
The Manager object Phinx used stores the migrations whenever some are found through a command.
The Migrations class erases them from the Manager object when a method is used to prevent wrong migrations to be returned.
This is done only if the migrations path between two calls are different.

This bug went unseen because in the tests, a dummy input is generated and passed to a Migrations object in order to get the PDO instance and share it with other objects (needed because of SQLite and the memory connection). The migrations were then ran against this Migrations object that already had a migrations path defined (because its manager was instanciated already with the dummy input), causing the method to raise an exception.
The tests now run migrations with a new object to make sure the bug does not happen.

Refs #111 