### PR TITLE
Better default ID than one in Phinx

### DIFF
--- a/src/AbstractMigration.php
+++ b/src/AbstractMigration.php
@@ -31,12 +31,19 @@ class AbstractMigration extends BaseAbstractMigration
     /**
      * {@inheritdoc}
      */
-    public function table($tableName, $options = array())
+    public function table($tableName, $options = [])
     {
-        if ($this->autoId === false) {
-            $options['id'] = false;
+        $options += ['primary_key' => 'id'];
+        $table = new Table($tableName, ['id' => false] + $options, $this->getAdapter());
+
+        if ($this->autoId === true && (!array_key_exists('id', $options) || $options['id'])) {
+            $table->addColumn($options['primary_key'], 'integer', [
+                'null' => false,
+                'signed' => false,
+                'identity' => true,
+            ]);
         }
 
-        return new Table($tableName, $options, $this->getAdapter());
+        return $table;
     }
 }


### PR DESCRIPTION
Phinx creates by default an ID that is `signed`, whereas IDs
in general should be `unsigned`.