### PR TITLE
Prevent phinx from exiting after the migration

### DIFF
--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -79,6 +79,7 @@ class MigrationsShell extends Shell
     {
         $app = new MigrationsDispatcher(PHINX_VERSION);
         $input = new ArgvInput($this->argv);
+        $app->setAutoExit(false);
         $app->run($input);
     }
 


### PR DESCRIPTION
When called from another shell, migrations would exit instead of returning

```
$this->dispatchShell('migrations migrate');
$this->out('this won't be printed in the console');
```