### PR TITLE
Introduce autocompletion to the Migrations Shell

### DIFF
--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -24,6 +24,17 @@ class MigrationsShell extends Shell
 {
 
     /**
+     * {@inheritDoc}
+     */
+    public $tasks = [
+        'Migrations.Create',
+        'Migrations.MarkMigrated',
+        'Migrations.Migrate',
+        'Migrations.Rollback',
+        'Migrations.Status'
+    ];
+
+    /**
      * Array of arguments to run the shell with.
      *
      * @var array
@@ -40,18 +51,9 @@ class MigrationsShell extends Shell
     public function getOptionParser()
     {
         return parent::getOptionParser()
-            ->addOption('plugin', ['short' => 'p'])
-            ->addOption('target', ['short' => 't'])
-            ->addOption('connection', ['short' => 'c'])
-            ->addOption('source', ['short' => 's'])
             ->addOption('ansi')
             ->addOption('no-ansi')
-            ->addOption('version', ['short' => 'V'])
-            ->addOption('no-interaction', ['short' => 'n'])
-            ->addOption('template', ['short' => 't'])
-            ->addOption('format', ['short' => 'f'])
-            ->addOption('only', ['short' => 'o'])
-            ->addOption('exclude', ['short' => 'x']);
+            ->addOption('no-interaction', ['short' => 'n']);
     }
 
     /**

--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -51,9 +51,18 @@ class MigrationsShell extends Shell
     public function getOptionParser()
     {
         return parent::getOptionParser()
+            ->addOption('plugin', ['short' => 'p'])
+            ->addOption('target', ['short' => 't'])
+            ->addOption('connection', ['short' => 'c'])
+            ->addOption('source', ['short' => 's'])
             ->addOption('ansi')
             ->addOption('no-ansi')
-            ->addOption('no-interaction', ['short' => 'n']);
+            ->addOption('version', ['short' => 'V'])
+            ->addOption('no-interaction', ['short' => 'n'])
+            ->addOption('template', ['short' => 't'])
+            ->addOption('format', ['short' => 'f'])
+            ->addOption('only', ['short' => 'o'])
+            ->addOption('exclude', ['short' => 'x']);
     }
 
     /**

--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -44,7 +44,10 @@ class CommandTask extends Shell
                 'short' => 's',
                 'help' => 'The name of the folder where migrations are stored',
                 'required' => false
-            ]);
+            ])
+            ->addOption('ansi')
+            ->addOption('no-ansi')
+            ->addOption('no-interaction', ['short' => 'n']);
 
         return $parser;
     }

--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Shell\Task;
+
+use Cake\Console\Shell;
+
+/**
+ * Base Task that Migrations subcommands Task class should extend.
+ * It implements the getOptionParser method that defines the common options
+ * for all subcommands.
+ */
+class CommandTask extends Shell
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser
+            ->addOption('plugin', [
+                'short' => 'p',
+                'help' => 'The plugin the command should be applied to',
+                'required' => false
+            ])
+            ->addOption('connection', [
+                'short' => 'c',
+                'help' => 'The datasource connection to use',
+                'required' => false
+            ])
+            ->addOption('source', [
+                'short' => 's',
+                'help' => 'The name of the folder where migrations are stored',
+                'required' => false
+            ]);
+
+        return $parser;
+    }
+}

--- a/src/Shell/Task/CreateTask.php
+++ b/src/Shell/Task/CreateTask.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Shell\Task;
+
+use Phinx\Console\Command\Create;
+
+/**
+ * This task class is needed in order to provide a correct autocompletion feature
+ * when using the CakePHP migrations shell plugin. It has no effect on the
+ * migrations process.
+ */
+class CreateTask extends CommandTask
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser
+            ->addArgument('name', [
+                'help' => 'What is the name of the migration?'
+            ])
+            ->addOption('template', [
+                'short' => 't',
+                'help' => 'Use an alternative template',
+                'required' => false
+            ])
+            ->addOption('class', [
+                'short' => 'l',
+                'help' => 'Use a class implementing "' . Create::CREATION_INTERFACE . '" to generate the template',
+                'required' => false
+            ]);
+
+        return $parser;
+    }
+}

--- a/src/Shell/Task/MarkMigratedTask.php
+++ b/src/Shell/Task/MarkMigratedTask.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Shell\Task;
+
+/**
+ * This task class is needed in order to provide a correct autocompletion feature
+ * when using the CakePHP migrations shell plugin. It has no effect on the
+ * migrations process.
+ */
+class MarkMigratedTask extends CommandTask
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser
+            ->addArgument('version', [
+                'help' => 'What is the version of the migration?'
+            ])
+            ->addOption('exclude', [
+                'short' => 'x',
+                'help' => 'If present it will mark migrations from beginning until the given version, excluding it',
+                'required' => false
+            ])
+            ->addOption('only', [
+                'short' => 'o',
+                'help' => 'If present it will only mark the given migration version',
+                'required' => false
+            ]);
+
+        return $parser;
+    }
+}

--- a/src/Shell/Task/MigrateTask.php
+++ b/src/Shell/Task/MigrateTask.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Shell\Task;
+
+/**
+ * This task class is needed in order to provide a correct autocompletion feature
+ * when using the CakePHP migrations shell plugin. It has no effect on the
+ * migrations process.
+ */
+class MigrateTask extends CommandTask
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser
+            ->addOption('target', [
+                'short' => 't',
+                'help' => 'The version number to migrate to',
+                'required' => false
+            ])
+            ->addOption('date', [
+                'short' => 'd',
+                'help' => 'The date to migrate to',
+                'required' => false
+            ]);
+
+        return $parser;
+    }
+}

--- a/src/Shell/Task/RollbackTask.php
+++ b/src/Shell/Task/RollbackTask.php
@@ -24,21 +24,21 @@ class RollbackTask extends CommandTask
     /**
      * {@inheritDoc}
      */
-	public function getOptionParser()
-	{
-		$parser = parent::getOptionParser();
-		$parser
-			->addOption('target', [
-				'short' => 't',
-				'help' => 'The version number to migrate to',
-				'required' => false
-			])
-			->addOption('date', [
-				'short' => 'd',
-				'help' => 'The date to migrate to',
-				'required' => false
-			]);
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser
+            ->addOption('target', [
+                'short' => 't',
+                'help' => 'The version number to migrate to',
+                'required' => false
+            ])
+            ->addOption('date', [
+                'short' => 'd',
+                'help' => 'The date to migrate to',
+                'required' => false
+            ]);
 
-		return $parser;
-	}
+        return $parser;
+    }
 }

--- a/src/Shell/Task/RollbackTask.php
+++ b/src/Shell/Task/RollbackTask.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Shell\Task;
+
+/**
+ * This task class is needed in order to provide a correct autocompletion feature
+ * when using the CakePHP migrations shell plugin. It has no effect on the
+ * migrations process.
+ */
+class RollbackTask extends CommandTask
+{
+
+    /**
+     * {@inheritDoc}
+     */
+	public function getOptionParser()
+	{
+		$parser = parent::getOptionParser();
+		$parser
+			->addOption('target', [
+				'short' => 't',
+				'help' => 'The version number to migrate to',
+				'required' => false
+			])
+			->addOption('date', [
+				'short' => 'd',
+				'help' => 'The date to migrate to',
+				'required' => false
+			]);
+
+		return $parser;
+	}
+}

--- a/src/Shell/Task/StatusTask.php
+++ b/src/Shell/Task/StatusTask.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Shell\Task;
+
+/**
+ * This task class is needed in order to provide a correct autocompletion feature
+ * when using the CakePHP migrations shell plugin. It has no effect on the
+ * migrations process.
+ */
+class StatusTask extends CommandTask
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser->addOption('format', [
+            'short' => 'f',
+            'help' => 'The output format: text or json. Defaults to text.',
+            'required' => false
+        ]);
+
+        return $parser;
+    }
+}

--- a/tests/TestCase/Shell/Task/CommandTaskTest.php
+++ b/tests/TestCase/Shell/Task/CommandTaskTest.php
@@ -12,24 +12,9 @@
 namespace Migrations\Test\TestCase\Shell\Task;
 
 use Cake\Console\ConsoleIo;
-use Cake\Console\ConsoleOutput;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
-
-/**
- * Class TestCompletionStringOutput
- *
- */
-class TestCompletionStringOutput extends ConsoleOutput
-{
-
-    public $output = '';
-
-    protected function _write($message)
-    {
-        $this->output .= $message;
-    }
-}
+use Migrations\Test\TestCase\Shell\TestCompletionStringOutput;
 
 /**
  * Class CommandTaskTest

--- a/tests/TestCase/Shell/Task/CommandTaskTest.php
+++ b/tests/TestCase/Shell/Task/CommandTaskTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Test\TestCase\Shell\Task;
+
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOutput;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Class TestCompletionStringOutput
+ *
+ */
+class TestCompletionStringOutput extends ConsoleOutput
+{
+
+    public $output = '';
+
+    protected function _write($message)
+    {
+        $this->output .= $message;
+    }
+}
+
+/**
+ * Class CommandTaskTest
+ */
+class CommandTaskTest extends TestCase
+{
+
+    /**
+     * Instance of ConsoleOutput
+     *
+     * @var \Cake\Console\ConsoleOutput
+     */
+    public $out;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->out = new TestCompletionStringOutput();
+        $io = new ConsoleIo($this->out);
+
+        $this->Shell = $this->getMock(
+            'Cake\Shell\CompletionShell',
+            ['in', '_stop', 'clear'],
+            [$io]
+        );
+
+        $this->Shell->Command = $this->getMock(
+            'Cake\Shell\Task\CommandTask',
+            ['in', '_stop', 'clear'],
+            [$io]
+        );
+    }
+
+    /**
+     * tearDown
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        unset($this->Shell);
+    }
+
+    /**
+     * Test that subcommands from the Migrations shell are correctly returned
+     * if needed with the autocompletion feature
+     *
+     * @return void
+     */
+    public function testMigrationsSubcommands()
+    {
+        $this->Shell->runCommand(['subcommands', 'Migrations.migrations']);
+        $output = $this->out->output;
+        $expected = "create mark_migrated migrate rollback status\n";
+        $this->assertTextEquals($expected, $output);
+    }
+
+    /**
+     * Test that subcommands from the Migrations shell are correctly returned
+     * if needed with the autocompletion feature
+     *
+     * @return void
+     */
+    public function testMigrationsOptionsCreate()
+    {
+        $this->Shell->runCommand(['options', 'Migrations.migrations', 'create']);
+        $output = $this->out->output;
+        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --template -t --class -l\n";
+        $this->assertTextEquals($expected, $output);
+    }
+
+    /**
+     * Test that subcommands from the Migrations shell are correctly returned
+     * if needed with the autocompletion feature
+     *
+     * @return void
+     */
+    public function testMigrationsOptionsMarkMigrated()
+    {
+        $this->Shell->runCommand(['options', 'Migrations.migrations', 'mark_migrated']);
+        $output = $this->out->output;
+        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --exclude -x --only -o\n";
+        $this->assertTextEquals($expected, $output);
+    }
+
+    /**
+     * Test that subcommands from the Migrations shell are correctly returned
+     * if needed with the autocompletion feature
+     *
+     * @return void
+     */
+    public function testMigrationsOptionsMigrate()
+    {
+        $this->Shell->runCommand(['options', 'Migrations.migrations', 'migrate']);
+        $output = $this->out->output;
+        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --target -t --date -d\n";
+        $this->assertTextEquals($expected, $output);
+    }
+
+    /**
+     * Test that subcommands from the Migrations shell are correctly returned
+     * if needed with the autocompletion feature
+     *
+     * @return void
+     */
+    public function testMigrationsOptionsRollback()
+    {
+        $this->Shell->runCommand(['options', 'Migrations.migrations', 'rollback']);
+        $output = $this->out->output;
+        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --target -t --date -d\n";
+        $this->assertTextEquals($expected, $output);
+    }
+
+    /**
+     * Test that subcommands from the Migrations shell are correctly returned
+     * if needed with the autocompletion feature
+     *
+     * @return void
+     */
+    public function testMigrationsOptionsStatus()
+    {
+        $this->Shell->runCommand(['options', 'Migrations.migrations', 'status']);
+        $output = $this->out->output;
+        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --format -f\n";
+        $this->assertTextEquals($expected, $output);
+    }
+}

--- a/tests/TestCase/Shell/Task/CommandTaskTest.php
+++ b/tests/TestCase/Shell/Task/CommandTaskTest.php
@@ -103,7 +103,8 @@ class CommandTaskTest extends TestCase
     {
         $this->Shell->runCommand(['options', 'Migrations.migrations', 'create']);
         $output = $this->out->output;
-        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --template -t --class -l\n";
+        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --ansi --no-ansi";
+        $expected .= " --no-interaction -n --template -t --class -l\n";
         $this->assertTextEquals($expected, $output);
     }
 
@@ -117,7 +118,8 @@ class CommandTaskTest extends TestCase
     {
         $this->Shell->runCommand(['options', 'Migrations.migrations', 'mark_migrated']);
         $output = $this->out->output;
-        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --exclude -x --only -o\n";
+        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --ansi --no-ansi";
+        $expected .= " --no-interaction -n --exclude -x --only -o\n";
         $this->assertTextEquals($expected, $output);
     }
 
@@ -131,7 +133,8 @@ class CommandTaskTest extends TestCase
     {
         $this->Shell->runCommand(['options', 'Migrations.migrations', 'migrate']);
         $output = $this->out->output;
-        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --target -t --date -d\n";
+        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --ansi --no-ansi";
+        $expected .= " --no-interaction -n --target -t --date -d\n";
         $this->assertTextEquals($expected, $output);
     }
 
@@ -145,7 +148,8 @@ class CommandTaskTest extends TestCase
     {
         $this->Shell->runCommand(['options', 'Migrations.migrations', 'rollback']);
         $output = $this->out->output;
-        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --target -t --date -d\n";
+        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --ansi --no-ansi";
+        $expected .= " --no-interaction -n --target -t --date -d\n";
         $this->assertTextEquals($expected, $output);
     }
 
@@ -159,7 +163,8 @@ class CommandTaskTest extends TestCase
     {
         $this->Shell->runCommand(['options', 'Migrations.migrations', 'status']);
         $output = $this->out->output;
-        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --format -f\n";
+        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --ansi --no-ansi";
+        $expected .= " --no-interaction -n --format -f\n";
         $this->assertTextEquals($expected, $output);
     }
 }

--- a/tests/TestCase/Shell/Task/CommandTaskTest.php
+++ b/tests/TestCase/Shell/Task/CommandTaskTest.php
@@ -13,6 +13,7 @@ namespace Migrations\Test\TestCase\Shell\Task;
 
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOutput;
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -50,6 +51,8 @@ class CommandTaskTest extends TestCase
      */
     public function setUp()
     {
+        $this->skipIf(version_compare(Configure::version(), '3.1.6', '<'));
+
         parent::setUp();
 
         $this->out = new TestCompletionStringOutput();

--- a/tests/TestCase/Shell/TestCompletionStringOutput.php
+++ b/tests/TestCase/Shell/TestCompletionStringOutput.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Test\TestCase\Shell;
+
+use Cake\Console\ConsoleOutput;
+
+class TestCompletionStringOutput extends ConsoleOutput
+{
+
+    public $output = '';
+
+    // @codingStandardsIgnoreStart
+    protected function _write($message)
+    {
+        // @codingStandardsIgnoreEnd
+        $this->output .= $message;
+    }
+}


### PR DESCRIPTION
In line with other improvements made to autocompletion feature with the CakePHP shell, this PR aims to introducte autocompletion to the Migrations Shell (and fix #145).

To do so, I implemented a Cake Task for each of the subcommands the migrations shell supports. This tricks the completion shell to suggest the subcommands and options specific to subcommands.

However, the options registration in the MigrationsShell still needs to be there otherwise the shell calls will trigger errors of undefined options.

**Note : build will fail** as long as the changes made to the CompletionShells will not be tagged with a new CakePHP release. So we should wait before merging.

The only downside I find to this is that it adds a few classes "just" for that. Might be too much but it is the only "quick and easy" way I found to this.