### PR TITLE
Follow up on #118

### DIFF
--- a/src/CakeManager.php
+++ b/src/CakeManager.php
@@ -108,17 +108,24 @@ class CakeManager extends Manager
         $dateString = $dateTime->format('Ymdhis');
         sort($versions);
         $versions = array_reverse($versions);
-        $versionToRollback = null;
-        foreach ($versions as $version) {
-            if ($dateString > $version) {
-                $versionToRollback = $version;
-            }
+
+        if ($dateString > $versions[0]) {
+            $this->getOutput()->writeln('No migrations to rollback');
+            return;
         }
 
-        if ($versionToRollback === null) {
+        if ($dateString < end($versions)) {
             $this->getOutput()->writeln('Rolling back all migrations');
             return $this->rollback($environment, 0);
         }
+
+        foreach ($versions as $index => $version) {
+            if ($dateString > $version) {
+                break;
+            }
+        }
+
+        $versionToRollback = $versions[$index];
 
         $this->getOutput()->writeln('Rolling back to version ' . $versionToRollback);
         return $this->rollback($environment, $versionToRollback);

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -103,15 +103,15 @@ class Migrations
     public function migrate($options = [])
     {
         $input = $this->getInput('Migrate', [], $options);
-        $params = ['default'];
+        $method = 'migrate';
+        $params = ['default', $input->getOption('target')];
 
         if ($input->getOption('date')) {
-            $params[] = new \DateTime($input->getOption('date'));
-            $this->run('migrateToDateTime', $params, $input);
-        } else {
-            $params[] = $input->getOption('target');
-            $this->run('migrate', $params, $input);
+            $method = 'migrateToDateTime';
+            $params[1] = new \DateTime($input->getOption('date'));
         }
+
+        $this->run($method, $params, $input);
         return true;
     }
 
@@ -133,16 +133,15 @@ class Migrations
     public function rollback($options = [])
     {
         $input = $this->getInput('Rollback', [], $options);
-        $params = ['default'];
+        $method = 'rollback';
+        $params = ['default', $input->getOption('target')];
 
         if ($input->getOption('date')) {
-            $params[] = new \DateTime($input->getOption('date'));
-            $this->run('rollbackToDateTime', $params, $input);
-        } else {
-            $params[] = $input->getOption('target');
-            $this->run('rollback', $params, $input);
+            $method = 'rollbackToDateTime';
+            $params[1] = new \DateTime($input->getOption('date'));
         }
 
+        $this->run($method, $params, $input);
         return true;
     }
 

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -46,6 +46,8 @@ class MarkMigratedTest extends TestCase
      */
     protected $Connection;
 
+    protected $commandTester;
+
     /**
      * setup method
      *
@@ -56,39 +58,12 @@ class MarkMigratedTest extends TestCase
         parent::setUp();
 
         $this->Connection = ConnectionManager::get('test');
-        $connectionConfig = $this->Connection->config();
         $this->Connection->execute('DROP TABLE IF EXISTS phinxlog');
-
-        $this->config = new Config([
-            'paths' => [
-                'migrations' => __FILE__,
-            ],
-            'environments' => [
-                'default_migration_table' => 'phinxlog',
-                'default_database' => 'cakephp_test',
-                'default' => [
-                    'adapter' => getenv('DB'),
-                    'host' => '127.0.0.1',
-                    'name' => !empty($connectionConfig['database']) ? $connectionConfig['database'] : '',
-                    'user' => !empty($connectionConfig['username']) ? $connectionConfig['username'] : '',
-                    'pass' => !empty($connectionConfig['password']) ? $connectionConfig['password'] : ''
-                ]
-            ]
-        ]);
+        $this->Connection->execute('DROP TABLE IF EXISTS numbers');
 
         $application = new MigrationsDispatcher('testing');
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
         $this->command = $application->find('mark_migrated');
-
-        $Environment = new Environment('default', $this->config['environments']['default']);
-
-        $Manager = $this->getMock('\Phinx\Migration\Manager', [], [$this->config, $output]);
-        $Manager->expects($this->any())
-            ->method('getEnvironment')
-            ->will($this->returnValue($Environment));
-
-        $this->command->setManager($Manager);
+        $this->commandTester = new CommandTester($this->command);
     }
 
     /**
@@ -99,7 +74,9 @@ class MarkMigratedTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        unset($this->Connection, $this->config, $this->command);
+        $this->Connection->execute('DROP TABLE IF EXISTS phinxlog');
+        $this->Connection->execute('DROP TABLE IF EXISTS numbers');
+        unset($this->Connection, $this->commandTester, $this->command);
     }
 
     /**
@@ -109,8 +86,7 @@ class MarkMigratedTest extends TestCase
      */
     public function testExecuteNoFile()
     {
-        $commandTester = new CommandTester($this->command);
-        $commandTester->execute([
+        $this->commandTester->execute([
             'command' => $this->command->getName(),
             'version' => '2000000',
             '--connection' => 'test'
@@ -118,7 +94,7 @@ class MarkMigratedTest extends TestCase
 
         $this->assertContains(
             'A migration file matching version number `2000000` could not be found',
-            $commandTester->getDisplay()
+            $this->commandTester->getDisplay()
         );
         $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->fetch('assoc');
         $this->assertFalse($result);
@@ -131,19 +107,18 @@ class MarkMigratedTest extends TestCase
      */
     public function testExecute()
     {
-        $commandTester = new CommandTester($this->command);
-        $commandTester->execute([
+        $this->commandTester->execute([
             'command' => $this->command->getName(),
             'version' => '20150416223600',
             '--connection' => 'test'
         ]);
 
-        $this->assertContains('Migration successfully marked migrated !', $commandTester->getDisplay());
+        $this->assertContains('Migration successfully marked migrated !', $this->commandTester->getDisplay());
 
         $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->fetch('assoc');
         $this->assertEquals('20150416223600', $result['version']);
 
-        $commandTester->execute([
+        $this->commandTester->execute([
             'command' => $this->command->getName(),
             'version' => '20150416223600',
             '--connection' => 'test'
@@ -151,7 +126,7 @@ class MarkMigratedTest extends TestCase
 
         $this->assertContains(
             'The migration with version number `20150416223600` has already been marked as migrated.',
-            $commandTester->getDisplay()
+            $this->commandTester->getDisplay()
         );
         $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->count();
         $this->assertEquals(1, $result);

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -14,10 +14,7 @@ namespace Migrations\Test\Command;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Migrations\MigrationsDispatcher;
-use Phinx\Migration\Manager\Environment;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Console\Output\StreamOutput;
-use Phinx\Config\Config;
 
 /**
  * MarkMigratedTest class
@@ -46,6 +43,11 @@ class MarkMigratedTest extends TestCase
      */
     protected $Connection;
 
+    /**
+     * Instance of a CommandTester object
+     *
+     * @var \Symfony\Component\Console\Tester\CommandTester
+     */
     protected $commandTester;
 
     /**

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -308,6 +308,25 @@ class MigrationsTest extends TestCase
         ];
         $this->assertEquals($expectedStatus, $this->migrations->status());
 
+        // If we want to rollback to a date after the last migrations,
+        // nothing should be rollbacked
+        $this->migrations->rollback([
+            'date' => '20150730'
+        ]);
+        $expectedStatus = [
+            [
+                'status' => 'up',
+                'id' => '20150704160200',
+                'name' => 'CreateNumbersTable'
+            ],
+            [
+                'status' => 'up',
+                'id' => '20150724233100',
+                'name' => 'UpdateNumbersTable'
+            ]
+        ];
+        $this->assertEquals($expectedStatus, $this->migrations->status());
+
         // If we want to rollback to a date between two migrations date,
         // only migrations file having a date AFTER the date should be rollbacked
         $this->migrations->rollback(['date' => '20150705']);


### PR DESCRIPTION
This is a follow up PR for #118.

- I rewrote the way the Migrations class chooses which method of the Manager to run.
- I rewrote the ``CakeManager::rollbackToDateTime()`` method to cover a case that was not (if you want to rollback to a date that is after the last migrations date, nothing should be rollbacked).

The changes of the MarkMigratedTest are not linked to #118 but I changed a few things.