### PR TITLE
Skip to and up to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ bin/cake migrations mark_migrated 20150417223600
 # Since Migrations 1.3.1, a new `all` special value for the version argumentwas added.
 # The following will mark all migrations found as migrated.
 bin/cake migrations mark_migrated all
+
+# The following option up-to will try to mark the migrations from beginning to the given version (including it)
+bin/cake migrations mark_migrated 20150417223600 --up-to
+
+# The following option skip-to will try to mark the migrations from beginning until the given version (excluding it)
+bin/cake migrations mark_migrated 20150417223600 --skip-to
 ```
 
 ### Creating Migrations

--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -79,6 +79,7 @@ class MigrationsShell extends Shell
     {
         $app = new MigrationsDispatcher(PHINX_VERSION);
         $input = new ArgvInput($this->argv);
+        $app->setAutoExit(false);
         $app->run($input);
     }
 

--- a/src/Shell/Task/MigrationTask.php
+++ b/src/Shell/Task/MigrationTask.php
@@ -109,7 +109,7 @@ class MigrationTask extends SimpleMigrationTask
         if (preg_match('/^(Create|Drop)(.*)/', $name, $matches)) {
             $action = strtolower($matches[1]) . '_table';
             $table = Inflector::tableize(Inflector::pluralize($matches[2]));
-        } elseif (preg_match('/^(Add).*(?:To)(.*)/', $name, $matches)) {
+        } elseif (preg_match('/^(Add).*?(?:To)(.*)/', $name, $matches)) {
             $action = 'add_field';
             $table = Inflector::tableize(Inflector::pluralize($matches[2]));
         } elseif (preg_match('/^(Remove).*(?:From)(.*)/', $name, $matches)) {

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -222,4 +222,93 @@ class MarkMigratedTest extends TestCase
             $buggyCommandTester->getDisplay()
         );
     }
+
+    public function testExecuteUpTo()
+    {
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'version' => '20150704160200',
+            '--up-to' => '',
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations'
+        ]);
+
+        $this->assertContains(
+            'Migration `20150704160200` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+
+        $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
+        $this->assertEquals('20150704160200', $result[0]['version']);
+
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'version' => '20150826191400',
+            '--up-to' => '',
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations'
+        ]);
+
+        $this->assertContains(
+            'Skipping migration `20150704160200` (already migrated).',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertContains(
+            'Migration `20150724233100` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertContains(
+            'Migration `20150826191400` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+
+        $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
+        $this->assertEquals('20150704160200', $result[0]['version']);
+        $this->assertEquals('20150724233100', $result[1]['version']);
+        $this->assertEquals('20150826191400', $result[2]['version']);
+        $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->count();
+        $this->assertEquals(3, $result);
+    }
+
+    public function testExecuteSkipTo()
+    {
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'version' => '20150724233100',
+            '--skip-to' => '',
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations'
+        ]);
+
+        $this->assertContains(
+            'Migration `20150704160200` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+
+        $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
+        $this->assertEquals('20150704160200', $result[0]['version']);
+
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'version' => '20150826191400',
+            '--skip-to' => '',
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations'
+        ]);
+
+        $this->assertContains(
+            'Skipping migration `20150704160200` (already migrated).',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertContains(
+            'Migration `20150724233100` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+
+        $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
+        $this->assertEquals('20150704160200', $result[0]['version']);
+        $this->assertEquals('20150724233100', $result[1]['version']);
+        $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->count();
+        $this->assertEquals(2, $result);
+    }
 }

--- a/tests/TestCase/Shell/Task/MigrationTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationTaskTest.php
@@ -180,6 +180,10 @@ class MigrationTaskTest extends TestCase
             ['add_field', 'groups_users'],
             $this->Task->detectAction('AddSomeFieldToGroupsUsers')
         );
+        $this->assertEquals(
+            ['add_field', 'todos'],
+            $this->Task->detectAction('AddSomeFieldToTodos')
+        );
 
         $this->assertEquals(
             ['drop_field', 'groups'],


### PR DESCRIPTION
This pull request implements the feature described on #129

The way it was implemented it should be used like:
`bin/cake migrations mark_migrated VERSION --skip-to` will mark all migrations from beginning until VERSION

`bin/cake migrations mark_migrated VERSION --up-to` will mark all migrations from beginning to VERSION (including it)

@HavokInspiration does it seem good?

Right now there are some duplicated logic (the migrations are being marked as migrated inside `execute($input, $output)` and `markVersionsAsMigrated($path, $versions)`). I can refactor it if you intend to merge :)

Cheers,
Pedro.