### PR TITLE
Add support for phinx 0.5.2 new features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,17 @@ matrix:
       env: DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
 
     - php: 5.6
+      dist: trusty
+      sudo: required
+      env: DB=mysql db_dsn='mysql://root@0.0.0.0/cakephp_test' DBV=56
+      addons:
+        apt:
+          packages:
+          - mysql-server-5.6
+          - mysql-client-core-5.6
+          - mysql-client-5.6
+
+    - php: 5.6
       env: DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
       
     - php: 7.0
@@ -57,7 +68,7 @@ before_script:
   - sh -c "if [ '$PREFER_LOWEST' != '1' ]; then composer install --prefer-source --no-interaction; fi"
   - sh -c "if [ '$PREFER_LOWEST' = '1' ]; then composer update --prefer-source --no-interaction --prefer-lowest --prefer-stable; fi"
 
-  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
+  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test;'; fi"
 
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
 

--- a/src/Command/Status.php
+++ b/src/Command/Status.php
@@ -71,7 +71,7 @@ class Status extends StatusCommand
 
         switch ($format) {
             case 'json':
-                $output->writeln($migrations);
+                $this->getManager()->getOutput()->writeln($migrations);
                 break;
             default:
                 $this->display($migrations);
@@ -96,14 +96,21 @@ class Status extends StatusCommand
 
             foreach ($migrations as $migration) {
                 $status = $migration['status'] === 'up' ? '     <info>up</info> ' : '   <error>down</error> ';
+                $maxNameLength = $this->getManager()->maxNameLength;
                 $name = $migration['name'] !== false ?
-                    ' <comment>' . $migration['name'] . ' </comment>' :
+                    ' <comment>' . str_pad($migration['name'], $maxNameLength, ' ') . ' </comment>' :
                     ' <error>** MISSING **</error>';
+
+                $missingComment = '';
+                if (!empty($migration['missing'])) {
+                    $missingComment = ' <error>** MISSING **</error>';
+                }
 
                 $output->writeln(
                     $status
                     . sprintf(' %14.0f ', $migration['id'])
                     . $name
+                    . $missingComment
                 );
             }
 

--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -139,6 +139,8 @@ class MigrationSnapshotTask extends SimpleMigrationTask
             }
         }
 
+        sort($tables, SORT_NATURAL);
+
         $autoId = true;
         if (isset($this->params['disable-autoid'])) {
             $autoId = !$this->params['disable-autoid'];

--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -128,7 +128,11 @@ class <%= $name %> extends AbstractMigration
             ->addIndex(
                 [<%
                     echo $this->Migration->stringifyList($index['columns'], ['indent' => 5]);
-                %>]
+                %>]<% echo ($index['type'] === 'fulltext') ? ',' : ''; %>
+
+                <%- if ($index['type'] === 'fulltext'): %>
+                ['type' => 'fulltext']
+                <%- endif; %>
             )
             <%- endif;
             endforeach; %>

--- a/tests/Fixture/ProductsFixture.php
+++ b/tests/Fixture/ProductsFixture.php
@@ -13,7 +13,10 @@
  */
 namespace Migrations\Test\Fixture;
 
+use Cake\Database\Driver\Mysql;
+use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\TestFixture;
+use PDO;
 
 /**
  * Class ProductsFixture
@@ -34,6 +37,12 @@ class ProductsFixture extends TestFixture
         'category_id' => ['type' => 'integer', 'length' => 11],
         'created' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],
+        '_indexes' => [
+            'title_idx_ft' => [
+                'type' => 'index',
+                'columns' => ['title']
+            ]
+        ],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
             'products_unique_slug' => ['type' => 'unique', 'columns' => ['slug']],
@@ -47,4 +56,22 @@ class ProductsFixture extends TestFixture
             ]
         ]
     ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        $connection = ConnectionManager::get($this->connection());
+        $driver = $connection->driver();
+
+        if ($driver instanceof Mysql) {
+            $dbv = getenv('DBV');
+            if ($dbv === '56') {
+                $this->fields['_indexes']['title_idx_ft']['type'] = 'fulltext';
+            }
+        }
+
+        parent::init();
+    }
 }

--- a/tests/TestCase/Command/StatusTest.php
+++ b/tests/TestCase/Command/StatusTest.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Test\Command;
+
+use Cake\Database\Schema\Collection;
+use Cake\Datasource\ConnectionManager;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Migrations\CakeManager;
+use Migrations\Migrations;
+use Migrations\MigrationsDispatcher;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * MarkMigratedTest class
+ */
+class StatusTest extends TestCase
+{
+
+    /**
+     * Instance of a Symfony Command object
+     *
+     * @var \Symfony\Component\Console\Command\Command
+     */
+    protected $command;
+
+    /**
+     * Instance of a Phinx Config object
+     *
+     * @var \Phinx\Config\Config
+     */
+    protected $config = [];
+
+    /**
+     * Instance of a Cake Connection object
+     *
+     * @var \Cake\Database\Connection
+     */
+    protected $Connection;
+
+    /**
+     * Instance of a CommandTester object
+     *
+     * @var \Symfony\Component\Console\Tester\CommandTester
+     */
+    protected $commandTester;
+
+    /**
+     * Instance of a StreamOutput object.
+     * It will store the output from the CommandTester
+     *
+     * @var \Symfony\Component\Console\Output\StreamOutput
+     */
+    protected $streamOutput;
+
+    /**
+     * setup method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->Connection = ConnectionManager::get('test');
+        $this->Connection->execute('DROP TABLE IF EXISTS phinxlog');
+        $this->Connection->execute('DROP TABLE IF EXISTS numbers');
+
+        $application = new MigrationsDispatcher('testing');
+        $this->command = $application->find('status');
+        $this->streamOutput = new StreamOutput(fopen('php://memory', 'w', false));
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->Connection->execute('DROP TABLE IF EXISTS phinxlog');
+        $this->Connection->execute('DROP TABLE IF EXISTS numbers');
+        unset($this->Connection, $this->command, $this->streamOutput);
+    }
+
+    /**
+     * Test executing the "status" command
+     *
+     * @return void
+     */
+    public function testExecute()
+    {
+        $params = [
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations'
+        ];
+        $commandTester = $this->getCommandTester($params);
+        $commandTester->execute(['command' => $this->command->getName()] + $params);
+
+        $display = $this->getDisplayFromOutput();
+        $this->assertTextContains('down  20150704160200  CreateNumbersTable', $display);
+        $this->assertTextContains('down  20150724233100  UpdateNumbersTable', $display);
+        $this->assertTextContains('down  20150826191400  CreateLettersTable', $display);
+    }
+
+    /**
+     * Test executing the "status" command with the JSON option
+     *
+     * @return void
+     */
+    public function testExecuteJson()
+    {
+        $params = [
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+            '--format' => 'json'
+        ];
+        $commandTester = $this->getCommandTester($params);
+        $commandTester->execute(['command' => $this->command->getName()] + $params);
+        $display = $this->getDisplayFromOutput();
+
+        $expected = '{"status":"down","id":"20150704160200","name":"CreateNumbersTable"},'
+            . '{"status":"down","id":"20150724233100","name":"UpdateNumbersTable"},'
+            . '{"status":"down","id":"20150826191400","name":"CreateLettersTable"}';
+
+        $this->assertTextContains($expected, $display);
+    }
+
+    /**
+     * Test executing the "status" command with the migrated migrations
+     *
+     * @return void
+     */
+    public function testExecuteWithMigrated()
+    {
+        $params = [
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations'
+        ];
+        $this->getCommandTester($params);
+        $migrations = $this->getMigrations();
+        $migrations->migrate();
+
+        $params = [
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations'
+        ];
+        $commandTester = $this->getCommandTester($params);
+        $commandTester->execute(['command' => $this->command->getName()] + $params);
+
+        $display = $this->getDisplayFromOutput();
+        $this->assertTextContains('up  20150704160200  CreateNumbersTable', $display);
+        $this->assertTextContains('up  20150724233100  UpdateNumbersTable', $display);
+        $this->assertTextContains('up  20150826191400  CreateLettersTable', $display);
+
+        $migrations->rollback(['target' => 0]);
+    }
+
+    /**
+     * Test executing the "status" command with inconsistency in the migrations files
+     *
+     * @return void
+     */
+    public function testExecuteWithInconsistency()
+    {
+        $params = [
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations'
+        ];
+        $this->getCommandTester($params);
+        $migrations = $this->getMigrations();
+        $migrations->migrate();
+
+        $origin = $migrations->getConfig()->getMigrationPath() . DS . '20150724233100_update_numbers_table.php';
+        $destination = $migrations->getConfig()->getMigrationPath() . DS . '_20150724233100_update_numbers_table.php';
+        rename($origin, $destination);
+
+        $params = [
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations'
+        ];
+        $commandTester = $this->getCommandTester($params);
+        $commandTester->execute(['command' => $this->command->getName()] + $params);
+
+        $display = $this->getDisplayFromOutput();
+        $this->assertTextContains('up  20150704160200  CreateNumbersTable', $display);
+        $this->assertTextContains('up  20150724233100  UpdateNumbersTable  ** MISSING **', $display);
+        $this->assertTextContains('up  20150826191400  CreateLettersTable', $display);
+
+        rename($destination, $origin);
+
+        $migrations->rollback(['target' => 0]);
+    }
+
+    /**
+     * Gets a pre-configured of a CommandTester object that is initialized for each
+     * test methods. This is needed in order to define the same PDO connection resource
+     * between every objects needed during the tests.
+     * This is mandatory for the SQLite database vendor, so phinx objects interacting
+     * with the database have the same connection resource as CakePHP objects.
+     *
+     * @return \Symfony\Component\Console\Tester\CommandTester
+     */
+    protected function getCommandTester($params)
+    {
+        $input = new ArrayInput($params, $this->command->getDefinition());
+        $this->command->setInput($input);
+        $manager = new CakeManager($this->command->getConfig(), $this->streamOutput);
+        $manager->getEnvironment('default')->getAdapter()->setConnection($this->Connection->driver()->connection());
+        $this->command->setManager($manager);
+        $commandTester = new CommandTester($this->command);
+
+        return $commandTester;
+    }
+
+    /**
+     * Gets a Migrations object in order to easily create and drop tables during the
+     * tests
+     *
+     * @return \Migrations\Migrations
+     */
+    protected function getMigrations()
+    {
+        $params = [
+            'connection' => 'test',
+            'source' => 'TestsMigrations'
+        ];
+        $migrations = new Migrations($params);
+        $migrations
+            ->getManager($this->command->getConfig())
+            ->getEnvironment('default')
+            ->getAdapter()
+            ->setConnection($this->Connection->driver()->connection());
+
+        $tables = (new Collection($this->Connection))->listTables();
+        if (in_array('phinxlog', $tables)) {
+            $ormTable = TableRegistry::get('phinxlog', ['connection' => $this->Connection]);
+            $query = $this->Connection->driver()->schemaDialect()->truncateTableSql($ormTable->schema());
+            $this->Connection->execute(
+                $query[0]
+            );
+        }
+
+        return $migrations;
+    }
+
+    /**
+     * Extract the content that was stored in self::$streamOutput.
+     *
+     * @return string
+     */
+    protected function getDisplayFromOutput()
+    {
+        rewind($this->streamOutput->getStream());
+        $display = stream_get_contents($this->streamOutput->getStream());
+        return str_replace(PHP_EOL, "\n", $display);
+    }
+}

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -838,12 +838,14 @@ class MigrationsTest extends TestCase
      */
     public function migrationsProvider()
     {
-        return [
+        $return = [
             [
                 Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS,
                 [
                     ['test_not_empty_snapshot', 20150912015601],
                     ['test_auto_id_disabled_snapshot', 20150912015602],
+                    ['test_not_empty_snapshot56', 20150912015611],
+                    ['test_auto_id_disabled_snapshot56', 20150912015612],
                     ['testCreatePrimaryKey', 20150912015603],
                     ['testCreatePrimaryKeyUuid', 20150912015604]
                 ]
@@ -854,15 +856,22 @@ class MigrationsTest extends TestCase
                     ['test_not_empty_snapshot_pgsql', 20150912015606],
                     ['test_auto_id_disabled_snapshot_pgsql', 20150912015607]
                 ]
-            ]
-            ,
+            ],
             [
                 Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS . 'sqlite' . DS,
                 [
                     ['test_not_empty_snapshot_sqlite', 20150912015609],
                     ['test_auto_id_disabled_snapshot_sqlite', 20150912015610]
                 ]
-            ],
+            ]
         ];
+
+        $db = getenv('DB');
+        $dbv = getenv('DBV');
+        if ($db === 'mysql' && empty($dbv)) {
+            unset($return[0][1]['test_not_empty_snapshot56'], $return[0][1]['test_auto_id_disabled_snapshot56']);
+        }
+
+        return $return;
     }
 }

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -149,7 +149,6 @@ class MigrationSnapshotTaskTest extends TestCase
     public function testPluginBlog()
     {
         $db = ConnectionManager::get('test');
-        $collection = $db->schemaCollection();
         $table = new Table('parts', [
             'id' => ['type' => 'integer', 'unsigned' => true],
             'name' => ['type' => 'string', 'length' => 255],
@@ -222,6 +221,11 @@ class MigrationSnapshotTaskTest extends TestCase
         $dbenv = getenv("DB");
         if ($dbenv !== 'mysql') {
             $name .= ucfirst($dbenv);
+        } else {
+            $dbv = getenv('DBV');
+            if (!empty($dbv)) {
+                $name .= $dbv;
+            }
         }
 
         return $name;

--- a/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
@@ -201,6 +201,11 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
                     'category_id',
                 ]
             )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
             ->create();
 
         $table = $this->table('special_pks');

--- a/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
@@ -201,6 +201,11 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
                     'category_id',
                 ]
             )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
             ->create();
 
         $table = $this->table('special_pks');

--- a/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
@@ -169,6 +169,11 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
                     'category_id',
                 ]
             )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
             ->create();
 
         $table = $this->table('special_pks', ['id' => false, 'primary_key' => ['id']]);

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -202,6 +202,11 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
                     'category_id',
                 ]
             )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
             ->create();
 
         $table = $this->table('special_pks');

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
@@ -1,32 +1,43 @@
 <?php
 use Migrations\AbstractMigration;
 
-class TestNotEmptySnapshotPgsql extends AbstractMigration
+class TestAutoIdDisabledSnapshot56 extends AbstractMigration
 {
+
+    public $autoId = false;
+
     public function up()
     {
         $table = $this->table('articles');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('title', 'string', [
                 'comment' => 'Article title',
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
+                'signed' => false,
             ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
@@ -57,18 +68,25 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
 
         $table = $this->table('categories');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('title', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
@@ -90,7 +108,7 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
             )
             ->create();
 
-        $table = $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']]);
+        $table = $this->table('composite_pks');
         $table
             ->addColumn('id', 'uuid', [
                 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
@@ -102,18 +120,26 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                 'limit' => 50,
                 'null' => false,
             ])
+            ->addPrimaryKey(['id', 'name'])
             ->create();
 
         $table = $this->table('orders');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('product_category', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addIndex(
@@ -126,19 +152,26 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
 
         $table = $this->table('products');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('title', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -159,8 +192,8 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
             )
             ->addIndex(
                 [
-                    'id',
                     'category_id',
+                    'id',
                 ],
                 ['unique' => true]
             )
@@ -172,19 +205,21 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
             ->addIndex(
                 [
                     'title',
-                ]
+                ],
+                ['type' => 'fulltext']
             )
             ->create();
 
-        $table = $this->table('special_pks', ['id' => false, 'primary_key' => ['id']]);
+        $table = $this->table('special_pks');
         $table
             ->addColumn('id', 'uuid', [
                 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
                 'limit' => null,
                 'null' => false,
             ])
+            ->addPrimaryKey(['id'])
             ->addColumn('name', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])
@@ -192,19 +227,26 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
 
         $table = $this->table('special_tags');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('article_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('author_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('tag_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('highlighted', 'boolean', [
@@ -227,13 +269,20 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
 
         $table = $this->table('users');
         $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('username', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])
             ->addColumn('password', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -170,6 +170,11 @@ class TestNotEmptySnapshot extends AbstractMigration
                     'category_id',
                 ]
             )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
             ->create();
 
         $table = $this->table('special_pks', ['id' => false, 'primary_key' => ['id']]);

--- a/tests/comparisons/Migration/test_not_empty_snapshot56.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot56.php
@@ -1,7 +1,7 @@
 <?php
 use Migrations\AbstractMigration;
 
-class TestNotEmptySnapshotPgsql extends AbstractMigration
+class TestNotEmptySnapshot56 extends AbstractMigration
 {
     public function up()
     {
@@ -9,24 +9,25 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
         $table
             ->addColumn('title', 'string', [
                 'comment' => 'Article title',
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
+                'signed' => false,
             ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
@@ -59,16 +60,16 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
         $table
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('title', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
@@ -108,12 +109,12 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
         $table
             ->addColumn('product_category', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addIndex(
@@ -127,18 +128,18 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
         $table = $this->table('products');
         $table
             ->addColumn('title', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('slug', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 255,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -159,8 +160,8 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
             )
             ->addIndex(
                 [
-                    'id',
                     'category_id',
+                    'id',
                 ],
                 ['unique' => true]
             )
@@ -172,7 +173,8 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
             ->addIndex(
                 [
                     'title',
-                ]
+                ],
+                ['type' => 'fulltext']
             )
             ->create();
 
@@ -184,7 +186,7 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                 'null' => false,
             ])
             ->addColumn('name', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])
@@ -194,17 +196,17 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
         $table
             ->addColumn('article_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('author_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => true,
             ])
             ->addColumn('tag_id', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('highlighted', 'boolean', [
@@ -228,12 +230,12 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
         $table = $this->table('users');
         $table
             ->addColumn('username', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])
             ->addColumn('password', 'string', [
-                'default' => 'NULL::character varying',
+                'default' => null,
                 'limit' => 256,
                 'null' => true,
             ])

--- a/tests/comparisons/Migration/test_plugin_blog56.php
+++ b/tests/comparisons/Migration/test_plugin_blog56.php
@@ -1,0 +1,171 @@
+<?php
+use Migrations\AbstractMigration;
+
+class TestPluginBlog56 extends AbstractMigration
+{
+
+    public $autoId = false;
+
+    public function up()
+    {
+        $table = $this->table('articles');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'comment' => 'Article title',
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'category_id',
+                ]
+            )
+            ->addIndex(
+                [
+                    'product_id',
+                ]
+            )
+            ->addIndex(
+                [
+                    'title',
+                ]
+            )
+            ->create();
+
+        $table = $this->table('categories');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('parent_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'slug',
+                ],
+                ['unique' => true]
+            )
+            ->create();
+
+        $table = $this->table('parts');
+        $table
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('number', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->create();
+
+        $this->table('articles')
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->addForeignKey(
+                'product_id',
+                'products',
+                'id',
+                [
+                    'update' => 'CASCADE',
+                    'delete' => 'CASCADE'
+                ]
+            )
+            ->update();
+
+    }
+
+    public function down()
+    {
+        $this->table('articles')
+            ->dropForeignKey(
+                'category_id'
+            )
+            ->dropForeignKey(
+                'product_id'
+            );
+
+        $this->dropTable('articles');
+        $this->dropTable('categories');
+        $this->dropTable('parts');
+    }
+}


### PR DESCRIPTION
Add support for the new output of the ``status`` command. Basically, the phinxlog now stores the name of the migrations. When missing from the filesystem but outputted because we request the history, the name can now be displayed.
See https://github.com/robmorgan/phinx/pull/744 for more details.

------

When baking a snapshot, fulltext indexes are exported correctly. 

:warning: This is only supported for MySQL :warning: 

However, fulltext indexes for MySQL are only available for InnoDB tables starting from 5.6. This implied to add a new build specifically targeting MySQL 5.6 since Travis runs 5.5 by default (which explains the travis-ninja skills that I had to use to achieve this).
This also means that we have new files (ending by ``56``) to test against when we are testing with the build including MySQL 5.6 (since migrations file having fulltext indexes from 5.6 are not backward compatible with 5.5).
Finally, to make sure we bake snapshot that can run against every db server supported, I added them to the list of migrations that are migrated to test the support from snapshot baked with different db servers.

:warning: Of course, baked snapshot from MySQL 5.6 might fail when migrating to 5.5 since fulltext indexes are not supported.  :warning: 

I can explain further if you guys need more details. This might no be really well explained :smile: 

Refs PR https://github.com/robmorgan/phinx/pull/795 from phinx