### PR TITLE
Improve support for boolean type in baked snapshot

### DIFF
--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -95,6 +95,9 @@ class <%= $name %> extends AbstractMigration
                     $columnOptions['precision'] = $columnOptions['limit'];
                     unset($columnOptions['limit']);
                 }
+                if ($config['columnType'] === 'boolean' && isset($columnOptions['default']) && $this->Migration->value($columnOptions['default']) !== 'null') {
+                    $columnOptions['default'] = (bool)$columnOptions['default'];
+                }
                 echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
             %>])
         <%- endforeach;

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -33,6 +33,7 @@ class ArticlesFixture extends TestFixture
         'category_id' => ['type' => 'integer', 'length' => 11],
         'product_id' => ['type' => 'integer', 'length' => 11],
         'counter' => ['type' => 'integer', 'length' => 11, 'unsigned' => true],
+        'active' => ['type' => 'boolean', 'default' => 0],
         'created' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         '_indexes' => [

--- a/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
@@ -38,6 +38,11 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
                 'limit' => 10,
                 'null' => true,
             ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,

--- a/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
@@ -28,6 +28,11 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                 'limit' => 10,
                 'null' => true,
             ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,

--- a/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
@@ -28,6 +28,11 @@ class TestPluginBlogPgsql extends AbstractMigration
                 'limit' => 10,
                 'null' => true,
             ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,

--- a/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
@@ -38,6 +38,11 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
                 'null' => true,
                 'signed' => false,
             ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,

--- a/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
@@ -28,6 +28,11 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
                 'null' => true,
                 'signed' => false,
             ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,

--- a/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
@@ -28,6 +28,11 @@ class TestPluginBlogSqlite extends AbstractMigration
                 'null' => true,
                 'signed' => false,
             ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -39,6 +39,11 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
                 'null' => true,
                 'signed' => false,
             ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -29,6 +29,11 @@ class TestNotEmptySnapshot extends AbstractMigration
                 'null' => true,
                 'signed' => false,
             ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -39,6 +39,11 @@ class TestPluginBlog extends AbstractMigration
                 'null' => true,
                 'signed' => false,
             ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
             ->addColumn('created', 'timestamp', [
                 'default' => null,
                 'limit' => null,


### PR DESCRIPTION
Postgres needs the default value for boolean field type to be a real boolean value and not 0 or 1.

Refs #207