### PR TITLE
Lock the phinx dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     },
     "require": {
         "php": ">=5.4",
-        "robmorgan/phinx": "~0.5.0",
-        "cakephp/cakephp": "~3.1 || 3.2.*"
+        "robmorgan/phinx": "0.5.1",
+        "cakephp/cakephp": "~3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "*",


### PR DESCRIPTION
This should prevent errors when a new version of phinx is released (which happens every single time).
This way we ensure the integrity of the plugin and can bump up the version of the dependency when we implemented what's new in phinx.

When this will be merged, a new release should be made immediately.

Refs #202 