### PR TITLE
Update the tests so they pass again following the release of phinx 0.4.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "robmorgan/phinx": ">=0.4.2 <1.0",
+        "robmorgan/phinx": "dev-master",
         "cakephp/cakephp": "~3.0"
     },
     "require-dev": {

--- a/src/CakeAdapter.php
+++ b/src/CakeAdapter.php
@@ -56,6 +56,16 @@ class CakeAdapter implements AdapterInterface
     }
 
     /**
+     * Gets the database connection
+     *
+     * @return \PDO
+     */
+    public function getConnection()
+    {
+        return $this->adapter->getConnection();
+    }
+
+    /**
      * Get all migrated version numbers.
      *
      * @return array
@@ -127,6 +137,60 @@ class CakeAdapter implements AdapterInterface
     public function getOutput()
     {
         return $this->adapter->getOutput();
+    }
+
+    /**
+     * Sets the command start time
+     *
+     * @param int $time
+     * @return AdapterInterface
+     */
+    public function setCommandStartTime($time)
+    {
+        return $this->adapter->setCommandStartTime($time);
+    }
+
+    /**
+     * Gets the command start time
+     *
+     * @return int
+     */
+    public function getCommandStartTime()
+    {
+        return $this->adapter->getCommandStartTime();
+    }
+
+    /**
+     * Start timing a command.
+     *
+     * @return void
+     */
+    public function startCommandTimer()
+    {
+        $this->adapter->startCommandTimer();
+    }
+
+    /**
+     * Stop timing the current command and write the elapsed time to the
+     * output.
+     *
+     * @return void
+     */
+    public function endCommandTimer()
+    {
+        $this->adapter->endCommandTimer();
+    }
+
+    /**
+     * Write a Phinx command to the output.
+     *
+     * @param string $command Command Name
+     * @param array  $args    Command Args
+     * @return void
+     */
+    public function writeCommand($command, $args = array())
+    {
+        $this->adapter->writeCommand($command, $args);
     }
 
     /**
@@ -506,6 +570,9 @@ class CakeAdapter implements AdapterInterface
 
     /**
      * Drops the specified foreign key from a database table.
+     * If the adapter property is an instance of the \Phinx\Db\Adapter\SQLiteAdapter,
+     * a specific method will be called. The original one from Phinx contains a bug
+     * that can drop a table in certain conditions.
      *
      * @param string   $tableName
      * @param string[] $columns    Column(s)
@@ -557,7 +624,7 @@ class CakeAdapter implements AdapterInterface
      * @param array $options Options
      * @return void
      */
-    public function createDatabase($name, $options = array())
+    public function createDatabase($name, $options = [])
     {
         return $this->adapter->createDatabase($name, $options);
     }

--- a/src/Table.php
+++ b/src/Table.php
@@ -80,7 +80,7 @@ class Table extends BaseTable
      */
     protected function filterPrimaryKey()
     {
-        if (!($this->getAdapter() instanceof SQLiteAdapter) || empty($this->options['primary_key'])) {
+        if ($this->getAdapter()->getAdapterType() !== 'sqlite' || empty($this->options['primary_key'])) {
             return;
         }
 

--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -151,14 +151,15 @@ class <%= $name %> extends AbstractMigration
 
     public function down()
     {
-        <%- foreach ($dropForeignKeys as $table => $columnsList): %>
+        <%- foreach ($dropForeignKeys as $table => $columnsList):
+                $maxKey = count($columnsList) - 1;
+        %>
         $this->table('<%= $table %>')
-            <%- foreach ($columnsList as $columns): %>
+            <%- foreach ($columnsList as $key => $columns): %>
             ->dropForeignKey(
                 <%= $columns %>
-            )
+            )<%= ($key === $maxKey) ? ';' : '' %>
             <%- endforeach; %>
-            ->update();
 
         <%- endforeach; %>
         <%- foreach ($tables as $table): %>

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -116,6 +116,13 @@ class MigrationsTest extends TestCase
             ]
         ];
         $this->assertEquals($expected, $result);
+
+        $adapter = $this->migrations
+            ->getManager()
+            ->getEnvironment('default')
+            ->getAdapter();
+
+        $this->assertInstanceOf('\Migrations\CakeAdapter', $adapter);
     }
 
     /**

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -430,16 +430,16 @@ class MigrationsTest extends TestCase
     public function testMigrateSnapshots($basePath, $files)
     {
         $destination = ROOT . 'config' . DS . 'SnapshotTests' . DS;
-        $timestamp = Util::getCurrentTimestamp();
 
         if (!file_exists($destination)) {
             mkdir($destination);
         }
 
         foreach ($files as $file) {
-            $copiedFileName = $timestamp . '_' . $file . '.php';
+            list($filename, $timestamp) = $file;
+            $copiedFileName = $timestamp . '_' . $filename . '.php';
             copy(
-                $basePath . $file . '.php',
+                $basePath . $filename . '.php',
                 $destination . $copiedFileName
             );
 
@@ -462,21 +462,30 @@ class MigrationsTest extends TestCase
             [
                 Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS,
                 [
-                    'testCompositeConstraintsSnapshot',
-                    'testNotEmptySnapshot',
-                    'testAutoIdDisabledSnapshot',
-                    'testCreatePrimaryKey',
-                    'testCreatePrimaryKeyUuid'
+                    ['test_composite_constraints_snapshot', 20150912015600],
+                    ['test_not_empty_snapshot', 20150912015601],
+                    ['test_auto_id_disabled_snapshot', 20150912015602],
+                    ['testCreatePrimaryKey', 20150912015603],
+                    ['testCreatePrimaryKeyUuid', 20150912015604]
                 ]
             ],
             [
-                Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS . 'sqlite' . DS,
-                ['testCompositeConstraintsSnapshot', 'testNotEmptySnapshot', 'testAutoIdDisabledSnapshot']
-            ],
-            [
                 Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS . 'pgsql' . DS,
-                ['testCompositeConstraintsSnapshot', 'testNotEmptySnapshot', 'testAutoIdDisabledSnapshot']
+                [
+                    ['test_composite_constraints_snapshot_pgsql', 20150912015605],
+                    ['test_not_empty_snapshot_pgsql', 20150912015606],
+                    ['test_auto_id_disabled_snapshot_pgsql', 20150912015607]
+                ]
             ]
+            ,
+            [
+                Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS . 'sqlite' . DS,
+                [
+                    ['test_composite_constraints_snapshot_sqlite', 20150912015608],
+                    ['test_not_empty_snapshot_sqlite', 20150912015609],
+                    ['test_auto_id_disabled_snapshot_sqlite', 20150912015610]
+                ]
+            ],
         ];
     }
 }

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -16,6 +16,7 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\StringCompareTrait;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Inflector;
 
 /**
  * MigrationSnapshotTaskTest class
@@ -85,9 +86,10 @@ class MigrationSnapshotTaskTest extends TestCase
                 )
             );
 
-        $result = $this->Task->bake('NotEmptySnapshot');
+        $bakeName = $this->getBakeName('TestNotEmptySnapshot');
+        $result = $this->Task->bake($bakeName);
 
-        $this->assertCorrectSnapshot(__FUNCTION__, $result);
+        $this->assertCorrectSnapshot($bakeName, $result);
     }
 
     public function testAutoIdDisabledSnapshot()
@@ -97,9 +99,10 @@ class MigrationSnapshotTaskTest extends TestCase
         $this->Task->params['connection'] = 'test';
         $this->Task->params['plugin'] = 'BogusPlugin';
 
-        $result = $this->Task->bake('AutoIdDisabledSnapshot');
+        $bakeName = $this->getBakeName('TestAutoIdDisabledSnapshot');
+        $result = $this->Task->bake($bakeName);
 
-        $this->assertCorrectSnapshot(__FUNCTION__, $result);
+        $this->assertCorrectSnapshot($bakeName, $result);
     }
 
     public function testCompositeConstraintsSnapshot()
@@ -116,18 +119,31 @@ class MigrationSnapshotTaskTest extends TestCase
 
         $this->Task->params['require-table'] = false;
         $this->Task->params['connection'] = 'test';
-        $result = $this->Task->bake('CompositeConstraintsSnapshot');
 
-        $this->assertCorrectSnapshot(__FUNCTION__, $result);
+        $bakeName = $this->getBakeName('TestCompositeConstraintsSnapshot');
+        $result = $this->Task->bake($bakeName);
+
+        $this->assertCorrectSnapshot($bakeName, $result);
     }
 
-    public function assertCorrectSnapshot($function, $result)
+    public function getBakeName($name)
     {
         $dbenv = getenv("DB");
-        if (file_exists($this->_compareBasePath . $dbenv . DS . $function . '.php')) {
-            $this->assertSameAsFile($dbenv . DS . $function . '.php', $result);
+        if ($dbenv !== 'mysql') {
+            $name .= ucfirst($dbenv);
+        }
+
+        return $name;
+    }
+
+    public function assertCorrectSnapshot($bakeName, $result)
+    {
+        $dbenv = getenv("DB");
+        $bakeName = Inflector::underscore($bakeName);
+        if (file_exists($this->_compareBasePath . $dbenv . DS . $bakeName . '.php')) {
+            $this->assertSameAsFile($dbenv . DS . $bakeName . '.php', $result);
         } else {
-            $this->assertSameAsFile($function . '.php', $result);
+            $this->assertSameAsFile($bakeName . '.php', $result);
         }
     }
 }

--- a/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
@@ -1,25 +1,36 @@
 <?php
 use Migrations\AbstractMigration;
 
-class CompositeConstraintsSnapshot extends AbstractMigration
+class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
 {
+
+    public $autoId = false;
+
     public function up()
     {
         $table = $this->table('articles');
         $table
-            ->addColumn('title', 'string', [
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
                 'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'comment' => 'Article title',
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -46,18 +57,25 @@ class CompositeConstraintsSnapshot extends AbstractMigration
 
         $table = $this->table('categories');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('title', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
@@ -79,7 +97,7 @@ class CompositeConstraintsSnapshot extends AbstractMigration
             )
             ->create();
 
-        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
+        $table = $this->table('composite_pks');
         $table
             ->addColumn('id', 'uuid', [
                 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
@@ -91,43 +109,31 @@ class CompositeConstraintsSnapshot extends AbstractMigration
                 'limit' => 50,
                 'null' => false,
             ])
-            ->create();
-
-        $table = $this->table('orders');
-        $table
-            ->addColumn('product_category', 'integer', [
-                'default' => null,
-                'limit' => 11,
-                'null' => false,
-            ])
-            ->addColumn('product_id', 'integer', [
-                'default' => null,
-                'limit' => 11,
-                'null' => false,
-            ])
-            ->addIndex(
-                [
-                    'product_category',
-                    'product_id',
-                ]
-            )
+            ->addPrimaryKey(['id', 'name'])
             ->create();
 
         $table = $this->table('products');
         $table
-            ->addColumn('title', 'string', [
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
                 'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -160,15 +166,16 @@ class CompositeConstraintsSnapshot extends AbstractMigration
             )
             ->create();
 
-        $table = $this->table('special_pks', ['id' => false, 'primary_key' => ['id']]);
+        $table = $this->table('special_pks');
         $table
             ->addColumn('id', 'uuid', [
                 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
                 'limit' => null,
                 'null' => false,
             ])
+            ->addPrimaryKey(['id'])
             ->addColumn('name', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 256,
                 'null' => true,
             ])
@@ -176,19 +183,26 @@ class CompositeConstraintsSnapshot extends AbstractMigration
 
         $table = $this->table('special_tags');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('article_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => false,
             ])
             ->addColumn('author_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('tag_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => false,
             ])
             ->addColumn('highlighted', 'boolean', [
@@ -211,13 +225,20 @@ class CompositeConstraintsSnapshot extends AbstractMigration
 
         $table = $this->table('users');
         $table
-            ->addColumn('username', 'string', [
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
                 'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('username', 'string', [
+                'default' => 'NULL::character varying',
                 'limit' => 256,
                 'null' => true,
             ])
             ->addColumn('password', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 256,
                 'null' => true,
             ])
@@ -254,24 +275,6 @@ class CompositeConstraintsSnapshot extends AbstractMigration
             )
             ->update();
 
-        $this->table('orders')
-            ->addForeignKey(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                'products',
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
-                ]
-            )
-            ->update();
-
         $this->table('products')
             ->addForeignKey(
                 'category_id',
@@ -294,28 +297,16 @@ class CompositeConstraintsSnapshot extends AbstractMigration
             )
             ->dropForeignKey(
                 'product_id'
-            )
-            ->update();
-
-        $this->table('orders')
-            ->dropForeignKey(
-                [
-                    'product_category',
-                    'product_id',
-                ]
-            )
-            ->update();
+            );
 
         $this->table('products')
             ->dropForeignKey(
                 'category_id'
-            )
-            ->update();
+            );
 
         $this->dropTable('articles');
         $this->dropTable('categories');
         $this->dropTable('composite_pks');
-        $this->dropTable('orders');
         $this->dropTable('products');
         $this->dropTable('special_pks');
         $this->dropTable('special_tags');

--- a/tests/comparisons/Migration/pgsql/test_composite_constraints_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_composite_constraints_snapshot_pgsql.php
@@ -1,36 +1,26 @@
 <?php
 use Migrations\AbstractMigration;
 
-class AutoIdDisabledSnapshot extends AbstractMigration
+class TestCompositeConstraintsSnapshotPgsql extends AbstractMigration
 {
-
-    public $autoId = false;
-
     public function up()
     {
         $table = $this->table('articles');
         $table
-            ->addColumn('id', 'integer', [
-                'autoIncrement' => true,
-                'default' => null,
-                'limit' => 11,
-                'null' => false,
-            ])
-            ->addPrimaryKey(['id'])
             ->addColumn('title', 'string', [
                 'comment' => 'Article title',
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -57,25 +47,18 @@ class AutoIdDisabledSnapshot extends AbstractMigration
 
         $table = $this->table('categories');
         $table
-            ->addColumn('id', 'integer', [
-                'autoIncrement' => true,
-                'default' => null,
-                'limit' => 11,
-                'null' => false,
-            ])
-            ->addPrimaryKey(['id'])
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('title', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
@@ -97,7 +80,7 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             )
             ->create();
 
-        $table = $this->table('composite_pks');
+        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
         $table
             ->addColumn('id', 'uuid', [
                 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
@@ -109,31 +92,43 @@ class AutoIdDisabledSnapshot extends AbstractMigration
                 'limit' => 50,
                 'null' => false,
             ])
-            ->addPrimaryKey(['id', 'name'])
+            ->create();
+
+        $table = $this->table('orders');
+        $table
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addIndex(
+                [
+                    'product_category',
+                    'product_id',
+                ]
+            )
             ->create();
 
         $table = $this->table('products');
         $table
-            ->addColumn('id', 'integer', [
-                'autoIncrement' => true,
-                'default' => null,
-                'limit' => 11,
-                'null' => false,
-            ])
-            ->addPrimaryKey(['id'])
             ->addColumn('title', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -166,16 +161,15 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             )
             ->create();
 
-        $table = $this->table('special_pks');
+        $table = $this->table('special_pks', ['id' => false, 'primary_key' => ['id']]);
         $table
             ->addColumn('id', 'uuid', [
                 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
                 'limit' => null,
                 'null' => false,
             ])
-            ->addPrimaryKey(['id'])
             ->addColumn('name', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 256,
                 'null' => true,
             ])
@@ -183,26 +177,19 @@ class AutoIdDisabledSnapshot extends AbstractMigration
 
         $table = $this->table('special_tags');
         $table
-            ->addColumn('id', 'integer', [
-                'autoIncrement' => true,
-                'default' => null,
-                'limit' => 11,
-                'null' => false,
-            ])
-            ->addPrimaryKey(['id'])
             ->addColumn('article_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => false,
             ])
             ->addColumn('author_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('tag_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => false,
             ])
             ->addColumn('highlighted', 'boolean', [
@@ -225,20 +212,13 @@ class AutoIdDisabledSnapshot extends AbstractMigration
 
         $table = $this->table('users');
         $table
-            ->addColumn('id', 'integer', [
-                'autoIncrement' => true,
-                'default' => null,
-                'limit' => 11,
-                'null' => false,
-            ])
-            ->addPrimaryKey(['id'])
             ->addColumn('username', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 256,
                 'null' => true,
             ])
             ->addColumn('password', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 256,
                 'null' => true,
             ])
@@ -275,6 +255,24 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             )
             ->update();
 
+        $this->table('orders')
+            ->addForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ],
+                'products',
+                [
+                    'category_id',
+                    'id',
+                ],
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->update();
+
         $this->table('products')
             ->addForeignKey(
                 'category_id',
@@ -297,18 +295,25 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             )
             ->dropForeignKey(
                 'product_id'
-            )
-            ->update();
+            );
+
+        $this->table('orders')
+            ->dropForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ]
+            );
 
         $this->table('products')
             ->dropForeignKey(
                 'category_id'
-            )
-            ->update();
+            );
 
         $this->dropTable('articles');
         $this->dropTable('categories');
         $this->dropTable('composite_pks');
+        $this->dropTable('orders');
         $this->dropTable('products');
         $this->dropTable('special_pks');
         $this->dropTable('special_tags');

--- a/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
@@ -1,7 +1,7 @@
 <?php
 use Migrations\AbstractMigration;
 
-class CompositeConstraintsSnapshot extends AbstractMigration
+class TestNotEmptySnapshotPgsql extends AbstractMigration
 {
     public function up()
     {
@@ -9,18 +9,18 @@ class CompositeConstraintsSnapshot extends AbstractMigration
         $table
             ->addColumn('title', 'string', [
                 'comment' => 'Article title',
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -49,16 +49,16 @@ class CompositeConstraintsSnapshot extends AbstractMigration
         $table
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('title', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
@@ -94,41 +94,21 @@ class CompositeConstraintsSnapshot extends AbstractMigration
             ])
             ->create();
 
-        $table = $this->table('orders');
-        $table
-            ->addColumn('product_category', 'integer', [
-                'default' => null,
-                'limit' => 11,
-                'null' => false,
-            ])
-            ->addColumn('product_id', 'integer', [
-                'default' => null,
-                'limit' => 11,
-                'null' => false,
-            ])
-            ->addIndex(
-                [
-                    'product_category',
-                    'product_id',
-                ]
-            )
-            ->create();
-
         $table = $this->table('products');
         $table
             ->addColumn('title', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -169,7 +149,7 @@ class CompositeConstraintsSnapshot extends AbstractMigration
                 'null' => false,
             ])
             ->addColumn('name', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 256,
                 'null' => true,
             ])
@@ -179,17 +159,17 @@ class CompositeConstraintsSnapshot extends AbstractMigration
         $table
             ->addColumn('article_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => false,
             ])
             ->addColumn('author_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => true,
             ])
             ->addColumn('tag_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => false,
             ])
             ->addColumn('highlighted', 'boolean', [
@@ -213,12 +193,12 @@ class CompositeConstraintsSnapshot extends AbstractMigration
         $table = $this->table('users');
         $table
             ->addColumn('username', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 256,
                 'null' => true,
             ])
             ->addColumn('password', 'string', [
-                'default' => null,
+                'default' => 'NULL::character varying',
                 'limit' => 256,
                 'null' => true,
             ])
@@ -255,24 +235,6 @@ class CompositeConstraintsSnapshot extends AbstractMigration
             )
             ->update();
 
-        $this->table('orders')
-            ->addForeignKey(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                'products',
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
-                ]
-            )
-            ->update();
-
         $this->table('products')
             ->addForeignKey(
                 'category_id',
@@ -295,28 +257,16 @@ class CompositeConstraintsSnapshot extends AbstractMigration
             )
             ->dropForeignKey(
                 'product_id'
-            )
-            ->update();
-
-        $this->table('orders')
-            ->dropForeignKey(
-                [
-                    'product_category',
-                    'product_id',
-                ]
-            )
-            ->update();
+            );
 
         $this->table('products')
             ->dropForeignKey(
                 'category_id'
-            )
-            ->update();
+            );
 
         $this->dropTable('articles');
         $this->dropTable('categories');
         $this->dropTable('composite_pks');
-        $this->dropTable('orders');
         $this->dropTable('products');
         $this->dropTable('special_pks');
         $this->dropTable('special_tags');

--- a/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
@@ -1,7 +1,7 @@
 <?php
 use Migrations\AbstractMigration;
 
-class AutoIdDisabledSnapshot extends AbstractMigration
+class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
 {
 
     public $autoId = false;
@@ -13,24 +13,23 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
                 'default' => null,
-                'limit' => 10,
+                'limit' => null,
                 'null' => false,
             ])
             ->addPrimaryKey(['id'])
             ->addColumn('title', 'string', [
-                'comment' => 'Article title',
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -60,22 +59,22 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
                 'default' => null,
-                'limit' => 10,
+                'limit' => null,
                 'null' => false,
             ])
             ->addPrimaryKey(['id'])
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('title', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
@@ -117,23 +116,23 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
                 'default' => null,
-                'limit' => 10,
+                'limit' => null,
                 'null' => false,
             ])
             ->addPrimaryKey(['id'])
             ->addColumn('title', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -175,7 +174,7 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             ])
             ->addPrimaryKey(['id'])
             ->addColumn('name', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])
@@ -186,23 +185,23 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
                 'default' => null,
-                'limit' => 10,
+                'limit' => null,
                 'null' => false,
             ])
             ->addPrimaryKey(['id'])
             ->addColumn('article_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('author_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('tag_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('highlighted', 'boolean', [
@@ -228,17 +227,17 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
                 'default' => null,
-                'limit' => 10,
+                'limit' => null,
                 'null' => false,
             ])
             ->addPrimaryKey(['id'])
             ->addColumn('username', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])
             ->addColumn('password', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])
@@ -297,14 +296,12 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             )
             ->dropForeignKey(
                 'product_id'
-            )
-            ->update();
+            );
 
         $this->table('products')
             ->dropForeignKey(
                 'category_id'
-            )
-            ->update();
+            );
 
         $this->dropTable('articles');
         $this->dropTable('categories');

--- a/tests/comparisons/Migration/sqlite/test_composite_constraints_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_composite_constraints_snapshot_sqlite.php
@@ -1,22 +1,12 @@
 <?php
 use Migrations\AbstractMigration;
 
-class AutoIdDisabledSnapshot extends AbstractMigration
+class TestCompositeConstraintsSnapshotSqlite extends AbstractMigration
 {
-
-    public $autoId = false;
-
     public function up()
     {
         $table = $this->table('articles');
         $table
-            ->addColumn('id', 'integer', [
-                'autoIncrement' => true,
-                'default' => null,
-                'limit' => null,
-                'null' => false,
-            ])
-            ->addPrimaryKey(['id'])
             ->addColumn('title', 'string', [
                 'default' => null,
                 'limit' => 255,
@@ -56,13 +46,6 @@ class AutoIdDisabledSnapshot extends AbstractMigration
 
         $table = $this->table('categories');
         $table
-            ->addColumn('id', 'integer', [
-                'autoIncrement' => true,
-                'default' => null,
-                'limit' => null,
-                'null' => false,
-            ])
-            ->addPrimaryKey(['id'])
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
                 'limit' => 11,
@@ -96,7 +79,7 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             )
             ->create();
 
-        $table = $this->table('composite_pks');
+        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
         $table
             ->addColumn('id', 'uuid', [
                 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
@@ -108,18 +91,30 @@ class AutoIdDisabledSnapshot extends AbstractMigration
                 'limit' => 50,
                 'null' => false,
             ])
-            ->addPrimaryKey(['id', 'name'])
+            ->create();
+
+        $table = $this->table('orders');
+        $table
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addIndex(
+                [
+                    'product_category',
+                    'product_id',
+                ]
+            )
             ->create();
 
         $table = $this->table('products');
         $table
-            ->addColumn('id', 'integer', [
-                'autoIncrement' => true,
-                'default' => null,
-                'limit' => null,
-                'null' => false,
-            ])
-            ->addPrimaryKey(['id'])
             ->addColumn('title', 'string', [
                 'default' => null,
                 'limit' => 255,
@@ -165,14 +160,13 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             )
             ->create();
 
-        $table = $this->table('special_pks');
+        $table = $this->table('special_pks', ['id' => false, 'primary_key' => ['id']]);
         $table
             ->addColumn('id', 'uuid', [
                 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
                 'limit' => null,
                 'null' => false,
             ])
-            ->addPrimaryKey(['id'])
             ->addColumn('name', 'string', [
                 'default' => null,
                 'limit' => 256,
@@ -182,13 +176,6 @@ class AutoIdDisabledSnapshot extends AbstractMigration
 
         $table = $this->table('special_tags');
         $table
-            ->addColumn('id', 'integer', [
-                'autoIncrement' => true,
-                'default' => null,
-                'limit' => null,
-                'null' => false,
-            ])
-            ->addPrimaryKey(['id'])
             ->addColumn('article_id', 'integer', [
                 'default' => null,
                 'limit' => 11,
@@ -224,13 +211,6 @@ class AutoIdDisabledSnapshot extends AbstractMigration
 
         $table = $this->table('users');
         $table
-            ->addColumn('id', 'integer', [
-                'autoIncrement' => true,
-                'default' => null,
-                'limit' => null,
-                'null' => false,
-            ])
-            ->addPrimaryKey(['id'])
             ->addColumn('username', 'string', [
                 'default' => null,
                 'limit' => 256,
@@ -274,6 +254,24 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             )
             ->update();
 
+        $this->table('orders')
+            ->addForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ],
+                'products',
+                [
+                    'category_id',
+                    'id',
+                ],
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->update();
+
         $this->table('products')
             ->addForeignKey(
                 'category_id',
@@ -296,18 +294,25 @@ class AutoIdDisabledSnapshot extends AbstractMigration
             )
             ->dropForeignKey(
                 'product_id'
-            )
-            ->update();
+            );
+
+        $this->table('orders')
+            ->dropForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ]
+            );
 
         $this->table('products')
             ->dropForeignKey(
                 'category_id'
-            )
-            ->update();
+            );
 
         $this->dropTable('articles');
         $this->dropTable('categories');
         $this->dropTable('composite_pks');
+        $this->dropTable('orders');
         $this->dropTable('products');
         $this->dropTable('special_pks');
         $this->dropTable('special_tags');

--- a/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
@@ -1,14 +1,13 @@
 <?php
 use Migrations\AbstractMigration;
 
-class NotEmptySnapshot extends AbstractMigration
+class TestNotEmptySnapshotSqlite extends AbstractMigration
 {
     public function up()
     {
         $table = $this->table('articles');
         $table
             ->addColumn('title', 'string', [
-                'comment' => 'Article title',
                 'default' => null,
                 'limit' => 255,
                 'null' => true,
@@ -257,14 +256,12 @@ class NotEmptySnapshot extends AbstractMigration
             )
             ->dropForeignKey(
                 'product_id'
-            )
-            ->update();
+            );
 
         $this->table('products')
             ->dropForeignKey(
                 'category_id'
-            )
-            ->update();
+            );
 
         $this->dropTable('articles');
         $this->dropTable('categories');

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -1,13 +1,24 @@
 <?php
 use Migrations\AbstractMigration;
 
-class NotEmptySnapshot extends AbstractMigration
+class TestAutoIdDisabledSnapshot extends AbstractMigration
 {
+
+    public $autoId = false;
+
     public function up()
     {
         $table = $this->table('articles');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('title', 'string', [
+                'comment' => 'Article title',
                 'default' => null,
                 'limit' => 255,
                 'null' => true,
@@ -46,6 +57,13 @@ class NotEmptySnapshot extends AbstractMigration
 
         $table = $this->table('categories');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
                 'limit' => 11,
@@ -79,7 +97,7 @@ class NotEmptySnapshot extends AbstractMigration
             )
             ->create();
 
-        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
+        $table = $this->table('composite_pks');
         $table
             ->addColumn('id', 'uuid', [
                 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
@@ -91,10 +109,18 @@ class NotEmptySnapshot extends AbstractMigration
                 'limit' => 50,
                 'null' => false,
             ])
+            ->addPrimaryKey(['id', 'name'])
             ->create();
 
         $table = $this->table('products');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('title', 'string', [
                 'default' => null,
                 'limit' => 255,
@@ -140,13 +166,14 @@ class NotEmptySnapshot extends AbstractMigration
             )
             ->create();
 
-        $table = $this->table('special_pks', ['id' => false, 'primary_key' => ['id']]);
+        $table = $this->table('special_pks');
         $table
             ->addColumn('id', 'uuid', [
                 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
                 'limit' => null,
                 'null' => false,
             ])
+            ->addPrimaryKey(['id'])
             ->addColumn('name', 'string', [
                 'default' => null,
                 'limit' => 256,
@@ -156,6 +183,13 @@ class NotEmptySnapshot extends AbstractMigration
 
         $table = $this->table('special_tags');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('article_id', 'integer', [
                 'default' => null,
                 'limit' => 11,
@@ -191,6 +225,13 @@ class NotEmptySnapshot extends AbstractMigration
 
         $table = $this->table('users');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('username', 'string', [
                 'default' => null,
                 'limit' => 256,
@@ -256,14 +297,12 @@ class NotEmptySnapshot extends AbstractMigration
             )
             ->dropForeignKey(
                 'product_id'
-            )
-            ->update();
+            );
 
         $this->table('products')
             ->dropForeignKey(
                 'category_id'
-            )
-            ->update();
+            );
 
         $this->dropTable('articles');
         $this->dropTable('categories');

--- a/tests/comparisons/Migration/test_composite_constraints_snapshot.php
+++ b/tests/comparisons/Migration/test_composite_constraints_snapshot.php
@@ -1,7 +1,7 @@
 <?php
 use Migrations\AbstractMigration;
 
-class CompositeConstraintsSnapshot extends AbstractMigration
+class TestCompositeConstraintsSnapshot extends AbstractMigration
 {
     public function up()
     {
@@ -9,18 +9,18 @@ class CompositeConstraintsSnapshot extends AbstractMigration
         $table
             ->addColumn('title', 'string', [
                 'comment' => 'Article title',
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -49,16 +49,16 @@ class CompositeConstraintsSnapshot extends AbstractMigration
         $table
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('title', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
@@ -98,12 +98,12 @@ class CompositeConstraintsSnapshot extends AbstractMigration
         $table
             ->addColumn('product_category', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addIndex(
@@ -117,18 +117,18 @@ class CompositeConstraintsSnapshot extends AbstractMigration
         $table = $this->table('products');
         $table
             ->addColumn('title', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -169,7 +169,7 @@ class CompositeConstraintsSnapshot extends AbstractMigration
                 'null' => false,
             ])
             ->addColumn('name', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])
@@ -179,17 +179,17 @@ class CompositeConstraintsSnapshot extends AbstractMigration
         $table
             ->addColumn('article_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('author_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('tag_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('highlighted', 'boolean', [
@@ -213,12 +213,12 @@ class CompositeConstraintsSnapshot extends AbstractMigration
         $table = $this->table('users');
         $table
             ->addColumn('username', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])
             ->addColumn('password', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])
@@ -295,8 +295,7 @@ class CompositeConstraintsSnapshot extends AbstractMigration
             )
             ->dropForeignKey(
                 'product_id'
-            )
-            ->update();
+            );
 
         $this->table('orders')
             ->dropForeignKey(
@@ -304,14 +303,12 @@ class CompositeConstraintsSnapshot extends AbstractMigration
                     'product_category',
                     'product_id',
                 ]
-            )
-            ->update();
+            );
 
         $this->table('products')
             ->dropForeignKey(
                 'category_id'
-            )
-            ->update();
+            );
 
         $this->dropTable('articles');
         $this->dropTable('categories');

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -1,7 +1,7 @@
 <?php
 use Migrations\AbstractMigration;
 
-class NotEmptySnapshot extends AbstractMigration
+class TestNotEmptySnapshot extends AbstractMigration
 {
     public function up()
     {
@@ -9,18 +9,18 @@ class NotEmptySnapshot extends AbstractMigration
         $table
             ->addColumn('title', 'string', [
                 'comment' => 'Article title',
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -49,16 +49,16 @@ class NotEmptySnapshot extends AbstractMigration
         $table
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('title', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
@@ -97,18 +97,18 @@ class NotEmptySnapshot extends AbstractMigration
         $table = $this->table('products');
         $table
             ->addColumn('title', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -149,7 +149,7 @@ class NotEmptySnapshot extends AbstractMigration
                 'null' => false,
             ])
             ->addColumn('name', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])
@@ -159,17 +159,17 @@ class NotEmptySnapshot extends AbstractMigration
         $table
             ->addColumn('article_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('author_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('tag_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('highlighted', 'boolean', [
@@ -193,12 +193,12 @@ class NotEmptySnapshot extends AbstractMigration
         $table = $this->table('users');
         $table
             ->addColumn('username', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])
             ->addColumn('password', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])
@@ -257,14 +257,12 @@ class NotEmptySnapshot extends AbstractMigration
             )
             ->dropForeignKey(
                 'product_id'
-            )
-            ->update();
+            );
 
         $this->table('products')
             ->dropForeignKey(
                 'category_id'
-            )
-            ->update();
+            );
 
         $this->dropTable('articles');
         $this->dropTable('categories');


### PR DESCRIPTION
**This should not be merged right now**

This phinx release and this PR shed some light on some migrations tests that were not done. Now that they are all running, I spotted a bug in phinx implementation of the mechanism to drop foreign key constraints with SQLite. I submitted a PR on phinx repo : https://github.com/robmorgan/phinx/pull/641

The test suite will be failing for SQLite until the change I will propose will be merged and a new phinx release is 

-----------------------

This phinx release introduced changes in the naming scheme the migration files / the migration classes should follow, breaking the tests.

This commit also removes the ``update()`` call after the ``dropForeignKey()`` calls : it was not necessary.