### PR TITLE
Add initial support for generating seed files

### DIFF
--- a/src/Shell/Task/SeedTask.php
+++ b/src/Shell/Task/SeedTask.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Shell\Task;
+
+use Bake\Shell\Task\SimpleBakeTask;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Core\Configure;
+use Cake\Core\Plugin;
+use Cake\Utility\Inflector;
+
+/**
+ * Task class for generating seed files.
+ */
+class SeedTask extends SimpleBakeTask
+{
+    /**
+     * path to Migration directory
+     *
+     * @var string
+     */
+    public $pathFragment = 'Seed/';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function name()
+    {
+        return 'seed';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fileName($name)
+    {
+        return Inflector::classify($this->args[0]) . 'Seed.php';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function template()
+    {
+        return 'Migrations.Seed/seed';
+    }
+
+    /**
+     * Get template data.
+     *
+     * @return array
+     */
+    public function templateData()
+    {
+        $namespace = Configure::read('App.namespace');
+        if ($this->plugin) {
+            $namespace = $this->_pluginNamespace($this->plugin);
+        }
+
+        $table = Inflector::tableize($this->args[0]);
+        if (!empty($this->params['table'])) {
+            $table = $this->params['table'];
+        }
+
+        return [
+            'className' => $this->BakeTemplate->viewVars['name'],
+            'namespace' => $namespace,
+            'records' => false,
+            'table' => $table,
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function bake($name)
+    {
+        $this->params['no-test'] = true;
+        return parent::bake($name);
+    }
+
+
+    /**
+     * Gets the option parser instance and configures it.
+     *
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function getOptionParser()
+    {
+        $name = ($this->plugin ? $this->plugin . '.' : '') . $this->name;
+        $parser = new ConsoleOptionParser($name);
+
+        $bakeThemes = [];
+        foreach (Plugin::loaded() as $plugin) {
+            $path = Plugin::classPath($plugin);
+            if (is_dir($path . 'Template' . DS . 'Bake')) {
+                $bakeThemes[] = $plugin;
+            }
+        }
+
+        $parser->description(
+            'Bake seed class.'
+        )->addOption('plugin', [
+            'short' => 'p',
+            'help' => 'Plugin to bake into.'
+        ])->addOption('force', [
+            'short' => 'f',
+            'boolean' => true,
+            'help' => 'Force overwriting existing files without prompting.'
+        ])->addOption('connection', [
+            'short' => 'c',
+            'default' => 'default',
+            'help' => 'The datasource connection to get data from.'
+        ])->addOption('table', [
+            'help' => 'The database table to use.'
+        ])->addOption('theme', [
+            'short' => 't',
+            'help' => 'The theme to use when baking code.',
+            'choices' => $bakeThemes
+        ])->addArgument('name', [
+            'help' => 'Name of the seed to bake. Can use Plugin.name to bake plugin models.'
+        ]);
+
+        return $parser;
+    }
+}

--- a/src/Template/Bake/Seed/seed.ctp
+++ b/src/Template/Bake/Seed/seed.ctp
@@ -1,0 +1,45 @@
+<%
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+%>
+<?php
+namespace <%= $namespace %>\Seed;
+
+use Phinx\Seed\AbstractSeed;
+
+/**
+ * <%= $name %> seed.
+ */
+class <%= $name %>Seed extends AbstractSeed
+{
+    /**
+     * Run Method.
+     *
+     * Write your database seeder using this method.
+     *
+     * More information on writing seeders is available here:
+     * http://docs.phinx.org/en/latest/seeding.html
+     */
+    public function run()
+    {
+<% if ($records): %>
+        $data = <%= $records %>;
+<% else: %>
+        $data = [];
+<% endif; %>
+
+        $table = $this->table('<%= $table %>');
+        $table->insert($data)->save();
+    }
+}


### PR DESCRIPTION
This is part one of the necessary work to add support for phinx seeds. Our next step is to add support to the migrations runners to actually apply seeds to a database.

Opening PR to continue discussion based on running code :)

Refs #19.