### PR TITLE
ConfigurationTrait postgresql schema config bug fixed #150

### DIFF
--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -99,6 +99,12 @@ trait ConfigurationTrait
             ]
         ];
 
+        if ($adapterName === 'pgsql') {
+            if (!empty($connectionConfig['schema'])) {
+                $config['environments']['default']['schema'] = $connectionConfig['schema'];
+            }
+        }
+
         if ($adapterName === 'mysql') {
             if (!empty($connectionConfig['ssl_key']) && !empty($connectionConfig['ssl_cert'])) {
                 $config['environments']['default']['mysql_attr_ssl_key'] = $connectionConfig['ssl_key'];


### PR DESCRIPTION
ConfigurationTrait  does not take the correct values in app postgresql schema settings.