### PR TITLE
Fix baking a plugin snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Full documentation of the plugin can be found on the [CakePHP Cookbook](http://b
 ## Installation
 
 You can install this plugin into your CakePHP application using
-[composer](http://getcomposer.org). 
+[composer](http://getcomposer.org).
 
 Run the following command
 ```sh
@@ -123,6 +123,11 @@ automatically reversible migrations.
 
 Once again, please make sure you read [the official phinx documentation](http://docs.phinx.org/en/latest/migrations.html) to understand how migrations are created and executed in your database.
 
+Be aware that when baking a snapshot for a plugin, your plugin must implements
+model Table classes matching the database tables you want to be in the snapshot :
+only those tables will be exported. This is the only way to filter your plugin's
+tables from you app tables if you are using the same database for both.
+
 #### Usage for custom primary key id in tables
 
 To create a table called `statuses` and use a CHAR (36) for the `id` field, this requires you to turn off the id.
@@ -146,7 +151,7 @@ $table->addColumn('id', 'char', ['limit' => 36])
 #### Collations
 
 If you need to create a table with a different collation than the database default one, you can define it
-with the ``table`` method, as an option : 
+with the ``table`` method, as an option :
 
 ```php
 $table = $this

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ automatically reversible migrations.
 
 Once again, please make sure you read [the official phinx documentation](http://docs.phinx.org/en/latest/migrations.html) to understand how migrations are created and executed in your database.
 
-Be aware that when baking a snapshot for a plugin, your plugin must implements
+Be aware that when baking a snapshot for a plugin, your plugin must implement
 model Table classes matching the database tables you want to be in the snapshot :
 only those tables will be exported. This is the only way to filter your plugin's
 tables from you app tables if you are using the same database for both.

--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -121,7 +121,7 @@ class MigrationSnapshotTask extends SimpleMigrationTask
         $collection = $this->getCollection($this->connection);
         $tables = $collection->listTables();
 
-        if ($this->params['require-table'] === true) {
+        if ($this->params['require-table'] === true || $this->plugin) {
             $tableNamesInModel = $this->getTableNames($this->plugin);
 
             foreach ($tableNamesInModel as $num => $table) {

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -14,7 +14,6 @@ namespace Migrations\Test\TestCase\Shell\Task;
 use Bake\Shell\Task\BakeTemplateTask;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\StringCompareTrait;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Inflector;

--- a/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
@@ -1,0 +1,83 @@
+<?php
+use Migrations\AbstractMigration;
+
+class TestPluginBlogPgsql extends AbstractMigration
+{
+    public function up()
+    {
+        $table = $this->table('articles');
+        $table
+            ->addColumn('title', 'string', [
+                'comment' => 'Article title',
+                'default' => 'NULL::character varying',
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'category_id',
+                ]
+            )
+            ->addIndex(
+                [
+                    'product_id',
+                ]
+            )
+            ->create();
+
+        $this->table('articles')
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->addForeignKey(
+                'product_id',
+                'products',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->update();
+
+    }
+
+    public function down()
+    {
+        $this->table('articles')
+            ->dropForeignKey(
+                'category_id'
+            )
+            ->dropForeignKey(
+                'product_id'
+            );
+
+        $this->dropTable('articles');
+    }
+}

--- a/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
@@ -1,0 +1,82 @@
+<?php
+use Migrations\AbstractMigration;
+
+class TestPluginBlogSqlite extends AbstractMigration
+{
+    public function up()
+    {
+        $table = $this->table('articles');
+        $table
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'category_id',
+                ]
+            )
+            ->addIndex(
+                [
+                    'product_id',
+                ]
+            )
+            ->create();
+
+        $this->table('articles')
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->addForeignKey(
+                'product_id',
+                'products',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->update();
+
+    }
+
+    public function down()
+    {
+        $this->table('articles')
+            ->dropForeignKey(
+                'category_id'
+            )
+            ->dropForeignKey(
+                'product_id'
+            );
+
+        $this->dropTable('articles');
+    }
+}

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -1,0 +1,83 @@
+<?php
+use Migrations\AbstractMigration;
+
+class TestPluginBlog extends AbstractMigration
+{
+    public function up()
+    {
+        $table = $this->table('articles');
+        $table
+            ->addColumn('title', 'string', [
+                'comment' => 'Article title',
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'category_id',
+                ]
+            )
+            ->addIndex(
+                [
+                    'product_id',
+                ]
+            )
+            ->create();
+
+        $this->table('articles')
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->addForeignKey(
+                'product_id',
+                'products',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->update();
+
+    }
+
+    public function down()
+    {
+        $this->table('articles')
+            ->dropForeignKey(
+                'category_id'
+            )
+            ->dropForeignKey(
+                'product_id'
+            );
+
+        $this->dropTable('articles');
+    }
+}

--- a/tests/test_app/Plugin/Blog/src/Model/Entity/Article.php
+++ b/tests/test_app/Plugin/Blog/src/Model/Entity/Article.php
@@ -1,0 +1,29 @@
+<?php
+namespace Pluginapp\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * Article Entity.
+ *
+ * @property int $id
+ * @property string $title
+ * @property string $content
+ */
+class Article extends Entity
+{
+
+    /**
+     * Fields that can be mass assigned using newEntity() or patchEntity().
+     *
+     * Note that when '*' is set to true, this allows all unspecified fields to
+     * be mass assigned. For security purposes, it is advised to set '*' to false
+     * (or remove it), and explicitly make individual fields accessible as needed.
+     *
+     * @var array
+     */
+    protected $_accessible = [
+        '*' => true,
+        'id' => false,
+    ];
+}

--- a/tests/test_app/Plugin/Blog/src/Model/Table/ArticlesTable.php
+++ b/tests/test_app/Plugin/Blog/src/Model/Table/ArticlesTable.php
@@ -1,0 +1,55 @@
+<?php
+namespace Pluginapp\Model\Table;
+
+use Cake\ORM\Query;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+use Pluginapp\Model\Entity\Article;
+
+/**
+ * Articles Model
+ *
+ */
+class ArticlesTable extends Table
+{
+
+    /**
+     * Initialize method
+     *
+     * @param array $config The configuration for the Table.
+     * @return void
+     */
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $this->table('articles');
+        $this->displayField('title');
+        $this->primaryKey('id');
+
+    }
+
+    /**
+     * Default validation rules.
+     *
+     * @param \Cake\Validation\Validator $validator Validator instance.
+     * @return \Cake\Validation\Validator
+     */
+    public function validationDefault(Validator $validator)
+    {
+        $validator
+            ->add('id', 'valid', ['rule' => 'numeric'])
+            ->allowEmpty('id', 'create');
+
+        $validator
+            ->requirePresence('title', 'create')
+            ->notEmpty('title');
+
+        $validator
+            ->requirePresence('content', 'create')
+            ->notEmpty('content');
+
+        return $validator;
+    }
+}


### PR DESCRIPTION
When baking a snapshot for a plugin, the tables that will be picked to be exported are now only the ones that have table classes defined in the plugin's ``src``. Basically, if you bake a snapshot for a plugin, it will be as if you used the ``--require-table`` flag.

It is the only way I found to prevent application tables to be exported as well when baking for a plugin.

Defining Table classes in the plugin is now **mandatory** to bake a snapshot for a plugin.

Refs #172 