### PR TITLE
Keep original index names in initial snapshot

### DIFF
--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -103,7 +103,7 @@ class <%= $name %> extends AbstractMigration
         <%- endforeach;
             $tableConstraints = $this->Migration->constraints($table);
             if (!empty($tableConstraints)):
-                sort($tableConstraints);
+                asort($tableConstraints);
                 $constraints[$table] = $tableConstraints;
 
                 foreach ($constraints[$table] as $name => $constraint):
@@ -112,17 +112,22 @@ class <%= $name %> extends AbstractMigration
                     endif;
                     if ($constraint['columns'] !== $primaryKeysColumns): %>
             ->addIndex(
-                [<% echo $this->Migration->stringifyList($constraint['columns'], ['indent' => 5]); %>]<% echo ($constraint['type'] === 'unique') ? ',' : ''; %>
-
-                <%- if ($constraint['type'] === 'unique'): %>
-                ['unique' => true]
-                <%- endif; %>
+                [<% echo $this->Migration->stringifyList($constraint['columns'], ['indent' => 5]); %>],
+                [<%
+                    $indexOptions = [
+                        'name' => $name
+                    ];
+                    if ($constraint['type'] === 'unique') {
+                        $indexOptions['unique'] = true;
+                    }
+                    echo $this->Migration->stringifyList($indexOptions, ['indent' => 5]);
+                %>]
             )
                     <%- endif;
                 endforeach;
             endif;
 
-            foreach($this->Migration->indexes($table) as $index):
+            foreach($this->Migration->indexes($table) as $name => $index):
                 sort($foreignKeys);
                 $indexColumns = $index['columns'];
                 sort($indexColumns);
@@ -131,11 +136,16 @@ class <%= $name %> extends AbstractMigration
             ->addIndex(
                 [<%
                     echo $this->Migration->stringifyList($index['columns'], ['indent' => 5]);
-                %>]<% echo ($index['type'] === 'fulltext') ? ',' : ''; %>
-
-                <%- if ($index['type'] === 'fulltext'): %>
-                ['type' => 'fulltext']
-                <%- endif; %>
+                %>],
+                [<%
+                    $indexOptions = [
+                        'name' => $name
+                    ];
+                    if ($constraint['type'] === 'fulltext') {
+                        $indexOptions['type'] = 'fulltext';
+                    }
+                    echo $this->Migration->stringifyList($indexOptions, ['indent' => 5]);
+                %>]
             )
             <%- endif;
             endforeach; %>

--- a/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
@@ -56,16 +56,25 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
             ->addIndex(
                 [
                     'category_id',
+                ],
+                [
+                    'name' => 'category_id_fk',
                 ]
             )
             ->addIndex(
                 [
                     'product_id',
+                ],
+                [
+                    'name' => 'product_id_fk',
                 ]
             )
             ->addIndex(
                 [
                     'title',
+                ],
+                [
+                    'name' => 'title_idx',
                 ]
             )
             ->create();
@@ -108,7 +117,10 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
                 [
                     'slug',
                 ],
-                ['unique' => true]
+                [
+                    'name' => 'sqlite_autoindex_categories_1',
+                    'unique' => true,
+                ]
             )
             ->create();
 
@@ -150,6 +162,9 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
                 [
                     'product_category',
                     'product_id',
+                ],
+                [
+                    'name' => 'product_category_fk',
                 ]
             )
             ->create();
@@ -192,23 +207,35 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
                 [
                     'slug',
                 ],
-                ['unique' => true]
+                [
+                    'name' => 'sqlite_autoindex_products_1',
+                    'unique' => true,
+                ]
             )
             ->addIndex(
                 [
                     'category_id',
                     'id',
                 ],
-                ['unique' => true]
+                [
+                    'name' => 'sqlite_autoindex_products_2',
+                    'unique' => true,
+                ]
             )
             ->addIndex(
                 [
                     'category_id',
+                ],
+                [
+                    'name' => 'category_id_fk',
                 ]
             )
             ->addIndex(
                 [
                     'title',
+                ],
+                [
+                    'name' => 'title_idx_ft',
                 ]
             )
             ->create();
@@ -266,7 +293,10 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
                 [
                     'article_id',
                 ],
-                ['unique' => true]
+                [
+                    'name' => 'sqlite_autoindex_special_tags_1',
+                    'unique' => true,
+                ]
             )
             ->create();
 

--- a/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
@@ -46,16 +46,25 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
             ->addIndex(
                 [
                     'category_id',
+                ],
+                [
+                    'name' => 'category_id_fk',
                 ]
             )
             ->addIndex(
                 [
                     'product_id',
+                ],
+                [
+                    'name' => 'product_id_fk',
                 ]
             )
             ->addIndex(
                 [
                     'title',
+                ],
+                [
+                    'name' => 'title_idx',
                 ]
             )
             ->create();
@@ -91,7 +100,10 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
                 [
                     'slug',
                 ],
-                ['unique' => true]
+                [
+                    'name' => 'sqlite_autoindex_categories_1',
+                    'unique' => true,
+                ]
             )
             ->create();
 
@@ -125,6 +137,9 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
                 [
                     'product_category',
                     'product_id',
+                ],
+                [
+                    'name' => 'product_category_fk',
                 ]
             )
             ->create();
@@ -160,23 +175,35 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
                 [
                     'slug',
                 ],
-                ['unique' => true]
+                [
+                    'name' => 'sqlite_autoindex_products_1',
+                    'unique' => true,
+                ]
             )
             ->addIndex(
                 [
                     'category_id',
                     'id',
                 ],
-                ['unique' => true]
+                [
+                    'name' => 'sqlite_autoindex_products_2',
+                    'unique' => true,
+                ]
             )
             ->addIndex(
                 [
                     'category_id',
+                ],
+                [
+                    'name' => 'category_id_fk',
                 ]
             )
             ->addIndex(
                 [
                     'title',
+                ],
+                [
+                    'name' => 'title_idx_ft',
                 ]
             )
             ->create();
@@ -226,7 +253,10 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
                 [
                     'article_id',
                 ],
-                ['unique' => true]
+                [
+                    'name' => 'sqlite_autoindex_special_tags_1',
+                    'unique' => true,
+                ]
             )
             ->create();
 

--- a/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
@@ -46,16 +46,25 @@ class TestPluginBlogSqlite extends AbstractMigration
             ->addIndex(
                 [
                     'category_id',
+                ],
+                [
+                    'name' => 'category_id_fk',
                 ]
             )
             ->addIndex(
                 [
                     'product_id',
+                ],
+                [
+                    'name' => 'product_id_fk',
                 ]
             )
             ->addIndex(
                 [
                     'title',
+                ],
+                [
+                    'name' => 'title_idx',
                 ]
             )
             ->create();
@@ -91,7 +100,10 @@ class TestPluginBlogSqlite extends AbstractMigration
                 [
                     'slug',
                 ],
-                ['unique' => true]
+                [
+                    'name' => 'sqlite_autoindex_categories_1',
+                    'unique' => true,
+                ]
             )
             ->create();
 


### PR DESCRIPTION
When baking the initial migration snapshot of the database, the indexes names are ignored when creating the migration file.

This should fix that.
