### PR TITLE
Remove the i18n table from the tables to skipped when baking a snapshot

### DIFF
--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -31,7 +31,7 @@ class MigrationSnapshotTask extends SimpleMigrationTask
      *
      * @var array
      */
-    public $skipTables = ['i18n', 'phinxlog'];
+    public $skipTables = ['phinxlog'];
 
     /**
      * Regex of Table name to skip


### PR DESCRIPTION
Refs #154 