### PR TITLE
Follow up to #137

### DIFF
--- a/src/Command/Create.php
+++ b/src/Command/Create.php
@@ -34,9 +34,9 @@ class Create extends CreateCommand
                 PHP_EOL,
                 PHP_EOL
             ));
-        $this->addOption('plugin', 'p', InputArgument::OPTIONAL, 'The plugin the file should be created for')
-            ->addOption('connection', 'c', InputArgument::OPTIONAL, 'The datasource connection to use')
-            ->addOption('source', 's', InputArgument::OPTIONAL, 'The folder where migrations are in')
+        $this->addOption('plugin', 'p', InputOption::VALUE_REQUIRED, 'The plugin the file should be created for')
+            ->addOption('connection', 'c', InputOption::VALUE_REQUIRED, 'The datasource connection to use')
+            ->addOption('source', 's', InputOption::VALUE_REQUIRED, 'The folder where migrations are in')
             ->addOption('template', 't', InputOption::VALUE_REQUIRED, 'Use an alternative template')
             ->addOption(
                 'class',

--- a/src/Command/MarkMigrated.php
+++ b/src/Command/MarkMigrated.php
@@ -11,6 +11,7 @@
  */
 namespace Migrations\Command;
 
+use InvalidArgumentException;
 use Migrations\ConfigurationTrait;
 use Phinx\Console\Command\AbstractCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -52,32 +53,32 @@ class MarkMigrated extends AbstractCommand
             ->addArgument(
                 'version',
                 InputArgument::OPTIONAL,
-                'DEPRECATED: use `bin/cake migrations mark_migrated --target=VERSION` instead'
+                'DEPRECATED: use `bin/cake migrations mark_migrated --target=VERSION --only` instead'
             )
             ->setHelp(sprintf(
                 '%sMark migrations as migrated%s',
                 PHP_EOL,
                 PHP_EOL
             ));
-        $this->addOption('plugin', 'p', InputArgument::OPTIONAL, 'The plugin the file should be created for')
-            ->addOption('connection', 'c', InputArgument::OPTIONAL, 'The datasource connection to use')
-            ->addOption('source', 's', InputArgument::OPTIONAL, 'The folder where migrations are in')
+        $this->addOption('plugin', 'p', InputOption::VALUE_REQUIRED, 'The plugin the file should be created for')
+            ->addOption('connection', 'c', InputOption::VALUE_REQUIRED, 'The datasource connection to use')
+            ->addOption('source', 's', InputOption::VALUE_REQUIRED, 'The folder where migrations are in')
             ->addOption(
                 'target',
                 't',
-                InputArgument::OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 'It will mark migrations from beginning to the given version'
             )
             ->addOption(
                 'exclude',
                 'x',
-                InputArgument::OPTIONAL,
+                InputOption::VALUE_NONE,
                 'If present it will mark migrations from beginning until the given version, excluding it'
             )
             ->addOption(
                 'only',
                 'o',
-                InputArgument::OPTIONAL,
+                InputOption::VALUE_NONE,
                 'If present it will only mark the given migration version'
             );
     }
@@ -122,7 +123,7 @@ class MarkMigrated extends AbstractCommand
 
         try {
             $versions = $this->getVersionsToMark($input);
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             $output->writeln(sprintf("<error>%s</error>", $e->getMessage()));
             return;
         }
@@ -181,7 +182,7 @@ class MarkMigrated extends AbstractCommand
      * Decides which versions it should mark as migrated
      *
      * @return array Array of versions that should be marked as migrated
-     * @throws InvalidArgumentException If the `--exclude` or `--only` options are used without `--target`
+     * @throws \InvalidArgumentException If the `--exclude` or `--only` options are used without `--target`
      * or version not found
      */
     protected function getVersionsToMark()
@@ -197,7 +198,7 @@ class MarkMigrated extends AbstractCommand
 
         if ($this->isOnly()) {
             if (!in_array($version, $versions)) {
-                throw new \InvalidArgumentException("Migration `$version` was not found !");
+                throw new InvalidArgumentException("Migration `$version` was not found !");
             }
 
             return [$version];
@@ -267,7 +268,7 @@ class MarkMigrated extends AbstractCommand
      */
     protected function hasExclude()
     {
-        return $this->input->getOption('exclude') !== null;
+        return $this->input->getOption('exclude');
     }
 
     /**
@@ -277,7 +278,7 @@ class MarkMigrated extends AbstractCommand
      */
     protected function hasOnly()
     {
-        return $this->input->getOption('only') !== null;
+        return $this->input->getOption('only');
     }
 
     /**

--- a/src/Command/MarkMigrated.php
+++ b/src/Command/MarkMigrated.php
@@ -59,8 +59,8 @@ class MarkMigrated extends AbstractCommand
                 '%sMark migrations as migrated%s',
                 PHP_EOL,
                 PHP_EOL
-            ));
-        $this->addOption('plugin', 'p', InputOption::VALUE_REQUIRED, 'The plugin the file should be created for')
+            ))
+            ->addOption('plugin', 'p', InputOption::VALUE_REQUIRED, 'The plugin the file should be created for')
             ->addOption('connection', 'c', InputOption::VALUE_REQUIRED, 'The datasource connection to use')
             ->addOption('source', 's', InputOption::VALUE_REQUIRED, 'The folder where migrations are in')
             ->addOption(

--- a/src/Command/Migrate.php
+++ b/src/Command/Migrate.php
@@ -16,6 +16,7 @@ use Migrations\ConfigurationTrait;
 use Phinx\Console\Command\Migrate as MigrateCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Migrate extends MigrateCommand
@@ -34,11 +35,11 @@ class Migrate extends MigrateCommand
         $this->setName('migrate')
             ->setDescription('Migrate the database')
             ->setHelp('runs all available migrations, optionally up to a specific version')
-            ->addOption('--target', '-t', InputArgument::OPTIONAL, 'The version number to migrate to')
-            ->addOption('--date', '-d', InputArgument::OPTIONAL, 'The date to migrate to')
-            ->addOption('--plugin', '-p', InputArgument::OPTIONAL, 'The plugin containing the migrations')
-            ->addOption('--connection', '-c', InputArgument::OPTIONAL, 'The datasource connection to use')
-            ->addOption('--source', '-s', InputArgument::OPTIONAL, 'The folder where migrations are in');
+            ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to migrate to')
+            ->addOption('--date', '-d', InputOption::VALUE_REQUIRED, 'The date to migrate to')
+            ->addOption('--plugin', '-p', InputOption::VALUE_REQUIRED, 'The plugin containing the migrations')
+            ->addOption('--connection', '-c', InputOption::VALUE_REQUIRED, 'The datasource connection to use')
+            ->addOption('--source', '-s', InputOption::VALUE_REQUIRED, 'The folder where migrations are in');
     }
 
     /**

--- a/src/Command/Rollback.php
+++ b/src/Command/Rollback.php
@@ -16,6 +16,7 @@ use Migrations\ConfigurationTrait;
 use Phinx\Console\Command\Rollback as RollbackCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Rollback extends RollbackCommand
@@ -34,11 +35,11 @@ class Rollback extends RollbackCommand
         $this->setName('rollback')
             ->setDescription('Rollback the last or to a specific migration')
             ->setHelp('reverts the last migration, or optionally up to a specific version')
-            ->addOption('--target', '-t', InputArgument::OPTIONAL, 'The version number to rollback to')
-            ->addOption('--date', '-d', InputArgument::OPTIONAL, 'The date to migrate to')
-            ->addOption('--plugin', '-p', InputArgument::OPTIONAL, 'The plugin containing the migrations')
-            ->addOption('--connection', '-c', InputArgument::OPTIONAL, 'The datasource connection to use')
-            ->addOption('--source', '-s', InputArgument::OPTIONAL, 'The folder where migrations are in');
+            ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to rollback to')
+            ->addOption('--date', '-d', InputOption::VALUE_REQUIRED, 'The date to migrate to')
+            ->addOption('--plugin', '-p', InputOption::VALUE_REQUIRED, 'The plugin containing the migrations')
+            ->addOption('--connection', '-c', InputOption::VALUE_REQUIRED, 'The datasource connection to use')
+            ->addOption('--source', '-s', InputOption::VALUE_REQUIRED, 'The folder where migrations are in');
     }
 
     /**

--- a/src/Command/Status.php
+++ b/src/Command/Status.php
@@ -30,7 +30,12 @@ class Status extends StatusCommand
     {
         $this->setName('status')
             ->setDescription('Show migration status')
-            ->addOption('--format', '-f', InputOption::VALUE_REQUIRED, 'The output format: text or json. Defaults to text.')
+            ->addOption(
+                '--format',
+                '-f',
+                InputOption::VALUE_REQUIRED,
+                'The output format: text or json. Defaults to text.'
+            )
             ->setHelp('prints a list of all migrations, along with their current status')
             ->addOption('--plugin', '-p', InputOption::VALUE_REQUIRED, 'The plugin containing the migrations')
             ->addOption('--connection', '-c', InputOption::VALUE_REQUIRED, 'The datasource connection to use')

--- a/src/Command/Status.php
+++ b/src/Command/Status.php
@@ -15,6 +15,7 @@ use Migrations\ConfigurationTrait;
 use Phinx\Console\Command\Status as StatusCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Status extends StatusCommand
@@ -29,11 +30,11 @@ class Status extends StatusCommand
     {
         $this->setName('status')
             ->setDescription('Show migration status')
-            ->addOption('--format', '-f', InputArgument::OPTIONAL, 'The output format: text or json. Defaults to text.')
+            ->addOption('--format', '-f', InputOption::VALUE_REQUIRED, 'The output format: text or json. Defaults to text.')
             ->setHelp('prints a list of all migrations, along with their current status')
-            ->addOption('--plugin', '-p', InputArgument::OPTIONAL, 'The plugin containing the migrations')
-            ->addOption('--connection', '-c', InputArgument::OPTIONAL, 'The datasource connection to use')
-            ->addOption('--source', '-s', InputArgument::OPTIONAL, 'The folder where migrations are in');
+            ->addOption('--plugin', '-p', InputOption::VALUE_REQUIRED, 'The plugin containing the migrations')
+            ->addOption('--connection', '-c', InputOption::VALUE_REQUIRED, 'The datasource connection to use')
+            ->addOption('--source', '-s', InputOption::VALUE_REQUIRED, 'The folder where migrations are in');
     }
 
     /**

--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -49,7 +49,9 @@ class MigrationsShell extends Shell
             ->addOption('version', ['short' => 'V'])
             ->addOption('no-interaction', ['short' => 'n'])
             ->addOption('template', ['short' => 't'])
-            ->addOption('format', ['short' => 'f']);
+            ->addOption('format', ['short' => 'f'])
+            ->addOption('only', ['short' => 'o'])
+            ->addOption('exclude', ['short' => 'x']);
     }
 
     /**

--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -85,7 +85,7 @@ class MigrationSnapshotTask extends SimpleMigrationTask
         list($version, ) = explode('_', $fileName, 2);
 
 
-        $dispatchCommand = 'migrations mark_migrated ' . $version;
+        $dispatchCommand = 'migrations mark_migrated -t ' . $version . ' -o';
         if (!empty($this->params['connection'])) {
             $dispatchCommand .= ' -c ' . $this->params['connection'];
         }

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -293,7 +293,7 @@ class MarkMigratedTest extends TestCase
         $this->commandTester->execute([
             'command' => $this->command->getName(),
             '--target' => '20150724233100',
-            '--exclude' => '',
+            '--exclude' => true,
             '--connection' => 'test',
             '--source' => 'TestsMigrations'
         ]);
@@ -309,7 +309,7 @@ class MarkMigratedTest extends TestCase
         $this->commandTester->execute([
             'command' => $this->command->getName(),
             '--target' => '20150826191400',
-            '--exclude' => '',
+            '--exclude' => true,
             '--connection' => 'test',
             '--source' => 'TestsMigrations'
         ]);
@@ -332,7 +332,7 @@ class MarkMigratedTest extends TestCase
         $this->commandTester->execute([
             'command' => $this->command->getName(),
             '--target' => '20150704160610',
-            '--exclude' => '',
+            '--exclude' => true,
             '--connection' => 'test',
             '--source' => 'TestsMigrations'
         ]);
@@ -348,7 +348,7 @@ class MarkMigratedTest extends TestCase
         $this->commandTester->execute([
             'command' => $this->command->getName(),
             '--target' => '20150724233100',
-            '--only' => '',
+            '--only' => true,
             '--connection' => 'test',
             '--source' => 'TestsMigrations'
         ]);
@@ -364,7 +364,7 @@ class MarkMigratedTest extends TestCase
         $this->commandTester->execute([
             'command' => $this->command->getName(),
             '--target' => '20150826191400',
-            '--only' => '',
+            '--only' => true,
             '--connection' => 'test',
             '--source' => 'TestsMigrations'
         ]);
@@ -383,7 +383,7 @@ class MarkMigratedTest extends TestCase
         $this->commandTester->execute([
             'command' => $this->command->getName(),
             '--target' => '20150704160610',
-            '--only' => '',
+            '--only' => true,
             '--connection' => 'test',
             '--source' => 'TestsMigrations'
         ]);
@@ -422,7 +422,7 @@ class MarkMigratedTest extends TestCase
     {
         $this->commandTester->execute([
             'command' => $this->command->getName(),
-            '--exclude' => '',
+            '--exclude' => true,
             '--connection' => 'test',
             '--source' => 'TestsMigrations'
         ]);
@@ -436,7 +436,7 @@ class MarkMigratedTest extends TestCase
 
         $this->commandTester->execute([
             'command' => $this->command->getName(),
-            '--only' => '',
+            '--only' => true,
             '--connection' => 'test',
             '--source' => 'TestsMigrations'
         ]);
@@ -451,8 +451,8 @@ class MarkMigratedTest extends TestCase
         $this->commandTester->execute([
             'command' => $this->command->getName(),
             '--target' => '20150724233100',
-            '--only' => '',
-            '--exclude' => '',
+            '--only' => true,
+            '--exclude' => true,
             '--connection' => 'test',
             '--source' => 'TestsMigrations'
         ]);

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -81,8 +81,8 @@ class MigrationSnapshotTaskTest extends TestCase
             ->method('dispatchShell')
             ->with(
                 $this->logicalAnd(
-                    $this->stringContains('migrations mark_migrated'),
-                    $this->stringContains('-c test -p BogusPlugin')
+                    $this->stringContains('migrations mark_migrated -t'),
+                    $this->stringContains('-o -c test -p BogusPlugin')
                 )
             );
 


### PR DESCRIPTION
This PR has two goals :

It's a follow up to #137, I forgot a key point when adding options : they have to be added to the MigrationsShell class otherwise the shell call can't execute.
I also updated the dispatched command that was issued after a snapshot was baked so it doesn't mark all migrations as migrated.

----------

Options mode should use a ``InputOption`` constant. Flags (bool values) use a ``InputOption::VALUE_NONE`` mode and options which are expecting a value should use ``InputOption;;VALUE_REQUIRED``

Refs http://symfony.com/doc/current/components/console/introduction.html#using-command-options