### PR TITLE
Include the "unsigned" attribute in snapshot

### DIFF
--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -15,11 +15,16 @@
 
 use Cake\Database\Schema\Table;
 
-$wantedOptions = array_flip(['length', 'limit', 'default', 'unsigned', 'null', 'comment', 'autoIncrement', 'precision']);
+$wantedOptions = array_flip(['length', 'limit', 'default', 'signed', 'null', 'comment', 'autoIncrement', 'precision']);
 $tableMethod = $this->Migration->tableMethod($action);
 $columnMethod = $this->Migration->columnMethod($action);
 $indexMethod = $this->Migration->indexMethod($action);
 $constraints = $foreignKeys = $dropForeignKeys = [];
+$hasUnsignedPk = $this->Migration->hasUnsignedPrimaryKey($tables);
+
+if ($autoId && $hasUnsignedPk) {
+    $autoId = false;
+}
 %>
 <?php
 use Migrations\AbstractMigration;
@@ -59,6 +64,9 @@ class <%= $name %> extends AbstractMigration
                 if (empty($columnOptions['precision'])) {
                     unset($columnOptions['precision']);
                 }
+                if (isset($columnOptions['signed']) && $columnOptions['signed'] === true) {
+                    unset($columnOptions['signed']);
+                }
                 echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
             %>])
             <%- endforeach;
@@ -75,6 +83,9 @@ class <%= $name %> extends AbstractMigration
                 }
                 if (empty($columnOptions['autoIncrement'])) {
                     unset($columnOptions['autoIncrement']);
+                }
+                if (isset($columnOptions['signed']) && $columnOptions['signed'] === true) {
+                    unset($columnOptions['signed']);
                 }
                 if (empty($columnOptions['precision'])) {
                     unset($columnOptions['precision']);

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -218,6 +218,31 @@ class MigrationHelper extends Helper
     }
 
     /**
+     * Returns whether the $tables list given as arguments contains primary keys
+     * unsigned.
+     *
+     * @param array $tables List of tables to check
+     * @return bool
+     */
+    public function hasUnsignedPrimaryKey($tables)
+    {
+        foreach ($tables as $table) {
+            $collection = $this->config('collection');
+            $tableSchema = $collection->describe($table);
+            $tablePrimaryKeys = $tableSchema->primaryKey();
+
+            foreach ($tablePrimaryKeys as $primaryKey) {
+                $column = $tableSchema->column($primaryKey);
+                if (isset($column['unsigned']) && $column['unsigned'] === true) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Returns the primary key columns name for a given table
      *
      * @param string $table Name of the table ot retrieve primary key for

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -32,6 +32,7 @@ class ArticlesFixture extends TestFixture
         'title' => ['type' => 'string', 'null' => true, 'length' => 255, 'comment' => 'Article title'],
         'category_id' => ['type' => 'integer', 'length' => 11],
         'product_id' => ['type' => 'integer', 'length' => 11],
+        'counter' => ['type' => 'integer', 'length' => 11, 'unsigned' => true],
         'created' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         '_indexes' => [

--- a/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
@@ -33,6 +33,11 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
                 'limit' => 10,
                 'null' => true,
             ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,

--- a/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
@@ -23,6 +23,11 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                 'limit' => 10,
                 'null' => true,
             ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,

--- a/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
@@ -23,6 +23,11 @@ class TestPluginBlogPgsql extends AbstractMigration
                 'limit' => 10,
                 'null' => true,
             ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,
@@ -85,6 +90,20 @@ class TestPluginBlogPgsql extends AbstractMigration
             )
             ->create();
 
+        $table = $this->table('parts');
+        $table
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('number', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
+            ->create();
+
         $this->table('articles')
             ->addForeignKey(
                 'category_id',
@@ -120,5 +139,6 @@ class TestPluginBlogPgsql extends AbstractMigration
 
         $this->dropTable('articles');
         $this->dropTable('categories');
+        $this->dropTable('parts');
     }
 }

--- a/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
@@ -32,6 +32,12 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+                'signed' => false,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,

--- a/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
@@ -22,6 +22,12 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+                'signed' => false,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,

--- a/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
@@ -22,6 +22,12 @@ class TestPluginBlogSqlite extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+                'signed' => false,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,
@@ -84,6 +90,21 @@ class TestPluginBlogSqlite extends AbstractMigration
             )
             ->create();
 
+        $table = $this->table('parts');
+        $table
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('number', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->create();
+
         $this->table('articles')
             ->addForeignKey(
                 'category_id',
@@ -119,5 +140,6 @@ class TestPluginBlogSqlite extends AbstractMigration
 
         $this->dropTable('articles');
         $this->dropTable('categories');
+        $this->dropTable('parts');
     }
 }

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -33,6 +33,12 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+                'signed' => false,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -23,6 +23,12 @@ class TestNotEmptySnapshot extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+                'signed' => false,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -3,10 +3,20 @@ use Migrations\AbstractMigration;
 
 class TestPluginBlog extends AbstractMigration
 {
+
+    public $autoId = false;
+
     public function up()
     {
         $table = $this->table('articles');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('title', 'string', [
                 'comment' => 'Article title',
                 'default' => null,
@@ -22,6 +32,12 @@ class TestPluginBlog extends AbstractMigration
                 'default' => null,
                 'limit' => 11,
                 'null' => true,
+            ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+                'signed' => false,
             ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
@@ -52,6 +68,13 @@ class TestPluginBlog extends AbstractMigration
 
         $table = $this->table('categories');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
                 'limit' => 11,
@@ -83,6 +106,29 @@ class TestPluginBlog extends AbstractMigration
                 ],
                 ['unique' => true]
             )
+            ->create();
+
+        $table = $this->table('parts');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('number', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+                'signed' => false,
+            ])
             ->create();
 
         $this->table('articles')
@@ -120,5 +166,6 @@ class TestPluginBlog extends AbstractMigration
 
         $this->dropTable('articles');
         $this->dropTable('categories');
+        $this->dropTable('parts');
     }
 }

--- a/tests/test_app/Plugin/TestBlog/src/Model/Table/PartsTable.php
+++ b/tests/test_app/Plugin/TestBlog/src/Model/Table/PartsTable.php
@@ -1,0 +1,12 @@
+<?php
+namespace TestBlog\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * Articles Model
+ *
+ */
+class PartsTable extends Table
+{
+}


### PR DESCRIPTION
This change will not have any effect on Postgres, which does not support signed integer.
Support for SQLite is limited to non-primary keys integers, as SQLite does not support integer unsigned primary keys.
MySQL support unsigned for both integer primary keys and simple integer.

This explains the differences between the comparisons files for each db vendors.

Refs #197 