### PR TITLE
Implements a new way to deal with primary keys

### DIFF
--- a/src/AbstractMigration.php
+++ b/src/AbstractMigration.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations;
+
+use Phinx\Migration\AbstractMigration as BaseAbstractMigration;
+
+class AbstractMigration extends BaseAbstractMigration
+{
+
+    /**
+     * Whether the tables created in this migration
+     * should auto-create an `id` field or not
+     *
+     * This option is global for all tables created in the migration file.
+     * If you set it to false, you have to manually add the primary keys for your
+     * tables using the Migrations\Table::addPrimaryKey() method
+     *
+     * @var bool
+     */
+    public $autoId = true;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function table($tableName, $options = array())
+    {
+        if ($this->autoId === false) {
+            $options['id'] = false;
+        }
+
+        return new Table($tableName, $options, $this->getAdapter());
+    }
+}

--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -149,6 +149,12 @@ class MigrationSnapshotTask extends SimpleMigrationTask
                 }
             }
         }
+
+        $autoId = true;
+        if (isset($this->params['disable-autoid'])) {
+            $autoId = !$this->params['disable-autoid'];
+        }
+
         return [
             'plugin' => $this->plugin,
             'pluginPath' => $pluginPath,
@@ -157,6 +163,7 @@ class MigrationSnapshotTask extends SimpleMigrationTask
             'tables' => $tables,
             'action' => 'create_table',
             'name' => $this->BakeTemplate->viewVars['name'],
+            'autoId' => $autoId
         ];
     }
 
@@ -278,6 +285,10 @@ class MigrationSnapshotTask extends SimpleMigrationTask
             'boolean' => true,
             'default' => false,
             'help' => 'If require-table is set to true, check also that the table class exists.'
+        ])->addOption('disable-autoid', [
+            'boolean' => true,
+            'default' => false,
+            'help' => 'Disable phinx behavior of automatically adding an id field.'
         ]);
 
         return $parser;

--- a/src/Shell/Task/MigrationTask.php
+++ b/src/Shell/Task/MigrationTask.php
@@ -16,6 +16,7 @@ namespace Migrations\Shell\Task;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
+use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Migrations\Shell\Task\SimpleMigrationTask;
 use Migrations\Util\ColumnParser;
@@ -25,6 +26,7 @@ use Migrations\Util\ColumnParser;
  */
 class MigrationTask extends SimpleMigrationTask
 {
+
     /**
      * {@inheritDoc}
      */
@@ -76,6 +78,7 @@ class MigrationTask extends SimpleMigrationTask
         $columnParser = new ColumnParser;
         $fields = $columnParser->parseFields($arguments);
         $indexes = $columnParser->parseIndexes($arguments);
+        $primaryKey = $columnParser->parsePrimaryKey($arguments);
 
         list($action, $table) = $action;
         return [
@@ -87,6 +90,7 @@ class MigrationTask extends SimpleMigrationTask
             'columns' => [
                 'fields' => $fields,
                 'indexes' => $indexes,
+                'primaryKey' => $primaryKey
             ],
             'name' => $className
         ];

--- a/src/Shell/Task/MigrationTask.php
+++ b/src/Shell/Task/MigrationTask.php
@@ -80,6 +80,10 @@ class MigrationTask extends SimpleMigrationTask
         $indexes = $columnParser->parseIndexes($arguments);
         $primaryKey = $columnParser->parsePrimaryKey($arguments);
 
+        if (in_array($action[0], ['alter_table', 'add_field']) && !empty($primaryKey)) {
+            $this->error('Adding a primary key to an already existing table is not supported.');
+        }
+
         list($action, $table) = $action;
         return [
             'plugin' => $this->plugin,

--- a/src/Shell/Task/MigrationTask.php
+++ b/src/Shell/Task/MigrationTask.php
@@ -16,7 +16,6 @@ namespace Migrations\Shell\Task;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
-use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Migrations\Shell\Task\SimpleMigrationTask;
 use Migrations\Util\ColumnParser;

--- a/src/Table.php
+++ b/src/Table.php
@@ -16,7 +16,14 @@ use Phinx\Db\Table as BaseTable;
 class Table extends BaseTable
 {
 
-    protected $primaryKeys = [];
+    /**
+     * Primary key for this table.
+     * Can either be a string or an array in case of composite
+     * primary key.
+     *
+     * @var string|array
+     */
+    protected $primaryKey;
 
     /**
      * Add a primary key to a database table.
@@ -26,7 +33,7 @@ class Table extends BaseTable
      */
     public function addPrimaryKey($columns)
     {
-        $this->primaryKeys = $columns;
+        $this->primaryKey = $columns;
         return $this;
     }
 
@@ -52,8 +59,8 @@ class Table extends BaseTable
      */
     public function create()
     {
-        if ($this->options['id'] === false && !empty($this->primaryKeys)) {
-            $this->options['primary_key'] = $this->primaryKeys;
+        if ($this->options['id'] === false && !empty($this->primaryKey)) {
+            $this->options['primary_key'] = $this->primaryKey;
         }
         parent::create();
     }

--- a/src/Table.php
+++ b/src/Table.php
@@ -59,7 +59,7 @@ class Table extends BaseTable
      */
     public function create()
     {
-        if ($this->options['id'] === false && !empty($this->primaryKey)) {
+        if ((!isset($this->options['id']) || $this->options['id'] === false) && !empty($this->primaryKey)) {
             $this->options['primary_key'] = $this->primaryKey;
         }
         parent::create();

--- a/src/Table.php
+++ b/src/Table.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations;
+
+use Phinx\Db\Table as BaseTable;
+
+class Table extends BaseTable
+{
+
+    protected $primaryKeys = [];
+
+    /**
+     * Add a primary key to a database table.
+     *
+     * @param string|array $columns Table Column(s)
+     * @return Table
+     */
+    public function addPrimaryKey($columns)
+    {
+        $this->primaryKeys = $columns;
+        return $this;
+    }
+
+    /**
+     * You can pass `autoIncrement` as an option and it will be converted
+     * to the correct option for phinx to create the column with an
+     * auto increment attribute
+     *
+     * {@inheritdoc}
+     */
+    public function addColumn($columnName, $type = null, $options = array())
+    {
+        if (isset($options['autoIncrement']) && $options['autoIncrement'] === true) {
+            $options['identity'] = true;
+            unset($options['autoIncrement']);
+        }
+
+        return parent::addColumn($columnName, $type, $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create()
+    {
+        if ($this->options['id'] === false && !empty($this->primaryKeys)) {
+            $this->options['primary_key'] = $this->primaryKeys;
+        }
+        parent::create();
+    }
+}

--- a/src/Template/Bake/config/skeleton.ctp
+++ b/src/Template/Bake/config/skeleton.ctp
@@ -23,6 +23,11 @@ use Migrations\AbstractMigration;
 
 class <%= $name %> extends AbstractMigration
 {
+    <%- if ($tableMethod === 'create' && !empty($columns['primaryKey'])): %>
+
+    public $autoId = false;
+
+    <%- endif; %>
     /**
      * Change Method.
      *
@@ -61,6 +66,11 @@ class <%= $name %> extends AbstractMigration
                 echo $this->Migration->stringifyList($config['options'], ['indent' => 3]);
             %>]);
 <% endforeach; %>
+<% if ($tableMethod === 'create' && !empty($columns['primaryKey'])): %>
+        $table->addPrimaryKey([<%=
+                $this->Migration->stringifyList($columns['primaryKey'], ['indent' => 3])
+                %>]);
+<% endif; %>
 <% endif; %>
 <% endif; %>
         $table-><%= $tableMethod %>();

--- a/src/Template/Bake/config/skeleton.ctp
+++ b/src/Template/Bake/config/skeleton.ctp
@@ -19,7 +19,7 @@ $columnMethod = $this->Migration->columnMethod($action);
 $indexMethod = $this->Migration->indexMethod($action);
 %>
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class <%= $name %> extends AbstractMigration
 {

--- a/src/Template/Bake/config/skeleton.ctp
+++ b/src/Template/Bake/config/skeleton.ctp
@@ -13,7 +13,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-$wantedOptions = array_flip(['length', 'limit', 'default', 'unsigned', 'null', 'comment']);
+$wantedOptions = array_flip(['length', 'limit', 'default', 'unsigned', 'null', 'comment', 'autoIncrement']);
 $tableMethod = $this->Migration->tableMethod($action);
 $columnMethod = $this->Migration->columnMethod($action);
 $indexMethod = $this->Migration->indexMethod($action);

--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -35,7 +35,7 @@ class <%= $name %> extends AbstractMigration
         $foreignKeys = [];
         $primaryKeysColumns = $this->Migration->primaryKeysColumnsList($table);
         $primaryKeys = $this->Migration->primaryKeys($table);
-        $specialPk = count($primaryKeys) > 1 || $primaryKeys[0]['name'] !== 'id' || $primaryKeys[0]['info']['columnType'] !== 'integer' && $autoId;
+        $specialPk = (count($primaryKeys) > 1 || $primaryKeys[0]['name'] !== 'id' || $primaryKeys[0]['info']['columnType'] !== 'integer') && $autoId;
         if ($specialPk):
         %>
         $table = $this->table('<%= $table%>', ['id' => false, 'primary_key' => ['<%= implode("', '", \Cake\Utility\Hash::extract($primaryKeys, '{n}.name')) %>']]);

--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -56,10 +56,10 @@ class <%= $name %> extends AbstractMigration
                 }
                 echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
             %>])
-            <%- if (!$autoId): %>
+            <%- endforeach;
+            if (!$autoId): %>
             ->addPrimaryKey(['<%= implode("', '", \Cake\Utility\Hash::extract($primaryKeys, '{n}.name')) %>'])
             <%- endif;
-            endforeach;
             endif;
         foreach ($this->Migration->columns($table) as $column => $config): %>
             -><%= $columnMethod %>('<%= $column %>', '<%= $config['columnType'] %>', [<%

--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -13,24 +13,29 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-$wantedOptions = array_flip(['length', 'limit', 'default', 'unsigned', 'null', 'comment']);
+$wantedOptions = array_flip(['length', 'limit', 'default', 'unsigned', 'null', 'comment', 'autoIncrement']);
 $tableMethod = $this->Migration->tableMethod($action);
 $columnMethod = $this->Migration->columnMethod($action);
 $indexMethod = $this->Migration->indexMethod($action);
 $constraints = $foreignKeys = $dropForeignKeys = [];
 %>
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class <%= $name %> extends AbstractMigration
 {
+    <%- if (!$autoId): %>
+
+    public $autoId = false;
+
+    <%- endif; %>
     public function up()
     {
     <%- foreach ($tables as $table):
         $foreignKeys = [];
         $primaryKeysColumns = $this->Migration->primaryKeysColumnsList($table);
         $primaryKeys = $this->Migration->primaryKeys($table);
-        $specialPk = count($primaryKeys) > 1 || $primaryKeys[0]['name'] !== 'id' || $primaryKeys[0]['info']['columnType'] !== 'integer';
+        $specialPk = count($primaryKeys) > 1 || $primaryKeys[0]['name'] !== 'id' || $primaryKeys[0]['info']['columnType'] !== 'integer' && $autoId;
         if ($specialPk):
         %>
         $table = $this->table('<%= $table%>', ['id' => false, 'primary_key' => ['<%= implode("', '", \Cake\Utility\Hash::extract($primaryKeys, '{n}.name')) %>']]);
@@ -38,7 +43,7 @@ class <%= $name %> extends AbstractMigration
         $table = $this->table('<%= $table%>');
         <%- endif; %>
         $table
-        <%- if ($specialPk):
+        <%- if ($specialPk || !$autoId):
             foreach ($primaryKeys as $primaryKey) : %>
             -><%= $columnMethod %>('<%= $primaryKey['name'] %>', '<%= $primaryKey['info']['columnType'] %>', [<%
                 $options = [];
@@ -46,9 +51,15 @@ class <%= $name %> extends AbstractMigration
                 if (empty($columnOptions['comment'])) {
                     unset($columnOptions['comment']);
                 }
+                if (empty($columnOptions['autoIncrement'])) {
+                    unset($columnOptions['autoIncrement']);
+                }
                 echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
             %>])
-            <%- endforeach;
+            <%- if (!$autoId): %>
+            ->addPrimaryKey(['<%= implode("', '", \Cake\Utility\Hash::extract($primaryKeys, '{n}.name')) %>'])
+            <%- endif;
+            endforeach;
             endif;
         foreach ($this->Migration->columns($table) as $column => $config): %>
             -><%= $columnMethod %>('<%= $column %>', '<%= $config['columnType'] %>', [<%
@@ -56,6 +67,9 @@ class <%= $name %> extends AbstractMigration
                 $columnOptions = array_intersect_key($config['options'], $wantedOptions);
                 if (empty($columnOptions['comment'])) {
                     unset($columnOptions['comment']);
+                }
+                if (empty($columnOptions['autoIncrement'])) {
+                    unset($columnOptions['autoIncrement']);
                 }
                 echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
             %>])

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -77,7 +77,9 @@ class ColumnParser
             $indexType = Hash::get($matches, 3);
             $indexName = Hash::get($matches, 4);
 
-            if (in_array($type, ['primary', 'primary_key']) || in_array($indexType, ['primary', 'primary_key']) || $indexType === null) {
+            if (in_array($type, ['primary', 'primary_key']) ||
+                in_array($indexType, ['primary', 'primary_key']) ||
+                $indexType === null) {
                 continue;
             }
 

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -26,11 +26,16 @@ class ColumnParser
             preg_match('/^(\w*)(?::(\w*))?(?::(\w*))?(?::(\w*))?/', $field, $matches);
             $field = $matches[1];
             $type = Hash::get($matches, 2);
+            $indexType = Hash::get($matches, 3);
 
+            $typeIsPk = in_array($type, ['primary', 'primary_key']);
             $isPrimaryKey = false;
-            if (in_array($type, ['primary', 'primary_key'])) {
+            if ($typeIsPk || in_array($indexType, ['primary', 'primary_key'])) {
                 $isPrimaryKey = true;
-                $type = 'primary';
+
+                if ($typeIsPk) {
+                    $type = 'primary';
+                }
             }
 
             $type = $this->getType($field, $type);

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -286,7 +286,8 @@ class MigrationHelper extends Helper
             'precision', 'scale',
             'after', 'update',
             'comment', 'unsigned',
-            'signed', 'properties'
+            'signed', 'properties',
+            'autoIncrement'
         ];
 
         $attributes = [];

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -149,18 +149,20 @@ class MigrationsTest extends TestCase
         ];
         $this->assertEquals($expectedStatus, $status);
 
-        $table = TableRegistry::get('Numbers', ['connection' => $this->Connection]);
-        $columns = $table->schema()->columns();
+        $numbersTable = TableRegistry::get('Numbers', ['connection' => $this->Connection]);
+        $columns = $numbersTable->schema()->columns();
         $expected = ['id', 'number', 'radix'];
         $this->assertEquals($columns, $expected);
+        $primaryKey = $numbersTable->schema()->primaryKey();
+        $this->assertEquals($primaryKey, ['id']);
 
-        $table = TableRegistry::get('Letters', ['connection' => $this->Connection]);
-        $columns = $table->schema()->columns();
+        $lettersTable = TableRegistry::get('Letters', ['connection' => $this->Connection]);
+        $columns = $lettersTable->schema()->columns();
         $expected = ['id', 'letter'];
         $this->assertEquals($expected, $columns);
-        $idColumn = $table->schema()->column('id');
+        $idColumn = $lettersTable->schema()->column('id');
         $this->assertEquals(true, $idColumn['autoIncrement']);
-        $primaryKey = $table->schema()->primaryKey();
+        $primaryKey = $lettersTable->schema()->primaryKey();
         $this->assertEquals($primaryKey, ['id']);
 
         // Rollback last

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -108,6 +108,11 @@ class MigrationsTest extends TestCase
                 'status' => 'down',
                 'id' => '20150724233100',
                 'name' => 'UpdateNumbersTable'
+            ],
+            [
+                'status' => 'down',
+                'id' => '20150826191400',
+                'name' => 'CreateLettersTable'
             ]
         ];
         $this->assertEquals($expected, $result);
@@ -135,6 +140,11 @@ class MigrationsTest extends TestCase
                 'status' => 'up',
                 'id' => '20150724233100',
                 'name' => 'UpdateNumbersTable'
+            ],
+            [
+                'status' => 'up',
+                'id' => '20150826191400',
+                'name' => 'CreateLettersTable'
             ]
         ];
         $this->assertEquals($expectedStatus, $status);
@@ -144,10 +154,19 @@ class MigrationsTest extends TestCase
         $expected = ['id', 'number', 'radix'];
         $this->assertEquals($columns, $expected);
 
+        $table = TableRegistry::get('Letters', ['connection' => $this->Connection]);
+        $columns = $table->schema()->columns();
+        $expected = ['id', 'letter'];
+        $this->assertEquals($expected, $columns);
+        $idColumn = $table->schema()->column('id');
+        $this->assertEquals(true, $idColumn['autoIncrement']);
+        $primaryKey = $table->schema()->primaryKey();
+        $this->assertEquals($primaryKey, ['id']);
+
         // Rollback last
         $rollback = $this->migrations->rollback();
         $this->assertTrue($rollback);
-        $expectedStatus[1]['status'] = 'down';
+        $expectedStatus[2]['status'] = 'down';
         $status = $this->migrations->status();
         $this->assertEquals($expectedStatus, $status);
 
@@ -155,7 +174,7 @@ class MigrationsTest extends TestCase
         $this->migrations->migrate();
         $rollback = $this->migrations->rollback(['target' => 0]);
         $this->assertTrue($rollback);
-        $expectedStatus[0]['status'] = 'down';
+        $expectedStatus[0]['status'] = $expectedStatus[1]['status'] = 'down';
         $status = $this->migrations->status();
         $this->assertEquals($expectedStatus, $status);
     }
@@ -215,6 +234,11 @@ class MigrationsTest extends TestCase
                 'status' => 'down',
                 'id' => '20150724233100',
                 'name' => 'UpdateNumbersTable'
+            ],
+            [
+                'status' => 'down',
+                'id' => '20150826191400',
+                'name' => 'CreateLettersTable'
             ]
         ];
         $this->assertEquals($expectedStatus, $result);

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -295,6 +295,11 @@ class MigrationsTest extends TestCase
                 'status' => 'down',
                 'id' => '20150724233100',
                 'name' => 'UpdateNumbersTable'
+            ],
+            [
+                'status' => 'down',
+                'id' => '20150826191400',
+                'name' => 'CreateLettersTable'
             ]
         ];
         $this->assertEquals($expectedStatus, $this->migrations->status());
@@ -312,6 +317,11 @@ class MigrationsTest extends TestCase
                 'status' => 'down',
                 'id' => '20150724233100',
                 'name' => 'UpdateNumbersTable'
+            ],
+            [
+                'status' => 'down',
+                'id' => '20150826191400',
+                'name' => 'CreateLettersTable'
             ]
         ];
         $this->assertEquals($expectedStatus, $this->migrations->status());
@@ -330,6 +340,11 @@ class MigrationsTest extends TestCase
                 'status' => 'up',
                 'id' => '20150724233100',
                 'name' => 'UpdateNumbersTable'
+            ],
+            [
+                'status' => 'down',
+                'id' => '20150826191400',
+                'name' => 'CreateLettersTable'
             ]
         ];
         $this->assertEquals($expectedStatus, $this->migrations->status());
@@ -347,6 +362,11 @@ class MigrationsTest extends TestCase
                 'status' => 'down',
                 'id' => '20150724233100',
                 'name' => 'UpdateNumbersTable'
+            ],
+            [
+                'status' => 'down',
+                'id' => '20150826191400',
+                'name' => 'CreateLettersTable'
             ]
         ];
         $this->assertEquals($expectedStatus, $this->migrations->status());
@@ -367,6 +387,11 @@ class MigrationsTest extends TestCase
                 'status' => 'down',
                 'id' => '20150724233100',
                 'name' => 'UpdateNumbersTable'
+            ],
+            [
+                'status' => 'down',
+                'id' => '20150826191400',
+                'name' => 'CreateLettersTable'
             ]
         ];
         $this->assertEquals($expectedStatus, $this->migrations->status());

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -352,7 +352,7 @@ class MigrationsTest extends TestCase
      * @dataProvider migrationsProvider
      * @return void
      */
-    public function testMigrateSnapshots($basePath)
+    public function testMigrateSnapshots($basePath, $files)
     {
         $destination = ROOT . 'config' . DS . 'SnapshotTests' . DS;
         $timestamp = Util::getCurrentTimestamp();
@@ -361,29 +361,19 @@ class MigrationsTest extends TestCase
             mkdir($destination);
         }
 
-        copy(
-            $basePath . 'testCompositeConstraintsSnapshot.php',
-            $destination . $timestamp . '_testCompositeConstraintsSnapshot.php'
-        );
+        foreach ($files as $file) {
+            $copiedFileName = $timestamp . '_' . $file . '.php';
+            copy(
+                $basePath . $file . '.php',
+                $destination . $copiedFileName
+            );
 
-        $result = $this->migrations->migrate(['source' => 'SnapshotTests']);
-        $this->assertTrue($result);
+            $result = $this->migrations->migrate(['source' => 'SnapshotTests']);
+            $this->assertTrue($result);
 
-        $this->migrations->rollback(['source' => 'SnapshotTests']);
-
-        unlink($destination . $timestamp . '_testCompositeConstraintsSnapshot.php');
-
-        copy(
-            $basePath . 'testNotEmptySnapshot.php',
-            $destination . $timestamp . '_testNotEmptySnapshot.php'
-        );
-
-        $result = $this->migrations->migrate(['source' => 'SnapshotTests']);
-        $this->assertTrue($result);
-
-        $this->migrations->rollback(['source' => 'SnapshotTests']);
-
-        unlink($destination . $timestamp . '_testNotEmptySnapshot.php');
+            $this->migrations->rollback(['source' => 'SnapshotTests']);
+            unlink($destination . $copiedFileName);
+        }
     }
 
     /**
@@ -394,9 +384,18 @@ class MigrationsTest extends TestCase
     public function migrationsProvider()
     {
         return [
-            [Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS],
-            [Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS . 'sqlite' . DS],
-            [Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS . 'pgsql' . DS]
+            [
+                Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS,
+                ['testCompositeConstraintsSnapshot', 'testNotEmptySnapshot', 'testAutoIdDisabledSnapshot']
+            ],
+            [
+                Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS . 'sqlite' . DS,
+                ['testCompositeConstraintsSnapshot', 'testNotEmptySnapshot', 'testAutoIdDisabledSnapshot']
+            ],
+            [
+                Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS . 'pgsql' . DS,
+                ['testCompositeConstraintsSnapshot', 'testNotEmptySnapshot', 'testAutoIdDisabledSnapshot']
+            ]
         ];
     }
 }

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -412,7 +412,13 @@ class MigrationsTest extends TestCase
         return [
             [
                 Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS,
-                ['testCompositeConstraintsSnapshot', 'testNotEmptySnapshot', 'testAutoIdDisabledSnapshot']
+                [
+                    'testCompositeConstraintsSnapshot',
+                    'testNotEmptySnapshot',
+                    'testAutoIdDisabledSnapshot',
+                    'testCreatePrimaryKey',
+                    'testCreatePrimaryKeyUuid'
+                ]
             ],
             [
                 Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS . 'sqlite' . DS,

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -92,6 +92,18 @@ class MigrationSnapshotTaskTest extends TestCase
         $this->assertCorrectSnapshot(__FUNCTION__, $result);
     }
 
+    public function testAutoIdDisabledSnapshot()
+    {
+        $this->Task->params['require-table'] = false;
+        $this->Task->params['disable-autoid'] = true;
+        $this->Task->params['connection'] = 'test';
+        $this->Task->params['plugin'] = 'BogusPlugin';
+
+        $result = $this->Task->bake('AutoIdDisabledSnapshot');
+
+        $this->assertCorrectSnapshot(__FUNCTION__, $result);
+    }
+
     public function testCompositeConstraintsSnapshot()
     {
         $this->skipIf(

--- a/tests/TestCase/Shell/Task/MigrationTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationTaskTest.php
@@ -37,7 +37,7 @@ class MigrationTaskTest extends TestCase
 
         $this->Task = $this->getMock(
             'Migrations\Shell\Task\MigrationTask',
-            ['in', 'err', 'createFile', '_stop'],
+            ['in', 'err', 'createFile', '_stop', 'error'],
             [$inputOutput]
         );
         $this->Task->name = 'Migration';
@@ -100,6 +100,30 @@ class MigrationTaskTest extends TestCase
         ];
         $result = $this->Task->bake('CreateUsers');
         $this->assertSameAsFile(__FUNCTION__ . 'PrimaryKeyUuid.php', $result);
+    }
+
+    /**
+     * Test that adding a field or altering a table with a primary
+     * key will error out
+     *
+     * @return void
+     */
+    public function testAddPrimaryKeyToExistingTable()
+    {
+        $this->Task->expects($this->any())
+            ->method('error');
+
+        $this->Task->args = [
+            'add_pk_to_users',
+            'somefield:primary_key'
+        ];
+        $this->Task->bake('AddPkToUsers');
+
+        $this->Task->args = [
+            'alter_users',
+            'somefield:primary_key'
+        ];
+        $this->Task->bake('AlterUsers');
     }
 
     /**

--- a/tests/TestCase/Shell/Task/MigrationTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationTaskTest.php
@@ -59,7 +59,7 @@ class MigrationTaskTest extends TestCase
     }
 
     /**
-     * Test the excute method.
+     * Test the execute method.
      *
      * @return void
      */
@@ -80,6 +80,26 @@ class MigrationTaskTest extends TestCase
         ];
         $result = $this->Task->bake('CreateUsers');
         $this->assertSameAsFile(__FUNCTION__ . 'Datetime.php', $result);
+
+        $this->Task->args = [
+            'create_users',
+            'id:integer:primary_key',
+            'name',
+            'created',
+            'modified'
+        ];
+        $result = $this->Task->bake('CreateUsers');
+        $this->assertSameAsFile(__FUNCTION__ . 'PrimaryKey.php', $result);
+
+        $this->Task->args = [
+            'create_users',
+            'id:uuid:primary_key',
+            'name',
+            'created',
+            'modified'
+        ];
+        $result = $this->Task->bake('CreateUsers');
+        $this->assertSameAsFile(__FUNCTION__ . 'PrimaryKeyUuid.php', $result);
     }
 
     /**

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -143,7 +143,10 @@ class ColumnParserTest extends TestCase
         $this->assertEquals(['id'], $this->columnParser->parsePrimaryKey(['id:primary']));
         $this->assertEquals(['id'], $this->columnParser->parsePrimaryKey(['id:integer:primary']));
         $this->assertEquals(['id'], $this->columnParser->parsePrimaryKey(['id:integer:primary:ID_INDEX']));
-        $this->assertEquals(['id', 'name'], $this->columnParser->parsePrimaryKey(['id:integer:primary', 'name:primary_key']));
+        $this->assertEquals(
+            ['id', 'name'],
+            $this->columnParser->parsePrimaryKey(['id:integer:primary', 'name:primary_key'])
+        );
     }
 
     /**

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -47,6 +47,7 @@ class ColumnParserTest extends TestCase
                 ],
             ],
         ], $this->columnParser->parseFields(['id']));
+
         $this->assertEquals([
             'id' => [
                 'columnType' => 'integer',
@@ -54,16 +55,18 @@ class ColumnParserTest extends TestCase
                     'null' => false,
                     'default' => null,
                     'limit' => 11,
+                    'autoIncrement' => true
                 ],
             ],
         ], $this->columnParser->parseFields(['id:primary']));
+
         $this->assertEquals([
             'id' => [
                 'columnType' => 'integer',
                 'options' => [
                     'null' => false,
                     'default' => null,
-                    'limit' => 11,
+                    'limit' => 11
                 ],
             ],
             'name' => [
@@ -75,13 +78,14 @@ class ColumnParserTest extends TestCase
                 ],
             ],
         ], $this->columnParser->parseFields(['id', 'name']));
+
         $this->assertEquals([
             'id' => [
                 'columnType' => 'integer',
                 'options' => [
                     'null' => false,
                     'default' => null,
-                    'limit' => 11,
+                    'limit' => 11
                 ],
             ],
             'created' => [
@@ -113,22 +117,6 @@ class ColumnParserTest extends TestCase
      */
     public function testParseIndexes()
     {
-        $this->assertEquals(['PRIMARY' => [
-            'columns' => ['id'],
-            'options' => ['unique' => true, 'name' => 'PRIMARY']
-        ]], $this->columnParser->parseIndexes(['id:primary_key']));
-        $this->assertEquals(['PRIMARY' => [
-            'columns' => ['id'],
-            'options' => ['unique' => true, 'name' => 'PRIMARY']
-        ]], $this->columnParser->parseIndexes(['id:primary']));
-        $this->assertEquals(['PRIMARY' => [
-            'columns' => ['id'],
-            'options' => ['unique' => true, 'name' => 'PRIMARY']
-        ]], $this->columnParser->parseIndexes(['id:integer:primary']));
-        $this->assertEquals(['ID_INDEX' => [
-            'columns' => ['id'],
-            'options' => ['unique' => true, 'name' => 'ID_INDEX']
-        ]], $this->columnParser->parseIndexes(['id:integer:primary:ID_INDEX']));
         $this->assertEquals(['UNIQUE_ID' => [
             'columns' => ['id'],
             'options' => ['unique' => true, 'name' => 'UNIQUE_ID']
@@ -145,6 +133,17 @@ class ColumnParserTest extends TestCase
             'event_id:integer:unique:UNIQUE_EVENT',
             'market_id:integer:unique:UNIQUE_EVENT',
         ]));
+    }
+
+    /**
+     * @covers Migrations\Util\ColumnParser::parsePrimaryKey
+     */
+    public function testParsePrimaryKey()
+    {
+        $this->assertEquals(['id'], $this->columnParser->parsePrimaryKey(['id:primary']));
+        $this->assertEquals(['id'], $this->columnParser->parsePrimaryKey(['id:integer:primary']));
+        $this->assertEquals(['id'], $this->columnParser->parsePrimaryKey(['id:integer:primary:ID_INDEX']));
+        $this->assertEquals(['id', 'name'], $this->columnParser->parsePrimaryKey(['id:integer:primary', 'name:primary_key']));
     }
 
     /**

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -179,6 +179,7 @@ class MigrationHelperTest extends TestCase
                 'precision' => null,
                 'comment' => $this->values['comment'],
                 'signed' => true,
+                'autoIncrement' => true
             ],
         ], $this->Helper->column($tableSchema, 'id'));
 
@@ -258,6 +259,7 @@ class MigrationHelperTest extends TestCase
             'precision' => null,
             'comment' => $this->values['comment'],
             'signed' => true,
+            'autoIncrement' => true
         ], $this->Helper->attributes('users', 'id'));
 
         $this->assertEquals([
@@ -301,6 +303,7 @@ class MigrationHelperTest extends TestCase
             'precision' => null,
             'comment' => $this->values['comment'],
             'signed' => true,
+            'autoIncrement' => null
         ], $this->Helper->attributes('special_tags', 'article_id'));
     }
 

--- a/tests/comparisons/Migration/pgsql/testAutoIdDisabledSnapshot.php
+++ b/tests/comparisons/Migration/pgsql/testAutoIdDisabledSnapshot.php
@@ -97,7 +97,7 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             )
             ->create();
 
-        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
+        $table = $this->table('composite_pks');
         $table
             ->addColumn('id', 'uuid', [
                 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',

--- a/tests/comparisons/Migration/pgsql/testAutoIdDisabledSnapshot.php
+++ b/tests/comparisons/Migration/pgsql/testAutoIdDisabledSnapshot.php
@@ -1,0 +1,317 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AutoIdDisabledSnapshot extends AbstractMigration
+{
+
+    public $autoId = false;
+
+    public function up()
+    {
+        $table = $this->table('articles');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'comment' => 'Article title',
+                'default' => 'NULL::character varying',
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'category_id',
+                ]
+            )
+            ->addIndex(
+                [
+                    'product_id',
+                ]
+            )
+            ->create();
+
+        $table = $this->table('categories');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('parent_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
+            ->addColumn('title', 'string', [
+                'default' => 'NULL::character varying',
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => 'NULL::character varying',
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'slug',
+                ],
+                ['unique' => true]
+            )
+            ->create();
+
+        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
+        $table
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => '',
+                'limit' => 50,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id', 'name'])
+            ->create();
+
+        $table = $this->table('products');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'default' => 'NULL::character varying',
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => 'NULL::character varying',
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'slug',
+                ],
+                ['unique' => true]
+            )
+            ->addIndex(
+                [
+                    'category_id',
+                    'id',
+                ],
+                ['unique' => true]
+            )
+            ->addIndex(
+                [
+                    'category_id',
+                ]
+            )
+            ->create();
+
+        $table = $this->table('special_pks');
+        $table
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('name', 'string', [
+                'default' => 'NULL::character varying',
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->create();
+
+        $table = $this->table('special_tags');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('article_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addColumn('author_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
+            ->addColumn('tag_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addColumn('highlighted', 'boolean', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('highlighted_time', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'article_id',
+                ],
+                ['unique' => true]
+            )
+            ->create();
+
+        $table = $this->table('users');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('username', 'string', [
+                'default' => 'NULL::character varying',
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('password', 'string', [
+                'default' => 'NULL::character varying',
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('updated', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('articles')
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->addForeignKey(
+                'product_id',
+                'products',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->update();
+
+        $this->table('products')
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->update();
+
+    }
+
+    public function down()
+    {
+        $this->table('articles')
+            ->dropForeignKey(
+                'category_id'
+            )
+            ->dropForeignKey(
+                'product_id'
+            )
+            ->update();
+
+        $this->table('products')
+            ->dropForeignKey(
+                'category_id'
+            )
+            ->update();
+
+        $this->dropTable('articles');
+        $this->dropTable('categories');
+        $this->dropTable('composite_pks');
+        $this->dropTable('products');
+        $this->dropTable('special_pks');
+        $this->dropTable('special_tags');
+        $this->dropTable('users');
+    }
+}

--- a/tests/comparisons/Migration/pgsql/testCompositeConstraintsSnapshot.php
+++ b/tests/comparisons/Migration/pgsql/testCompositeConstraintsSnapshot.php
@@ -1,5 +1,5 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class CompositeConstraintsSnapshot extends AbstractMigration
 {

--- a/tests/comparisons/Migration/pgsql/testNotEmptySnapshot.php
+++ b/tests/comparisons/Migration/pgsql/testNotEmptySnapshot.php
@@ -1,5 +1,5 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class NotEmptySnapshot extends AbstractMigration
 {

--- a/tests/comparisons/Migration/sqlite/testAutoIdDisabledSnapshot.php
+++ b/tests/comparisons/Migration/sqlite/testAutoIdDisabledSnapshot.php
@@ -96,7 +96,7 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             )
             ->create();
 
-        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
+        $table = $this->table('composite_pks');
         $table
             ->addColumn('id', 'uuid', [
                 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',

--- a/tests/comparisons/Migration/sqlite/testAutoIdDisabledSnapshot.php
+++ b/tests/comparisons/Migration/sqlite/testAutoIdDisabledSnapshot.php
@@ -1,0 +1,316 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AutoIdDisabledSnapshot extends AbstractMigration
+{
+
+    public $autoId = false;
+
+    public function up()
+    {
+        $table = $this->table('articles');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'category_id',
+                ]
+            )
+            ->addIndex(
+                [
+                    'product_id',
+                ]
+            )
+            ->create();
+
+        $table = $this->table('categories');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('parent_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'slug',
+                ],
+                ['unique' => true]
+            )
+            ->create();
+
+        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
+        $table
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => '',
+                'limit' => 50,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id', 'name'])
+            ->create();
+
+        $table = $this->table('products');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'slug',
+                ],
+                ['unique' => true]
+            )
+            ->addIndex(
+                [
+                    'category_id',
+                    'id',
+                ],
+                ['unique' => true]
+            )
+            ->addIndex(
+                [
+                    'category_id',
+                ]
+            )
+            ->create();
+
+        $table = $this->table('special_pks');
+        $table
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->create();
+
+        $table = $this->table('special_tags');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('article_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addColumn('author_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('tag_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addColumn('highlighted', 'boolean', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('highlighted_time', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'article_id',
+                ],
+                ['unique' => true]
+            )
+            ->create();
+
+        $table = $this->table('users');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('username', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('password', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('updated', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('articles')
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->addForeignKey(
+                'product_id',
+                'products',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->update();
+
+        $this->table('products')
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->update();
+
+    }
+
+    public function down()
+    {
+        $this->table('articles')
+            ->dropForeignKey(
+                'category_id'
+            )
+            ->dropForeignKey(
+                'product_id'
+            )
+            ->update();
+
+        $this->table('products')
+            ->dropForeignKey(
+                'category_id'
+            )
+            ->update();
+
+        $this->dropTable('articles');
+        $this->dropTable('categories');
+        $this->dropTable('composite_pks');
+        $this->dropTable('products');
+        $this->dropTable('special_pks');
+        $this->dropTable('special_tags');
+        $this->dropTable('users');
+    }
+}

--- a/tests/comparisons/Migration/sqlite/testCompositeConstraintsSnapshot.php
+++ b/tests/comparisons/Migration/sqlite/testCompositeConstraintsSnapshot.php
@@ -1,5 +1,5 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class CompositeConstraintsSnapshot extends AbstractMigration
 {

--- a/tests/comparisons/Migration/sqlite/testNotEmptySnapshot.php
+++ b/tests/comparisons/Migration/sqlite/testNotEmptySnapshot.php
@@ -1,5 +1,5 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class NotEmptySnapshot extends AbstractMigration
 {

--- a/tests/comparisons/Migration/testAutoIdDisabledSnapshot.php
+++ b/tests/comparisons/Migration/testAutoIdDisabledSnapshot.php
@@ -97,7 +97,7 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             )
             ->create();
 
-        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
+        $table = $this->table('composite_pks');
         $table
             ->addColumn('id', 'uuid', [
                 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',

--- a/tests/comparisons/Migration/testAutoIdDisabledSnapshot.php
+++ b/tests/comparisons/Migration/testAutoIdDisabledSnapshot.php
@@ -1,0 +1,317 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AutoIdDisabledSnapshot extends AbstractMigration
+{
+
+    public $autoId = false;
+
+    public function up()
+    {
+        $table = $this->table('articles');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'comment' => 'Article title',
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'category_id',
+                ]
+            )
+            ->addIndex(
+                [
+                    'product_id',
+                ]
+            )
+            ->create();
+
+        $table = $this->table('categories');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('parent_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'slug',
+                ],
+                ['unique' => true]
+            )
+            ->create();
+
+        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
+        $table
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => '',
+                'limit' => 50,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id', 'name'])
+            ->create();
+
+        $table = $this->table('products');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'slug',
+                ],
+                ['unique' => true]
+            )
+            ->addIndex(
+                [
+                    'category_id',
+                    'id',
+                ],
+                ['unique' => true]
+            )
+            ->addIndex(
+                [
+                    'category_id',
+                ]
+            )
+            ->create();
+
+        $table = $this->table('special_pks');
+        $table
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->create();
+
+        $table = $this->table('special_tags');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('article_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addColumn('author_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('tag_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addColumn('highlighted', 'boolean', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('highlighted_time', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'article_id',
+                ],
+                ['unique' => true]
+            )
+            ->create();
+
+        $table = $this->table('users');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('username', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('password', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('updated', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('articles')
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->addForeignKey(
+                'product_id',
+                'products',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->update();
+
+        $this->table('products')
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->update();
+
+    }
+
+    public function down()
+    {
+        $this->table('articles')
+            ->dropForeignKey(
+                'category_id'
+            )
+            ->dropForeignKey(
+                'product_id'
+            )
+            ->update();
+
+        $this->table('products')
+            ->dropForeignKey(
+                'category_id'
+            )
+            ->update();
+
+        $this->dropTable('articles');
+        $this->dropTable('categories');
+        $this->dropTable('composite_pks');
+        $this->dropTable('products');
+        $this->dropTable('special_pks');
+        $this->dropTable('special_tags');
+        $this->dropTable('users');
+    }
+}

--- a/tests/comparisons/Migration/testCompositeConstraintsSnapshot.php
+++ b/tests/comparisons/Migration/testCompositeConstraintsSnapshot.php
@@ -1,5 +1,5 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class CompositeConstraintsSnapshot extends AbstractMigration
 {

--- a/tests/comparisons/Migration/testCreate.php
+++ b/tests/comparisons/Migration/testCreate.php
@@ -1,5 +1,5 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class CreateUsers extends AbstractMigration
 {

--- a/tests/comparisons/Migration/testCreateDatetime.php
+++ b/tests/comparisons/Migration/testCreateDatetime.php
@@ -1,5 +1,5 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class CreateUsers extends AbstractMigration
 {

--- a/tests/comparisons/Migration/testCreatePrimaryKey.php
+++ b/tests/comparisons/Migration/testCreatePrimaryKey.php
@@ -17,6 +17,7 @@ class CreateUsers extends AbstractMigration
     {
         $table = $this->table('users');
         $table->addColumn('id', 'integer', [
+            'autoIncrement' => true,
             'default' => null,
             'limit' => 11,
             'null' => false,

--- a/tests/comparisons/Migration/testCreatePrimaryKey.php
+++ b/tests/comparisons/Migration/testCreatePrimaryKey.php
@@ -1,0 +1,42 @@
+<?php
+use Migrations\AbstractMigration;
+
+class CreateUsers extends AbstractMigration
+{
+
+    public $autoId = false;
+
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('users');
+        $table->addColumn('id', 'integer', [
+            'default' => null,
+            'limit' => 11,
+            'null' => false,
+        ]);
+        $table->addColumn('name', 'string', [
+            'default' => null,
+            'limit' => 255,
+            'null' => false,
+        ]);
+        $table->addColumn('created', 'datetime', [
+            'default' => null,
+            'null' => false,
+        ]);
+        $table->addColumn('modified', 'datetime', [
+            'default' => null,
+            'null' => false,
+        ]);
+        $table->addPrimaryKey([
+            'id',
+        ]);
+        $table->create();
+    }
+}

--- a/tests/comparisons/Migration/testCreatePrimaryKeyUuid.php
+++ b/tests/comparisons/Migration/testCreatePrimaryKeyUuid.php
@@ -1,0 +1,41 @@
+<?php
+use Migrations\AbstractMigration;
+
+class CreateUsers extends AbstractMigration
+{
+
+    public $autoId = false;
+
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('users');
+        $table->addColumn('id', 'uuid', [
+            'default' => null,
+            'null' => false,
+        ]);
+        $table->addColumn('name', 'string', [
+            'default' => null,
+            'limit' => 255,
+            'null' => false,
+        ]);
+        $table->addColumn('created', 'datetime', [
+            'default' => null,
+            'null' => false,
+        ]);
+        $table->addColumn('modified', 'datetime', [
+            'default' => null,
+            'null' => false,
+        ]);
+        $table->addPrimaryKey([
+            'id',
+        ]);
+        $table->create();
+    }
+}

--- a/tests/comparisons/Migration/testNoContents.php
+++ b/tests/comparisons/Migration/testNoContents.php
@@ -1,5 +1,5 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class NoContents extends AbstractMigration
 {

--- a/tests/comparisons/Migration/testNotEmptySnapshot.php
+++ b/tests/comparisons/Migration/testNotEmptySnapshot.php
@@ -1,5 +1,5 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class NotEmptySnapshot extends AbstractMigration
 {

--- a/tests/test_app/config/Migrations/20150416223600_mark_migrated_test.php
+++ b/tests/test_app/config/Migrations/20150416223600_mark_migrated_test.php
@@ -1,5 +1,5 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class MarkMigratedTest extends AbstractMigration
 {

--- a/tests/test_app/config/TestsMigrations/20150704160200_create_numbers_table.php
+++ b/tests/test_app/config/TestsMigrations/20150704160200_create_numbers_table.php
@@ -1,5 +1,5 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class CreateNumbersTable extends AbstractMigration
 {

--- a/tests/test_app/config/TestsMigrations/20150724233100_update_numbers_table.php
+++ b/tests/test_app/config/TestsMigrations/20150724233100_update_numbers_table.php
@@ -1,5 +1,5 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\AbstractMigration;
 
 class UpdateNumbersTable extends AbstractMigration
 {

--- a/tests/test_app/config/TestsMigrations/20150826191400_create_letters_table.php
+++ b/tests/test_app/config/TestsMigrations/20150826191400_create_letters_table.php
@@ -1,0 +1,30 @@
+<?php
+use Migrations\AbstractMigration;
+
+class CreateLettersTable extends AbstractMigration
+{
+
+    public $autoId = false;
+
+    public function up()
+    {
+        $table = $this->table('letters');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('letter', 'string', [
+                'limit' => 1
+            ])
+            ->create();
+    }
+
+    public function down()
+    {
+        $this->dropTable('letters');
+    }
+}


### PR DESCRIPTION
This PR aims to provide a way to deal with how Phinx automatically creates an ``id`` field.
Currently, the only way to do so is to define, for each ``table()`` calls, this array of options :

```php
$table = $this->table('statuses',
    [
        'id' => false,
        'primary_key' => ['id']
    ]);
```

With these changes, a new ``AbstractMigration`` class has been added.
It can accept a ``autoId`` property that, when set to ``false``, will prevent Phinx from automatically create the ``id`` column.
When set, you will have to manually create the ``id`` column.
A new ``autoIncrement`` option has been added so columns can be defined as such (it really is just a "sugar" option, it can currently be done using the ``identity`` option but I find it not self-explanatory).

This file is a good example of how to use this :
https://github.com/HavokInspiration/migrations/blob/custom-migrations/tests/test_app/config/TestsMigrations/20150826191400_create_letters_table.php

I also added a ``disable-autoid`` boolean option to the ``MigrationSnashot`` bake command. By default, baking a snapshot will generate a file similar to the one currently baked (except for the parent ``AbstractMigration`` class).
With this option, it will set the ``autoId`` property to false and use the new methods implemented to bake the snapshot.

**Note that when ``autoId`` is set to ``true`` in a migration class file, you need to manually create the PK column for all tables in the migration class file.**

Potential use cases : 
- when only UUID are used as PK
- if you want to customize the column(s) of the PK (for example, if you need it to be unsigned)
- if you want your PK column to not be named id

I'm completely open to suggestion, this does not really "improve" the potential "cumbersome-factor" of calling 

```php
$table = $this->table('statuses',
    [
        'id' => false,
        'primary_key' => ['id']
    ]);
```

for each table since every PK column now need to be defined manually if ``autoId`` is set to ``false`` (well except for UUID since you already have to do this) but the resulting migrations files, are, in my opinion, much more readable this way.

Could resolve #9 since the issue seems to be around that.