### PR TITLE
Allow to migrate all migrations with one "mark_migrated" call

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ bin/cake migrations status -c my_datasource
 # The following will mark targeted migration as marked without actually running it.
 # The expected argument is the migration version number
 bin/cake migrations mark_migrated 20150417223600
+
+# Since Migrations 1.3.1, a new `all` special value for the version argumentwas added.
+# The following will mark all migrations found as migrated.
+bin/cake migrations mark_migrated all
 ```
 
 ### Creating Migrations

--- a/src/Command/MarkMigrated.php
+++ b/src/Command/MarkMigrated.php
@@ -23,13 +23,36 @@ class MarkMigrated extends AbstractCommand
     use ConfigurationTrait;
 
     /**
+     * The console output instance
+     *
+     * @var \Symfony\Component\Console\Output\OutputInterface
+     */
+    protected $output;
+
+    /**
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return mixed
+     */
+    public function output(OutputInterface $output = null)
+    {
+        if ($output !== null) {
+            $this->output = $output;
+        }
+        return $this->output;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function configure()
     {
         $this->setName('mark_migrated')
             ->setDescription('Mark a migration as migrated')
-            ->addArgument('version', InputArgument::REQUIRED, 'What is the version of the migration?')
+            ->addArgument(
+                'version',
+                InputArgument::REQUIRED,
+                'What is the version of the migration? Use the special value `all` to mark all migrations as migrated.'
+            )
             ->setHelp(sprintf(
                 '%sMark a migration migrated based on its version number%s',
                 PHP_EOL,
@@ -42,6 +65,8 @@ class MarkMigrated extends AbstractCommand
 
     /**
      * Mark a migration migrated
+     * If the `version` argument has the value `all`, all migrations found will be marked as
+     * migrated
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input the input object
      * @param \Symfony\Component\Console\Output\OutputInterface $output the output object
@@ -51,9 +76,15 @@ class MarkMigrated extends AbstractCommand
     {
         $this->setInput($input);
         $this->bootstrap($input, $output);
+        $this->output($output);
 
         $path = $this->getConfig()->getMigrationPath();
         $version = $input->getArgument('version');
+
+        if ($version === 'all') {
+            $this->markAllMigrated($path);
+            return;
+        }
 
         if ($this->getManager()->isMigrated($version)) {
             $output->writeln(
@@ -71,5 +102,52 @@ class MarkMigrated extends AbstractCommand
         } catch (\Exception $e) {
             $output->writeln(sprintf('<error>An error occurred : %s</error>', $e->getMessage()));
         }
+    }
+
+    /**
+     * Mark all migrations found in $path as migrated
+     *
+     * It will start a transaction and rollback in case one of the operation raises an exception
+     *
+     * @param string $path Path where to look for migrations
+     * @return void
+     */
+    protected function markAllMigrated($path)
+    {
+        $manager = $this->getManager();
+        $adapter = $manager->getEnvironment('default')->getAdapter();
+        $migrations = $manager->getMigrations();
+        $output = $this->output();
+
+        if (empty($migrations)) {
+            $output->writeln('<info>No migrations were found. Nothing to mark as migrated.</info>');
+            return;
+        }
+
+        $adapter->beginTransaction();
+        foreach ($migrations as $version => $migration) {
+            if ($manager->isMigrated($version)) {
+                $output->writeln(sprintf('<info>Skipping migration `%s` (already migrated).</info>', $version));
+            } else {
+                try {
+                    $this->getManager()->markMigrated($version, $path);
+                    $output->writeln(
+                        sprintf('<info>Migration `%s` successfully marked migrated !</info>', $version)
+                    );
+                } catch (\Exception $e) {
+                    $adapter->rollbackTransaction();
+                    $output->writeln(
+                        sprintf(
+                            '<error>An error occurred while marking migration `%s` as migrated : %s</error>',
+                            $version,
+                            $e->getMessage()
+                        )
+                    );
+                    $output->writeln('<error>All marked migrations during this process were unmarked.</error>');
+                    return;
+                }
+            }
+        }
+        $adapter->commitTransaction();
     }
 }

--- a/src/Command/MarkMigrated.php
+++ b/src/Command/MarkMigrated.php
@@ -81,7 +81,7 @@ class MarkMigrated extends AbstractCommand
         $path = $this->getConfig()->getMigrationPath();
         $version = $input->getArgument('version');
 
-        if ($version === 'all') {
+        if ($version === 'all' || $version === '*') {
             $this->markAllMigrated($path);
             return;
         }

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -14,6 +14,7 @@ namespace Migrations\Test\Command;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Migrations\MigrationsDispatcher;
+use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -132,5 +133,75 @@ class MarkMigratedTest extends TestCase
         );
         $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->count();
         $this->assertEquals(1, $result);
+    }
+
+    /**
+     * Test executing "mark_migration"
+     *
+     * @return void
+     */
+    public function testExecuteAll()
+    {
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'version' => 'all',
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations'
+        ]);
+
+        $this->assertContains('Migration `20150826191400` successfully marked migrated !', $this->commandTester->getDisplay());
+        $this->assertContains('Migration `20150724233100` successfully marked migrated !', $this->commandTester->getDisplay());
+        $this->assertContains('Migration `20150704160200` successfully marked migrated !', $this->commandTester->getDisplay());
+
+        $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
+        $this->assertEquals('20150704160200', $result[0]['version']);
+        $this->assertEquals('20150724233100', $result[1]['version']);
+        $this->assertEquals('20150826191400', $result[2]['version']);
+
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'version' => 'all',
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations'
+        ]);
+
+        $this->assertContains('Skipping migration `20150704160200` (already migrated).', $this->commandTester->getDisplay());
+        $this->assertContains('Skipping migration `20150724233100` (already migrated).', $this->commandTester->getDisplay());
+        $this->assertContains('Skipping migration `20150826191400` (already migrated).', $this->commandTester->getDisplay());
+
+        $config = $this->command->getConfig();
+        $env = $this->command->getManager()->getEnvironment('default');
+        $migrations = $this->command->getManager()->getMigrations();
+
+        $manager = $this->getMock(
+            '\Migrations\CakeManager',
+            ['getEnvironment', 'markMigrated'],
+            [$config, new StreamOutput(fopen('php://memory', 'a', false))]
+        );
+
+        $manager->expects($this->any())
+            ->method('getEnvironment')->will($this->returnValue($env));
+        $manager->expects($this->any())
+            ->method('getMigrations')->will($this->returnValue($migrations));
+        $manager
+            ->method('markMigrated')->will($this->throwException(new \Exception('Error during marking process')));
+
+        $this->Connection->execute('DELETE FROM phinxlog');
+
+        $application = new MigrationsDispatcher('testing');
+        $buggyCommand = $application->find('mark_migrated');
+        $buggyCommand->setManager($manager);
+        $buggyCommandTester = new CommandTester($buggyCommand);
+        $buggyCommandTester->execute([
+            'command' => $this->command->getName(),
+            'version' => 'all',
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations'
+        ]);
+
+        $this->assertContains(
+            'An error occurred while marking migration `20150704160200` as migrated : Error during marking process',
+            $buggyCommandTester->getDisplay()
+        );
     }
 }

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -149,9 +149,18 @@ class MarkMigratedTest extends TestCase
             '--source' => 'TestsMigrations'
         ]);
 
-        $this->assertContains('Migration `20150826191400` successfully marked migrated !', $this->commandTester->getDisplay());
-        $this->assertContains('Migration `20150724233100` successfully marked migrated !', $this->commandTester->getDisplay());
-        $this->assertContains('Migration `20150704160200` successfully marked migrated !', $this->commandTester->getDisplay());
+        $this->assertContains(
+            'Migration `20150826191400` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertContains(
+            'Migration `20150724233100` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertContains(
+            'Migration `20150704160200` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
 
         $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
         $this->assertEquals('20150704160200', $result[0]['version']);
@@ -165,9 +174,18 @@ class MarkMigratedTest extends TestCase
             '--source' => 'TestsMigrations'
         ]);
 
-        $this->assertContains('Skipping migration `20150704160200` (already migrated).', $this->commandTester->getDisplay());
-        $this->assertContains('Skipping migration `20150724233100` (already migrated).', $this->commandTester->getDisplay());
-        $this->assertContains('Skipping migration `20150826191400` (already migrated).', $this->commandTester->getDisplay());
+        $this->assertContains(
+            'Skipping migration `20150704160200` (already migrated).',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertContains(
+            'Skipping migration `20150724233100` (already migrated).',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertContains(
+            'Skipping migration `20150826191400` (already migrated).',
+            $this->commandTester->getDisplay()
+        );
 
         $config = $this->command->getConfig();
         $env = $this->command->getManager()->getEnvironment('default');

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -208,8 +208,7 @@ class MigrationsTest extends TestCase
      */
     public function testRollbackErrors()
     {
-        $this->migrations->markMigrated(20150704160200);
-        $this->migrations->markMigrated(20150724233100);
+        $this->migrations->markMigrated('all');
         $this->migrations->rollback();
     }
 


### PR DESCRIPTION
Added a special value ``all`` for the ``version`` argument of the ``mark_migrated`` command.
It allows to mark all migrations found (based on the other arguments) as migrated in one call.
Everything is done in one transaction. If one the marking as migrated operations raises an exception, the entire process is cancelled and the transaction rollbacked.

I went with ``all`` instead of ``*`` because the ``*`` raised a ``TooManyArguments`` exception (I could figured out why though).
And ``all`` is closer to what we have in bake for instance.

The tests will fail because I'm waiting for https://github.com/robmorgan/phinx/pull/641 to be reviewed, tested and merged (to be able to merge #123 after the build passes).

Refs #124 