### PR TITLE
Disable table metadata caching mechanism

### DIFF
--- a/src/CakeAdapter.php
+++ b/src/CakeAdapter.php
@@ -57,6 +57,7 @@ class CakeAdapter implements AdapterInterface
         if ($pdo->getAttribute(PDO::ATTR_ERRMODE) !== PDO::ERRMODE_EXCEPTION) {
             $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         }
+        $connection->cacheMetadata(false);
         $connection->driver()->connection($pdo);
     }
 

--- a/tests/ExampleCommand.php
+++ b/tests/ExampleCommand.php
@@ -11,9 +11,9 @@
  */
 namespace Migrations\Test;
 
-use Migrations\Command\Create;
+use Migrations\Command\Status;
 
-class ExampleCommand extends Create
+class ExampleCommand extends Status
 {
 
 }

--- a/tests/TestCase/ConfigurationTraitTest.php
+++ b/tests/TestCase/ConfigurationTraitTest.php
@@ -14,6 +14,7 @@ namespace Migrations\Test;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
 
 /**
  * Tests the ConfigurationTrait
@@ -109,6 +110,25 @@ class ConfigurationTraitTest extends TestCase
         $this->assertEquals('/certs/my_cert', $environment['mysql_attr_ssl_ca']);
         $this->assertEquals('ssl_key_value', $environment['mysql_attr_ssl_key']);
         $this->assertEquals('ssl_cert_value', $environment['mysql_attr_ssl_cert']);
+    }
+
+    /**
+     * Tests that the when the Adapter is built, the Connection cache metadata
+     * feature is turned off to prevent "unknown column" errors when adding a column
+     * then adding data to that column
+     *
+     * @return void
+     */
+    public function testCacheMetadataDisabled()
+    {
+        $input = new ArrayInput([], $this->command->getDefinition());
+        $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+        $this->command->setInput($input);
+
+        $input->setOption('connection', 'test');
+        $this->command->bootstrap($input, $output);
+        $config = ConnectionManager::get('test')->config();
+        $this->assertFalse($config['cacheMetadata']);
     }
 
     /**


### PR DESCRIPTION
If the Schema metadata are generated and put in the cache and a column is added to a table, when doing a data insertion or update, it can results in error because the new column is not in the schema (because metadata are fetched from the cache).
This change completely disables the cache metadata feature.

Refs #199 