### PR TITLE
Skip to and up to options feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,23 @@ bin/cake migrations status -p PluginName
 # You can also scope a command to a connection via the `--connection` or `-c` option
 bin/cake migrations status -c my_datasource
 
-# The following will mark targeted migration as marked without actually running it.
-# The expected argument is the migration version number
-bin/cake migrations mark_migrated 20150417223600
+# The following will mark migrations as marked without actually running it.
+bin/cake migrations mark_migrated
 
-# Since Migrations 1.3.1, a new `all` special value for the version argumentwas added.
-# The following will mark all migrations found as migrated.
+# DEPRECATED: The use of the argument `all` will have the same effect as above
 bin/cake migrations mark_migrated all
+
+# Using the option `--target` it will try to mark every migration from beginning up to the given VERSION
+bin/cake migrations mark_migrated --target=VERSION
+
+# When using the `--target` option you can also use `--exclude` or `--only`:
+# `--exclude` will try to mark every migration from beginning until the given VERSION (excluding it from marking)
+# `--only` will try to mark only the given VERSION
+bin/cake migrations mark_migrated --target=VERSION --exclude
+bin/cake migrations mark_migrated --target=VERSION --only
+
+# DEPRECATED: Using the VERSION argument will try to mark only the given VERSION
+bin/cake migrations mark_migrated VERSION
 ```
 
 ### Creating Migrations

--- a/src/Command/MarkMigrated.php
+++ b/src/Command/MarkMigrated.php
@@ -16,6 +16,7 @@ use Phinx\Console\Command\AbstractCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 class MarkMigrated extends AbstractCommand
 {
@@ -50,23 +51,47 @@ class MarkMigrated extends AbstractCommand
             ->setDescription('Mark a migration as migrated')
             ->addArgument(
                 'version',
-                InputArgument::REQUIRED,
-                'What is the version of the migration? Use the special value `all` to mark all migrations as migrated.'
+                InputArgument::OPTIONAL,
+                'DEPRECATED: use `bin/cake migrations mark_migrated --target=VERSION` instead'
             )
             ->setHelp(sprintf(
-                '%sMark a migration migrated based on its version number%s',
+                '%sMark migrations as migrated%s',
                 PHP_EOL,
                 PHP_EOL
             ));
         $this->addOption('plugin', 'p', InputArgument::OPTIONAL, 'The plugin the file should be created for')
             ->addOption('connection', 'c', InputArgument::OPTIONAL, 'The datasource connection to use')
-            ->addOption('source', 's', InputArgument::OPTIONAL, 'The folder where migrations are in');
+            ->addOption('source', 's', InputArgument::OPTIONAL, 'The folder where migrations are in')
+            ->addOption(
+                'target',
+                't',
+                InputArgument::OPTIONAL,
+                'It will mark migrations from beginning to the given version'
+            )
+            ->addOption(
+                'exclude',
+                'x',
+                InputArgument::OPTIONAL,
+                'If present it will mark migrations from beginning until the given version, excluding it'
+            )
+            ->addOption(
+                'only',
+                'o',
+                InputArgument::OPTIONAL,
+                'If present it will only mark the given migration version'
+            );
     }
 
     /**
-     * Mark a migration migrated
-     * If the `version` argument has the value `all`, all migrations found will be marked as
-     * migrated
+     * Mark migrations as migrated
+     *
+     * `bin/cake migrations mark_migrated` mark every migrations as migrated
+     * `bin/cake migrations mark_migrated all` DEPRECATED: the same effect as above
+     * `bin/cake migrations mark_migrated --target=VERSION` mark migrations as migrated up to the VERSION param
+     * `bin/cake migrations mark_migrated --target=20150417223600 --exclude` mark migrations as migrated up to
+     *  and except the VERSION param
+     * `bin/cake migrations mark_migrated --target=20150417223600 --only` mark only the VERSION migration as migrated
+     * `bin/cake migrations mark_migrated 20150417223600` DEPRECATED: the same effect as above
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input the input object
      * @param \Symfony\Component\Console\Output\OutputInterface $output the output object
@@ -79,53 +104,54 @@ class MarkMigrated extends AbstractCommand
         $this->output($output);
 
         $path = $this->getConfig()->getMigrationPath();
-        $version = $input->getArgument('version');
 
-        if ($version === 'all' || $version === '*') {
-            $this->markAllMigrated($path);
-            return;
-        }
-
-        if ($this->getManager()->isMigrated($version)) {
+        if ($this->invalidOnlyOrExclude()) {
             $output->writeln(
-                sprintf(
-                    '<info>The migration with version number `%s` has already been marked as migrated.</info>',
-                    $version
-                )
+                "<error>You should use `--exclude` OR `--only` (not both) along with a `--target` !</error>"
             );
             return;
         }
 
-        try {
-            $this->getManager()->markMigrated($version, $path);
-            $output->writeln('<info>Migration successfully marked migrated !</info>');
-        } catch (\Exception $e) {
-            $output->writeln(sprintf('<error>An error occurred : %s</error>', $e->getMessage()));
+        if ($this->isUsingDeprecatedAll()) {
+            $this->outputDeprecatedAllMessage();
         }
+
+        if ($this->isUsingDeprecatedVersion()) {
+            $this->outputDeprecatedVersionMessage();
+        }
+
+        try {
+            $versions = $this->getVersionsToMark($input);
+        } catch (\InvalidArgumentException $e) {
+            $output->writeln(sprintf("<error>%s</error>", $e->getMessage()));
+            return;
+        }
+
+        $this->markVersionsAsMigrated($path, $versions);
     }
 
     /**
-     * Mark all migrations found in $path as migrated
+     * Mark all migrations in $versions array found in $path as migrated
      *
      * It will start a transaction and rollback in case one of the operation raises an exception
      *
      * @param string $path Path where to look for migrations
+     * @param array $versions Versions which should be marked
      * @return void
      */
-    protected function markAllMigrated($path)
+    protected function markVersionsAsMigrated($path, $versions)
     {
         $manager = $this->getManager();
         $adapter = $manager->getEnvironment('default')->getAdapter();
-        $migrations = $manager->getMigrations();
         $output = $this->output();
 
-        if (empty($migrations)) {
+        if (empty($versions)) {
             $output->writeln('<info>No migrations were found. Nothing to mark as migrated.</info>');
             return;
         }
 
         $adapter->beginTransaction();
-        foreach ($migrations as $version => $migration) {
+        foreach ($versions as $version) {
             if ($manager->isMigrated($version)) {
                 $output->writeln(sprintf('<info>Skipping migration `%s` (already migrated).</info>', $version));
             } else {
@@ -149,5 +175,156 @@ class MarkMigrated extends AbstractCommand
             }
         }
         $adapter->commitTransaction();
+    }
+
+    /**
+     * Decides which versions it should mark as migrated
+     *
+     * @return array Array of versions that should be marked as migrated
+     * @throws InvalidArgumentException If the `--exclude` or `--only` options are used without `--target`
+     * or version not found
+     */
+    protected function getVersionsToMark()
+    {
+        $migrations = $this->getManager()->getMigrations();
+        $versions = array_keys($migrations);
+
+        if ($this->isAllVersion()) {
+            return $versions;
+        }
+
+        $version = $this->getTarget();
+
+        if ($this->isOnly()) {
+            if (!in_array($version, $versions)) {
+                throw new \InvalidArgumentException("Migration `$version` was not found !");
+            }
+
+            return [$version];
+        }
+
+        $lengthIncrease = $this->hasExclude() ? 0 : 1;
+        $index = array_search($version, $versions);
+
+        if ($index === false) {
+            throw new \InvalidArgumentException("Migration `$version` was not found !");
+        }
+
+        return array_slice($versions, 0, $index + $lengthIncrease);
+    }
+
+    /**
+     * Returns the target version from `--target` or from the deprecated version argument
+     *
+     * @return string Version found as target
+     */
+    protected function getTarget()
+    {
+        $target = $this->input->getOption('target');
+        return $target ? $target : $this->input->getArgument('version');
+    }
+
+    /**
+     * Checks if the $version is for all migrations
+     *
+     * @return bool Returns true if it should try to mark all versions
+     */
+    protected function isAllVersion()
+    {
+        if ($this->isUsingDeprecatedVersion()) {
+            return false;
+        }
+
+        return $this->isUsingDeprecatedAll() || $this->input->getOption('target') === null;
+    }
+
+    /**
+     * Checks if the version is using the deprecated `all`
+     *
+     * @return bool Returns true if it is using the deprecated `all` otherwise false
+     */
+    protected function isUsingDeprecatedAll()
+    {
+        $version = $this->input->getArgument('version');
+        return $version === 'all' || $version === '*';
+    }
+
+    /**
+     * Checks if the input has the `--only` option or it is using the deprecated version argument
+     *
+     * @return bool Returns true when it is trying to mark only one migration
+     */
+    protected function isOnly()
+    {
+
+        return $this->hasOnly() || $this->isUsingDeprecatedVersion();
+    }
+
+    /**
+     * Checks if the input has the `--exclude` option
+     *
+     * @return bool Returns true if `--exclude` option gets passed in otherwise false
+     */
+    protected function hasExclude()
+    {
+        return $this->input->getOption('exclude') !== null;
+    }
+
+    /**
+     * Checks if the input has the `--only` option
+     *
+     * @return bool Returns true if `--only` option gets passed in otherwise false
+     */
+    protected function hasOnly()
+    {
+        return $this->input->getOption('only') !== null;
+    }
+
+    /**
+     * Checks for the usage of deprecated VERSION as argument when not `all`
+     *
+     * @return bool True if it is using VERSION argument otherwise false
+     */
+    protected function isUsingDeprecatedVersion()
+    {
+        $version = $this->input->getArgument('version');
+        return $version && $version !== 'all' && $version !== '*';
+    }
+
+    /**
+     * Checks for an invalid use of `--exclude` or `--only`
+     *
+     * @return bool Returns true when it is an invalid use of `--exclude` or `--only` otherwise false
+     */
+    protected function invalidOnlyOrExclude()
+    {
+        return ($this->hasExclude() && $this->hasOnly()) ||
+            ($this->hasExclude() || $this->hasOnly()) &&
+            $this->input->getOption('target') === null;
+    }
+
+    /**
+     * Outputs the deprecated message for the `all` or `*` usage
+     *
+     * @return void Just outputs the message
+     */
+    protected function outputDeprecatedAllMessage()
+    {
+        $msg = "DEPRECATED: `all` or `*` as version is deprecated. Use `bin/cake migrations mark_migrated` instead";
+        $output = $this->output();
+        $output->writeln(sprintf("<comment>%s</comment>", $msg));
+    }
+
+    /**
+     * Outputs the deprecated message for the usage of VERSION as argument
+     *
+     * @return void Just outputs the message
+     */
+    protected function outputDeprecatedVersionMessage()
+    {
+        $msg = 'DEPRECATED: VERSION as argument is deprecated. Use: ' .
+            '`bin/cake migrations mark_migrated --target=VERSION --only`';
+        $output = $this->output();
+        $output->writeln(sprintf("<comment>%s</comment>", $msg));
     }
 }


### PR DESCRIPTION
Finally now it seems right!!

Sorry for the mess.

Recommenting:
The way it was implemented it should be used like:
`bin/cake migrations mark_migrated VERSION --skip-to` will mark all migrations from beginning until VERSION

`bin/cake migrations mark_migrated VERSION --up-to` will mark all migrations from beginning to VERSION (including it)

@HavokInspiration does it seem good?

Right now there are some duplicated logic (the migrations are being marked as migrated inside execute($input, $output) and markVersionsAsMigrated($path, $versions)). I can refactor it if you intend to merge :)