### PR TITLE
Bump up the minimum requirement to CakePHP 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=5.4",
         "robmorgan/phinx": "dev-master",
-        "cakephp/cakephp": "~3.0"
+        "cakephp/cakephp": "~3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "*",
@@ -39,5 +39,7 @@
     },
     "suggest": {
         "cakephp/bake": "Required if you want to generate migrations."
-    }
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
 }

--- a/src/Command/Migrate.php
+++ b/src/Command/Migrate.php
@@ -11,7 +11,7 @@
  */
 namespace Migrations\Command;
 
-use Cake\Event\EventManagerTrait;
+use Cake\Event\EventDispatcherTrait;
 use Migrations\ConfigurationTrait;
 use Phinx\Console\Command\Migrate as MigrateCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -24,7 +24,7 @@ class Migrate extends MigrateCommand
     use ConfigurationTrait {
         execute as parentExecute;
     }
-    use EventManagerTrait;
+    use EventDispatcherTrait;
 
     /**
      * {@inheritdoc}

--- a/src/Command/Rollback.php
+++ b/src/Command/Rollback.php
@@ -11,7 +11,7 @@
  */
 namespace Migrations\Command;
 
-use Cake\Event\EventManagerTrait;
+use Cake\Event\EventDispatcherTrait;
 use Migrations\ConfigurationTrait;
 use Phinx\Console\Command\Rollback as RollbackCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -24,7 +24,7 @@ class Rollback extends RollbackCommand
     use ConfigurationTrait {
         execute as parentExecute;
     }
-    use EventManagerTrait;
+    use EventDispatcherTrait;
 
     /**
      * {@inheritDoc}

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -107,12 +107,6 @@ class MigrationSnapshotTaskTest extends TestCase
 
     public function testCompositeConstraintsSnapshot()
     {
-        $this->skipIf(
-            version_compare(Configure::version(), '3.0.8', '<'),
-            'Cannot run "testCompositeConstraintsSnapshot" because CakePHP Core feature' .
-            'is not implemented in this version'
-        );
-
         $this->loadFixtures(
             'Orders'
         );


### PR DESCRIPTION
Following changes to other projects, min requirement for Cake is now 3.1.