### PR TITLE
Clear the TableRegistry after an update call

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,13 @@ no way of adding a column to an existing table with a different collation than t
 the database.
 Only MySQL and SqlServer supports this configuration key for the time being.
 
+#### Updating columns name and using Table objects
+
+If you use a CakePHP ORM Table object to manipulate values from your database along with renaming or removing a
+column, make sure you create a new instance of your Table object after the ``update()`` call. The Table object registry
+is cleared after an ``update()`` call in order to refresh the schema that is reflected and stored in the Table object
+upon Table object instantiation.
+
 #### Generating Migrations from the CLI
 
 > When using this option, you can still modify the migration before running them if so desired.

--- a/src/Table.php
+++ b/src/Table.php
@@ -12,6 +12,7 @@
 namespace Migrations;
 
 use Cake\Collection\Collection;
+use Cake\ORM\TableRegistry;
 use Phinx\Db\Adapter\SQLiteAdapter;
 use Phinx\Db\Table as BaseTable;
 
@@ -67,6 +68,19 @@ class Table extends BaseTable
         }
 
         parent::create();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * After a table update, the TableRegistry should be cleared in order to prevent issues with
+     * table schema stored in Table objects having columns that might have been renamed or removed during
+     * the update process.
+     */
+    public function update()
+    {
+        parent::update();
+        TableRegistry::clear();
     }
 
     /**


### PR DESCRIPTION
Clear the TableRegistry after an update call in order to prevent issues with the Schema stored in Table objects that could be out of sync after a column rename or deletion.
This however implies that every Table objects are needed to be recreated in order for this to have an effect.

Refs #157 