### PR TITLE
Update the Migrate and Rollback commands with the new date option.

### DIFF
--- a/src/CakeManager.php
+++ b/src/CakeManager.php
@@ -72,6 +72,61 @@ class CakeManager extends Manager
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function migrateToDateTime($environment, \DateTime $dateTime)
+    {
+
+        $env = $this->getEnvironment($environment);
+        $versions = array_keys($this->getMigrations());
+        $dateString = $dateTime->format('Ymdhis');
+        $versionToMigrate = null;
+        foreach ($versions as $version) {
+            if ($dateString > $version) {
+                $versionToMigrate = $version;
+            }
+        }
+
+        if ($versionToMigrate === null) {
+            $this->getOutput()->writeln(
+                'No migrations to run'
+            );
+            return;
+        }
+
+        $this->getOutput()->writeln(
+            'Migrating to version ' . $versionToMigrate
+        );
+        return $this->migrate($environment, $versionToMigrate);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rollbackToDateTime($environment, \DateTime $dateTime)
+    {
+        $env = $this->getEnvironment($environment);
+        $versions = $env->getVersions();
+        $dateString = $dateTime->format('Ymdhis');
+        sort($versions);
+        $versions = array_reverse($versions);
+        $versionToRollback = null;
+        foreach ($versions as $version) {
+            if ($dateString > $version) {
+                $versionToRollback = $version;
+            }
+        }
+
+        if ($versionToRollback === null) {
+            $this->getOutput()->writeln('Rolling back all migrations');
+            return $this->rollback($environment, 0);
+        }
+
+        $this->getOutput()->writeln('Rolling back to version ' . $versionToRollback);
+        return $this->rollback($environment, $versionToRollback);
+    }
+
+    /**
      * Checks if the migration with version number $version as already been mark migrated
      *
      * @param int|string $version Version number of the migration to check

--- a/src/Command/Migrate.php
+++ b/src/Command/Migrate.php
@@ -33,8 +33,9 @@ class Migrate extends MigrateCommand
     {
         $this->setName('migrate')
             ->setDescription('Migrate the database')
-            ->addOption('--target', '-t', InputArgument::OPTIONAL, 'The version number to migrate to')
             ->setHelp('runs all available migrations, optionally up to a specific version')
+            ->addOption('--target', '-t', InputArgument::OPTIONAL, 'The version number to migrate to')
+            ->addOption('--date', '-d', InputArgument::OPTIONAL, 'The date to migrate to')
             ->addOption('--plugin', '-p', InputArgument::OPTIONAL, 'The plugin containing the migrations')
             ->addOption('--connection', '-c', InputArgument::OPTIONAL, 'The datasource connection to use')
             ->addOption('--source', '-s', InputArgument::OPTIONAL, 'The folder where migrations are in');
@@ -42,10 +43,10 @@ class Migrate extends MigrateCommand
 
     /**
      * Overrides the action execute method in order to vanish the idea of environments
-     * from phinx. CakePHP does not beleive in the idea of having in-app environments
+     * from phinx. CakePHP does not believe in the idea of having in-app environments
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input the input object
-     * @param \Symfony\Component\Console\Input\OutputInterface $output the output object
+     * @param \Symfony\Component\Console\Output\OutputInterface $output the output object
      * @return void
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Command/Rollback.php
+++ b/src/Command/Rollback.php
@@ -33,8 +33,9 @@ class Rollback extends RollbackCommand
     {
         $this->setName('rollback')
             ->setDescription('Rollback the last or to a specific migration')
-            ->addOption('--target', '-t', InputArgument::OPTIONAL, 'The version number to rollback to')
             ->setHelp('reverts the last migration, or optionally up to a specific version')
+            ->addOption('--target', '-t', InputArgument::OPTIONAL, 'The version number to rollback to')
+            ->addOption('--date', '-d', InputArgument::OPTIONAL, 'The date to migrate to')
             ->addOption('--plugin', '-p', InputArgument::OPTIONAL, 'The plugin containing the migrations')
             ->addOption('--connection', '-c', InputArgument::OPTIONAL, 'The datasource connection to use')
             ->addOption('--source', '-s', InputArgument::OPTIONAL, 'The folder where migrations are in');
@@ -42,10 +43,10 @@ class Rollback extends RollbackCommand
 
     /**
      * Overrides the action execute method in order to vanish the idea of environments
-     * from phinx. CakePHP does not beleive in the idea of having in-app environments
+     * from phinx. CakePHP does not believe in the idea of having in-app environments
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input the input object
-     * @param \Symfony\Component\Console\Input\OutputInterface $output the output object
+     * @param \Symfony\Component\Console\Output\OutputInterface $output the output object
      * @return void
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Command/Status.php
+++ b/src/Command/Status.php
@@ -40,7 +40,7 @@ class Status extends StatusCommand
      * Show the migration status.
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input the input object
-     * @param \Symfony\Component\Console\Input\OutputInterface $output the output object
+     * @param \Symfony\Component\Console\Output\OutputInterface $output the output object
      * @return void
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -96,15 +96,22 @@ class Migrations
      * - `connection` The datasource connection to use
      * - `source` The folder where migrations are in
      * - `plugin` The plugin containing the migrations
+     * - `date` The date to migrate to
      *
      * @return bool Success
      */
     public function migrate($options = [])
     {
         $input = $this->getInput('Migrate', [], $options);
-        $params = ['default', $input->getOption('target')];
+        $params = ['default'];
 
-        $this->run('migrate', $params, $input);
+        if ($input->getOption('date')) {
+            $params[] = new \DateTime($input->getOption('date'));
+            $this->run('migrateToDateTime', $params, $input);
+        } else {
+            $params[] = $input->getOption('target');
+            $this->run('migrate', $params, $input);
+        }
         return true;
     }
 
@@ -119,15 +126,23 @@ class Migrations
      * - `connection` The datasource connection to use
      * - `source` The folder where migrations are in
      * - `plugin` The plugin containing the migrations
+     * - `date` The date to rollback to
      *
      * @return bool Success
      */
     public function rollback($options = [])
     {
         $input = $this->getInput('Rollback', [], $options);
-        $params = ['default', $input->getOption('target')];
+        $params = ['default'];
 
-        $this->run('rollback', $params, $input);
+        if ($input->getOption('date')) {
+            $params[] = new \DateTime($input->getOption('date'));
+            $this->run('rollbackToDateTime', $params, $input);
+        } else {
+            $params[] = $input->getOption('target');
+            $this->run('rollback', $params, $input);
+        }
+
         return true;
     }
 

--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -35,7 +35,7 @@ class MigrationsShell extends Shell
      * This is required because CakePHP validates the passed options
      * and would complain if something not configured here is present
      *
-     * @return Cake\Console\ConsoleOptionParser
+     * @return \Cake\Console\ConsoleOptionParser
      */
     public function getOptionParser()
     {

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -103,7 +103,7 @@ class MigrationHelper extends Helper
      * Returns the Cake\Database\Schema\Table for $table
      *
      * @param string $table Name of the table to get the Schema for
-     * @return Cake\Database\Schema\Table
+     * @return \Cake\Database\Schema\Table
      */
     protected function schema($table)
     {


### PR DESCRIPTION
The date option was added in Phinx 0.4.5 release and allow migrations to be migrated or rollbacked by specifying a date rather than targeting a specific migration

I also updated the classes to use the ``EventDispatcherTrait`` rather than the deprecated ``EventManagerTrait``.

I also fixed some docblocks.

Closes #117 