### PR TITLE
Use cached version of table schema

### DIFF
--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -205,8 +205,7 @@ class MigrationHelper extends Helper
      */
     public function primaryKeys($table)
     {
-        $collection = $this->config('collection');
-        $tableSchema = $collection->describe($table);
+        $tableSchema = $this->schema($table);
         $primaryKeys = [];
         $tablePrimaryKeys = $tableSchema->primaryKey();
         foreach ($tableSchema->columns() as $column) {
@@ -227,8 +226,7 @@ class MigrationHelper extends Helper
     public function hasUnsignedPrimaryKey($tables)
     {
         foreach ($tables as $table) {
-            $collection = $this->config('collection');
-            $tableSchema = $collection->describe($table);
+            $tableSchema = $this->schema($table);
             $tablePrimaryKeys = $tableSchema->primaryKey();
 
             foreach ($tablePrimaryKeys as $primaryKey) {
@@ -307,8 +305,7 @@ class MigrationHelper extends Helper
      */
     public function attributes($table, $column)
     {
-        $collection = $this->config('collection');
-        $tableSchema = $collection->describe($table);
+        $tableSchema = $this->schema($table);
         $validOptions = [
             'length', 'limit',
             'default', 'null',


### PR DESCRIPTION
Extending `MigrationHelper` class i found there is a "cached" version of each table schema using `schema($table)`: that is good for performance to avoid multiple call to db for same infos, also if you want to extend class behavior about table handling you only have to override one method.
