### PR TITLE
Fix to create snapshot for all tables from plugin

### DIFF
--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -207,10 +207,10 @@ class MigrationSnapshotTask extends SimpleMigrationTask
         $list = [];
         $tables = $this->findTables($pluginName);
         foreach ($tables as $num => $table) {
-            $list = $list + $this->fetchTableName($table, $pluginName);
+            $list = array_merge($list, $this->fetchTableName($table, $pluginName));
         }
 
-        return $list;
+        return array_unique($list);
     }
 
     /**


### PR DESCRIPTION
Fix to create snapshot for all tables from plugin when using --plugin and --require-table options. Now only creates snapshot for only one table from plugin