### PR TITLE
Update the Migrations class to support the seeding feature

### DIFF
--- a/src/CakeManager.php
+++ b/src/CakeManager.php
@@ -31,6 +31,16 @@ class CakeManager extends Manager
     }
 
     /**
+     * Reset the seeds stored in the object
+     *
+     * @return void
+     */
+    public function resetSeeds()
+    {
+        $this->seeds = null;
+    }
+
+    /**
      * Prints the specified environment's migration status.
      *
      * @param string $environment

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -61,7 +61,7 @@ trait ConfigurationTrait
 
         $source = $this->input->getOption('source');
         if ($source) {
-            if ($this instanceof Seed) {
+            if ($this instanceof Seed || ($this instanceof Migrations && $this->getCommand() === 'seed')) {
                 $seedsFolder = $source;
             } else {
                 $migrationsFolder = $source;

--- a/tests/TestCase/Command/SeedTest.php
+++ b/tests/TestCase/Command/SeedTest.php
@@ -155,7 +155,7 @@ class SeedTest extends TestCase
             ->execute()->fetchAll('assoc');
         $expected = [
             [
-                'id' => '1',
+                'id' => '2',
                 'number' => '5',
                 'radix' => '10'
             ]

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -427,6 +427,143 @@ class MigrationsTest extends TestCase
     }
 
     /**
+     * Tests seeding the database
+     *
+     * @return void
+     */
+    public function testSeed()
+    {
+        $this->migrations->migrate();
+        $seed = $this->migrations->seed(['source' => 'Seeds']);
+        $this->assertTrue($seed);
+
+        $result = $this->Connection->newQuery()
+            ->select(['*'])
+            ->from('numbers')
+            ->execute()->fetchAll('assoc');
+        $expected = [
+            [
+                'id' => '1',
+                'number' => '10',
+                'radix' => '10'
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+
+        $seed = $this->migrations->seed(['source' => 'Seeds']);
+        $this->assertTrue($seed);
+        $result = $this->Connection->newQuery()
+            ->select(['*'])
+            ->from('numbers')
+            ->execute()->fetchAll('assoc');
+        $expected = [
+            [
+                'id' => '1',
+                'number' => '10',
+                'radix' => '10'
+            ],
+            [
+                'id' => '2',
+                'number' => '10',
+                'radix' => '10'
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+
+        $seed = $this->migrations->seed(['source' => 'AltSeeds']);
+        $this->assertTrue($seed);
+        $result = $this->Connection->newQuery()
+            ->select(['*'])
+            ->from('numbers')
+            ->execute()->fetchAll('assoc');
+        $expected = [
+            [
+                'id' => '1',
+                'number' => '10',
+                'radix' => '10'
+            ],
+            [
+                'id' => '2',
+                'number' => '10',
+                'radix' => '10'
+            ],
+            [
+                'id' => '3',
+                'number' => '2',
+                'radix' => '10'
+            ],
+            [
+                'id' => '4',
+                'number' => '5',
+                'radix' => '10'
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+        $this->migrations->rollback(['target' => 0]);
+    }
+
+    /**
+     * Tests seeding the database with seeder
+     *
+     * @return void
+     */
+    public function testSeedOneSeeder()
+    {
+        $this->migrations->migrate();
+
+        $seed = $this->migrations->seed(['source' => 'AltSeeds', 'seed' => 'AnotherNumbersSeed']);
+        $this->assertTrue($seed);
+        $result = $this->Connection->newQuery()
+            ->select(['*'])
+            ->from('numbers')
+            ->execute()->fetchAll('assoc');
+
+        $expected = [
+            [
+                'id' => '1',
+                'number' => '2',
+                'radix' => '10'
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+
+        $seed = $this->migrations->seed(['source' => 'AltSeeds', 'seed' => 'NumbersAltSeed']);
+        $this->assertTrue($seed);
+        $result = $this->Connection->newQuery()
+            ->select(['*'])
+            ->from('numbers')
+            ->execute()->fetchAll('assoc');
+
+        $expected = [
+            [
+                'id' => '1',
+                'number' => '2',
+                'radix' => '10'
+            ],
+            [
+                'id' => '2',
+                'number' => '5',
+                'radix' => '10'
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+
+        $this->migrations->rollback(['target' => 0]);
+    }
+
+    /**
+     * Tests that requesting a unexistant seed throws an exception
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The seed class "DerpSeed" does not exist
+     * @return void
+     */
+    public function testSeedWrongSeed()
+    {
+        $this->migrations->seed(['source' => 'AltSeeds', 'seed' => 'DerpSeed']);
+    }
+
+    /**
      * Tests migrating the baked snapshots
      *
      * @dataProvider migrationsProvider

--- a/tests/test_app/config/AltSeeds/AnotherNumbersSeed.php
+++ b/tests/test_app/config/AltSeeds/AnotherNumbersSeed.php
@@ -4,7 +4,7 @@ use Phinx\Seed\AbstractSeed;
 /**
  * NumbersSeed seed.
  */
-class NumbersSeed extends AbstractSeed
+class AnotherNumbersSeed extends AbstractSeed
 {
     /**
      * Run Method.
@@ -18,7 +18,7 @@ class NumbersSeed extends AbstractSeed
     {
         $data = [
             [
-                'number' => '10',
+                'number' => '2',
                 'radix' => '10'
             ]
         ];

--- a/tests/test_app/config/AltSeeds/NumbersAltSeed.php
+++ b/tests/test_app/config/AltSeeds/NumbersAltSeed.php
@@ -18,7 +18,6 @@ class NumbersAltSeed extends AbstractSeed
     {
         $data = [
             [
-                'id' => '1',
                 'number' => '5',
                 'radix' => '10'
             ]


### PR DESCRIPTION
This gives the ability to run seed from a non-shell context, using the ``Migrations\Migrations`` class.

Follow up to #179 and #181 