### PR TITLE
Add the ability to specify the field length to the bake command

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,12 +211,14 @@ name you are specifying.
 
 Fields are verified via the following the following regular expression:
 
-    /^(\w*)(?::(\w*))?(?::(\w*))?(?::(\w*))?/
+    /^(\w*)(?::(\w*\[?\d*\]?))?(?::(\w*))?(?::(\w*))?/
 
 They follow the format:
 
-    field:fieldType:indexType:indexName
+    field:fieldType[length]:indexType:indexName
 
+The length parameter for the ``fieldType`` is optionnal and should always be
+written between bracket.
 For instance, the following are all valid ways of specifying the primary key `id`:
 
 - `id:primary_key`
@@ -232,7 +234,11 @@ There are some heuristics to choosing fieldtypes when left unspecified or set to
 - `created`, `modified`, `updated`: *datetime*
 - Default *string*
 
-Lengths for certain columns are also defaulted:
+You can specify the wanted length for a field type by writing it between bracket:
+
+    username:string[128]
+
+If no length is specified, lengths for certain columns are defaulted:
 
 - *string*: `255`
 - *integer*: `11`

--- a/tests/TestCase/Shell/Task/MigrationTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationTaskTest.php
@@ -99,6 +99,14 @@ class MigrationTaskTest extends TestCase
         ];
         $result = $this->Task->bake('CreateUsers');
         $this->assertSameAsFile(__FUNCTION__ . 'PrimaryKeyUuid.php', $result);
+
+        $this->Task->args = [
+            'create_users',
+            'name:string[128]',
+            'counter:integer[8]'
+        ];
+        $result = $this->Task->bake('CreateUsers');
+        $this->assertSameAsFile(__FUNCTION__ . 'FieldLength.php', $result);
     }
 
     /**

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -186,6 +186,18 @@ class ColumnParserTest extends TestCase
             ['field:fieldType:indexType:indexName'],
             $this->columnParser->validArguments(['field:fieldType:indexType:indexName'])
         );
+        $this->assertEquals(
+            ['field:fieldType[128]:indexType:indexName'],
+            $this->columnParser->validArguments(['field:fieldType[128]:indexType:indexName'])
+        );
+        $this->assertEquals(
+            ['field:integer[9]:indexType:indexName'],
+            $this->columnParser->validArguments(['field:integer[9]:indexType:indexName'])
+        );
+        $this->assertEquals(
+            ['field:biginteger[18]:indexType:indexName'],
+            $this->columnParser->validArguments(['field:biginteger[18]:indexType:indexName'])
+        );
     }
 
     /**
@@ -206,6 +218,21 @@ class ColumnParserTest extends TestCase
         $this->assertEquals('string', $this->columnParser->getType('some_field', 'string'));
         $this->assertEquals('boolean', $this->columnParser->getType('field', 'boolean'));
         $this->assertEquals('polygon', $this->columnParser->getType('field', 'polygon'));
+    }
+
+    /**
+     * @covers Migrations\Util\ColumnParser::getTypeAndLength
+     */
+    public function testGetTypeAndLength()
+    {
+        $this->assertEquals(['string', 255], $this->columnParser->getTypeAndLength('name', 'string'));
+        $this->assertEquals(['integer', 11], $this->columnParser->getTypeAndLength('counter', 'integer'));
+        $this->assertEquals(['string', 128], $this->columnParser->getTypeAndLength('name', 'string[128]'));
+        $this->assertEquals(['integer', 9], $this->columnParser->getTypeAndLength('counter', 'integer[9]'));
+        $this->assertEquals(['biginteger', 18], $this->columnParser->getTypeAndLength('bigcounter', 'biginteger[18]'));
+        $this->assertEquals(['integer', 11], $this->columnParser->getTypeAndLength('id', null));
+        $this->assertEquals(['string', 255], $this->columnParser->getTypeAndLength('username', null));
+        $this->assertEquals(['datetime', null], $this->columnParser->getTypeAndLength('created', null));
     }
 
     /**

--- a/tests/comparisons/Migration/testCreateFieldLength.php
+++ b/tests/comparisons/Migration/testCreateFieldLength.php
@@ -1,0 +1,28 @@
+<?php
+use Migrations\AbstractMigration;
+
+class CreateUsers extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('users');
+        $table->addColumn('name', 'string', [
+            'default' => null,
+            'limit' => 128,
+            'null' => false,
+        ]);
+        $table->addColumn('counter', 'integer', [
+            'default' => null,
+            'limit' => 8,
+            'null' => false,
+        ]);
+        $table->create();
+    }
+}


### PR DESCRIPTION
This allows to specify the field length when baking a new migration file by allowing the ``fieldType`` syntax to accept a number written within brackets :

``bin/cake bake migrations create_users username:string[128]``

I went with brackets because parenthesis cause the shell call to fail.

I did not add any test to control the length specified other than the one that were already done because phinx does it with the adapters and default sizes based on the field type.

Refs to #128 