### PR TITLE
[1.3.X] Update phinx dependency to a more suitable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ The plugin consists of a wrapper for the [phinx](http://phinx.org) migrations li
 
 Full documentation of the plugin can be found on the [CakePHP Cookbook](http://book.cakephp.org/3.0/en/migrations.html).
 
+## Special notes
+
+This is the last release of the plugin compatible with the CakePHP 3.0.X release cycle.
+Be aware that, due to a defect in our main dependency, if you use the SQLite database provider and update indexes in an existing table, the table may be dropped during migrations. The bug has been fixed for later versions of the plugin.
+Also note that if you run the test suites of this version of the plugin, it will fail.
+
 ## Installation
 
 You can install this plugin into your CakePHP application using

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     },
     "require": {
         "php": ">=5.4",
-        "robmorgan/phinx": "dev-master",
-        "cakephp/cakephp": "~3.0"
+        "robmorgan/phinx": ">=0.4.2 <0.5.0",
+        "cakephp/cakephp": "3.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "*",


### PR DESCRIPTION
In order to fix #167 and prevent users using the CakePHP 3.0.X release cycle from running into trouble when doing a ``composer update``, we should release a last compatible version for this cycle. Currently, 1.3.1 leads to problems raised in #167.
So I restored the dependency schema we had before pinning to ``dev-master`` for ``robmorgan/phinx`` but I changed the max dependency to ``0.5.0`` (I suspect there will be no more ``0.4.x`` release anymore).
If you think we should play "safe", we can edit to force it to 0.4.6 where we know it should properly work (I won't be able to edit it for a couple of days, but the diff branch is on the cakephp repo, so feel free to edit it at will).

I also updated the README with some important notes.

This should prevent any future problems with users using the 3.0.X release cycle.
After merge, a new 1.3.2 release should be made.