### PR TITLE
fixing MigrationTask#detectAction bug for adding field #133

### DIFF
--- a/src/Shell/Task/MigrationTask.php
+++ b/src/Shell/Task/MigrationTask.php
@@ -109,7 +109,7 @@ class MigrationTask extends SimpleMigrationTask
         if (preg_match('/^(Create|Drop)(.*)/', $name, $matches)) {
             $action = strtolower($matches[1]) . '_table';
             $table = Inflector::tableize(Inflector::pluralize($matches[2]));
-        } elseif (preg_match('/^(Add).*(?:To)(.*)/', $name, $matches)) {
+        } elseif (preg_match('/^(Add).*?(?:To)(.*)/', $name, $matches)) {
             $action = 'add_field';
             $table = Inflector::tableize(Inflector::pluralize($matches[2]));
         } elseif (preg_match('/^(Remove).*(?:From)(.*)/', $name, $matches)) {

--- a/tests/TestCase/Shell/Task/MigrationTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationTaskTest.php
@@ -180,6 +180,10 @@ class MigrationTaskTest extends TestCase
             ['add_field', 'groups_users'],
             $this->Task->detectAction('AddSomeFieldToGroupsUsers')
         );
+        $this->assertEquals(
+            ['add_field', 'todos'],
+            $this->Task->detectAction('AddSomeFieldToTodos')
+        );
 
         $this->assertEquals(
             ['drop_field', 'groups'],


### PR DESCRIPTION
Hi guys,

I ran into a very specific case where the MigrationTask#detectAction is returning the wrong table name:

`bin/cake bake migration AddSomeFieldToTodos`

It gets the table name as being `dos` instead of `todos`. It seems to occur for every table that starts with `to`.