### PR TITLE
Fix the way indexes are added when baking a snapshot

### DIFF
--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -13,6 +13,8 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
+use Cake\Database\Schema\Table;
+
 $wantedOptions = array_flip(['length', 'limit', 'default', 'unsigned', 'null', 'comment', 'autoIncrement', 'precision']);
 $tableMethod = $this->Migration->tableMethod($action);
 $columnMethod = $this->Migration->columnMethod($action);
@@ -91,7 +93,7 @@ class <%= $name %> extends AbstractMigration
                 $constraints[$table] = $tableConstraints;
 
                 foreach ($constraints[$table] as $name => $constraint):
-                    if ($constraint['type'] !== 'unique'):
+                    if ($constraint['type'] === Table::CONSTRAINT_FOREIGN):
                         $foreignKeys[] = $constraint['columns'];
                     endif;
                     if ($constraint['columns'] !== $primaryKeysColumns): %>
@@ -110,13 +112,13 @@ class <%= $name %> extends AbstractMigration
                 sort($foreignKeys);
                 $indexColumns = $index['columns'];
                 sort($indexColumns);
-                if (in_array($foreignKeys, $indexColumns)):
+                if (!in_array($indexColumns, $foreignKeys)):
                 %>
-                ->addIndex(
-                    [<%
-                        echo $this->Migration->stringifyList($index['columns'], ['indent' => 5]);
-                    %>]
-                )
+            ->addIndex(
+                [<%
+                    echo $this->Migration->stringifyList($index['columns'], ['indent' => 5]);
+                %>]
+            )
             <%- endif;
             endforeach; %>
             -><%= $tableMethod %>();

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -34,6 +34,12 @@ class ArticlesFixture extends TestFixture
         'product_id' => ['type' => 'integer', 'length' => 11],
         'created' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],
+        '_indexes' => [
+            'title_idx' => [
+                'type' => 'index',
+                'columns' => ['title']
+            ]
+        ],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
             'category_article_idx' => [

--- a/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
@@ -53,6 +53,11 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
                     'product_id',
                 ]
             )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
             ->create();
 
         $table = $this->table('categories');

--- a/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
@@ -43,6 +43,11 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                     'product_id',
                 ]
             )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
             ->create();
 
         $table = $this->table('categories');

--- a/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
@@ -43,6 +43,11 @@ class TestPluginBlogPgsql extends AbstractMigration
                     'product_id',
                 ]
             )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
             ->create();
 
         $this->table('articles')

--- a/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
@@ -52,6 +52,11 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
                     'product_id',
                 ]
             )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
             ->create();
 
         $table = $this->table('categories');

--- a/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
@@ -42,6 +42,11 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
                     'product_id',
                 ]
             )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
             ->create();
 
         $table = $this->table('categories');

--- a/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
@@ -42,6 +42,11 @@ class TestPluginBlogSqlite extends AbstractMigration
                     'product_id',
                 ]
             )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
             ->create();
 
         $this->table('articles')

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -53,6 +53,11 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
                     'product_id',
                 ]
             )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
             ->create();
 
         $table = $this->table('categories');

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -43,6 +43,11 @@ class TestNotEmptySnapshot extends AbstractMigration
                     'product_id',
                 ]
             )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
             ->create();
 
         $table = $this->table('categories');

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -43,6 +43,11 @@ class TestPluginBlog extends AbstractMigration
                     'product_id',
                 ]
             )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
             ->create();
 
         $this->table('articles')


### PR DESCRIPTION
If you had indexes (not unique) defined in your table schema not linked to a FK, those indexes were not added to the snapshot.