### PR TITLE
Fix snapshot decimals handling

### DIFF
--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -13,7 +13,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-$wantedOptions = array_flip(['length', 'limit', 'default', 'unsigned', 'null', 'comment', 'autoIncrement']);
+$wantedOptions = array_flip(['length', 'limit', 'default', 'unsigned', 'null', 'comment', 'autoIncrement', 'precision']);
 $tableMethod = $this->Migration->tableMethod($action);
 $columnMethod = $this->Migration->columnMethod($action);
 $indexMethod = $this->Migration->indexMethod($action);
@@ -70,6 +70,14 @@ class <%= $name %> extends AbstractMigration
                 }
                 if (empty($columnOptions['autoIncrement'])) {
                     unset($columnOptions['autoIncrement']);
+                }
+                if (empty($columnOptions['precision'])) {
+                    unset($columnOptions['precision']);
+                } else {
+                    // due to Phinx using different naming for the precision and scale to CakePHP
+                    $columnOptions['scale'] = $columnOptions['precision'];
+                    $columnOptions['precision'] = $columnOptions['limit'];
+                    unset($columnOptions['limit']);
                 }
                 echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
             %>])

--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -54,6 +54,9 @@ class <%= $name %> extends AbstractMigration
                 if (empty($columnOptions['autoIncrement'])) {
                     unset($columnOptions['autoIncrement']);
                 }
+                if (empty($columnOptions['precision'])) {
+                    unset($columnOptions['precision']);
+                }
                 echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
             %>])
             <%- endforeach;

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -261,7 +261,7 @@ class MigrationHelper extends Helper
         }
 
         if (is_numeric($value) || ctype_digit($value)) {
-            return (int)$value;
+            return (float)$value;
         }
 
         return sprintf("'%s'", addslashes($value));

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -241,8 +241,10 @@ class MigrationHelperTest extends TestCase
         $this->assertEquals('false', $this->Helper->value(false));
         $this->assertEquals(1, $this->Helper->value(1));
         $this->assertEquals(-1, $this->Helper->value(-1));
+        $this->assertEquals(1.5, $this->Helper->value(1.5));
+        $this->assertEquals(1.5, $this->Helper->value('1.5'));
         $this->assertEquals(1, $this->Helper->value('1'));
-        $this->assertInternalType('int', $this->Helper->value('1'));
+        $this->assertInternalType('float', $this->Helper->value('1'));
         $this->assertEquals("'one'", $this->Helper->value('one'));
         $this->assertEquals("'o\\\"ne'", $this->Helper->value('o"ne'));
     }


### PR DESCRIPTION
Basically adds precision to the wantedOptions array in the snapshot template, then adds sum array element juggling to make sure the options (if set) line up with the Phinx equivalents

Also changes the Migration helper `value` method to return a float rather than an integer for numerics values.

This fixes my particular use case, so I thought I'd share it.

Fixes #168 