### PR TITLE
Reset cached environments when manager config is changed

### DIFF
--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -288,6 +288,19 @@ class Migrations
 
             $this->manager = new CakeManager($config, $this->output);
         } elseif ($config !== null) {
+            $defaultEnvironment = $config->getEnvironment('default');
+            try {
+                $environment = $this->manager->getEnvironment('default');
+                $oldConfig = $environment->getOptions();
+                unset($oldConfig['connection']);
+                if ($oldConfig == $defaultEnvironment) {
+                    $defaultEnvironment['connection'] = $environment
+                        ->getAdapter()
+                        ->getConnection();
+                }
+            } catch (\InvalidArgumentException $e) {
+            }
+            $config['environments'] = ['default' => $defaultEnvironment];
             $this->manager->setEnvironments([]);
             $this->manager->setConfig($config);
         }

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -288,6 +288,7 @@ class Migrations
 
             $this->manager = new CakeManager($config, $this->output);
         } elseif ($config !== null) {
+            $this->manager->setEnvironments([]);
             $this->manager->setConfig($config);
         }
 


### PR DESCRIPTION
A small change to ensure that cached environments are reset when the migration config is changed. Not doing this resulted in weird issues where it would read from the wrong plugin phinxlog. This only occurred when you used a single `Migration()` instance to check the status for multiple plugins