### PR TITLE
Migrations `markMigrated()` update (non-shell)

### DIFF
--- a/src/CakeAdapter.php
+++ b/src/CakeAdapter.php
@@ -12,6 +12,7 @@
 namespace Migrations;
 
 use Cake\Database\Connection;
+use PDO;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table;
 use Phinx\Db\Table\Column;
@@ -52,6 +53,10 @@ class CakeAdapter implements AdapterInterface
         $this->adapter = $adapter;
         $this->connection = $connection;
         $pdo = $adapter->getConnection();
+
+        if ($pdo->getAttribute(PDO::ATTR_ERRMODE) !== PDO::ERRMODE_EXCEPTION) {
+            $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        }
         $connection->driver()->connection($pdo);
     }
 

--- a/src/CakeManager.php
+++ b/src/CakeManager.php
@@ -189,6 +189,8 @@ class CakeManager extends Manager
     /**
      * Decides which versions it should mark as migrated
      *
+     * @param \Symfony\Component\Console\Input\InputInterface $input Input interface from which argument and options
+     * will be extracted to determine which versions to be marked as migrated
      * @return array Array of versions that should be marked as migrated
      * @throws \InvalidArgumentException If the `--exclude` or `--only` options are used without `--target`
      * or version not found
@@ -232,6 +234,8 @@ class CakeManager extends Manager
      *
      * @param string $path Path where to look for migrations
      * @param array $versions Versions which should be marked
+     * @param \Symfony\Component\Console\Output\OutputInterface $output OutputInterface used to store
+     * the command output
      * @return void
      */
     public function markVersionsAsMigrated($path, $versions, $output)

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -193,20 +193,28 @@ class Migrations
      *
      * @return bool Success
      */
-    public function markMigrated($version, $options = [])
+    public function markMigrated($version = null, $options = [])
     {
         $this->setCommand('mark_migrated');
-        $input = $this->getInput('MarkMigrated', ['version' => $version], $options);
-        $params = [$version];
 
-        $isMigrated = $this->run('isMigrated', $params, $input);
-        if ($isMigrated) {
-            return true;
+        if (isset($options['target']) &&
+            isset($options['exclude']) &&
+            isset($options['only'])
+        ) {
+            $exceptionMessage = 'You should use `exclude` OR `only` (not both) along with a `target` argument';
+            throw new \InvalidArgumentException($exceptionMessage);
         }
 
-        $params[] = $this->getConfig()->getMigrationPath();
+        $input = $this->getInput('MarkMigrated', ['version' => $version], $options);
+        $this->setInput($input);
 
-        $this->run('markMigrated', $params, $input);
+        $params = [
+            $this->getConfig()->getMigrationPath(),
+            $this->getManager()->getVersionsToMark($input),
+            $this->output
+        ];
+
+        $this->run('markVersionsAsMigrated', $params, $input);
         return true;
     }
 

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -187,6 +187,15 @@ class MigrationsTest extends TestCase
         $this->assertEquals($expectedStatus, $status);
     }
 
+//    public function testMarkMigrated()
+//    {
+//        $status = $this->migrations->status();
+//        $markMigrated = $this->migrations->markMigrated();
+//        debug($markMigrated);
+//        $status = $this->migrations->status();
+//        debug($status);
+//    }
+
     /**
      * Tests that migrate returns false in case of error
      * and can return a error message


### PR DESCRIPTION
This allows the ``\Migrations\Migrations::markMigrated()`` to work as the command now works since the changes introducted in #137 

I had to swap methods from the ``\Migrations\Command\MarkMigrated`` class to the Manager in order to get the correct informations to adapt the ``\Migrations\Migrations::markMigrated()`` method.
This also fixed tests that were passing but for the wrong reasons. An exception was indeed thrown but too early.

The part where the PDO error mode is now set is because Phinx does not set it and for some reasons that still eludes me, the PDO Sqlite driver was not throwing exception when queries could not be executed or prepared. Now it does.
For instance, before that, you could set a migrations with a ``dropTable()`` to a table that does not exist and SQLite would not throw an exception and phinx was like "Everything's okay, migrations has been migrated !" which is, for obvious reasons, really wrong, since internally, SQLite was getting an error.

Refs #183 