### PR TITLE
Fix expected output of some tests due to a change in CakePHP Core

### DIFF
--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -141,7 +141,7 @@ class MarkMigratedTest extends TestCase
 
         $manager = $this->getMock(
             '\Migrations\CakeManager',
-            ['getEnvironment', 'markMigrated'],
+            ['getEnvironment', 'markMigrated', 'getMigrations'],
             [$config, new StreamOutput(fopen('php://memory', 'a', false))]
         );
 

--- a/tests/TestCase/Shell/Task/CommandTaskTest.php
+++ b/tests/TestCase/Shell/Task/CommandTaskTest.php
@@ -89,10 +89,11 @@ class CommandTaskTest extends TestCase
      */
     public function testMigrationsOptionsCreate()
     {
+        $this->skipIf(version_compare(phpversion(), '5.5.0', '<'));
         $this->Shell->runCommand(['options', 'Migrations.migrations', 'create']);
         $output = $this->out->output;
-        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --ansi --no-ansi";
-        $expected .= " --no-interaction -n --template -t --class -l\n";
+        $expected = "--ansi --help -h --no-ansi --no-interaction -n --quiet -q --verbose -v --class -l --connection";
+        $expected .= " -c --plugin -p --source -s --template -t\n";
         $this->assertTextEquals($expected, $output);
     }
 
@@ -104,10 +105,11 @@ class CommandTaskTest extends TestCase
      */
     public function testMigrationsOptionsMarkMigrated()
     {
+        $this->skipIf(version_compare(phpversion(), '5.5.0', '<'));
         $this->Shell->runCommand(['options', 'Migrations.migrations', 'mark_migrated']);
         $output = $this->out->output;
-        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --ansi --no-ansi";
-        $expected .= " --no-interaction -n --exclude -x --only -o\n";
+        $expected = "--ansi --help -h --no-ansi --no-interaction -n --quiet -q --verbose -v --connection -c";
+        $expected .= " --exclude -x --only -o --plugin -p --source -s\n";
         $this->assertTextEquals($expected, $output);
     }
 
@@ -119,10 +121,11 @@ class CommandTaskTest extends TestCase
      */
     public function testMigrationsOptionsMigrate()
     {
+        $this->skipIf(version_compare(phpversion(), '5.5.0', '<'));
         $this->Shell->runCommand(['options', 'Migrations.migrations', 'migrate']);
         $output = $this->out->output;
-        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --ansi --no-ansi";
-        $expected .= " --no-interaction -n --target -t --date -d\n";
+        $expected = "--ansi --help -h --no-ansi --no-interaction -n --quiet -q --verbose -v --connection -c";
+        $expected .= " --date -d --plugin -p --source -s --target -t\n";
         $this->assertTextEquals($expected, $output);
     }
 
@@ -134,10 +137,11 @@ class CommandTaskTest extends TestCase
      */
     public function testMigrationsOptionsRollback()
     {
+        $this->skipIf(version_compare(phpversion(), '5.5.0', '<'));
         $this->Shell->runCommand(['options', 'Migrations.migrations', 'rollback']);
         $output = $this->out->output;
-        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --ansi --no-ansi";
-        $expected .= " --no-interaction -n --target -t --date -d\n";
+        $expected = "--ansi --help -h --no-ansi --no-interaction -n --quiet -q --verbose -v --connection -c";
+        $expected .= " --date -d --plugin -p --source -s --target -t\n";
         $this->assertTextEquals($expected, $output);
     }
 
@@ -149,10 +153,11 @@ class CommandTaskTest extends TestCase
      */
     public function testMigrationsOptionsStatus()
     {
+        $this->skipIf(version_compare(phpversion(), '5.5.0', '<'));
         $this->Shell->runCommand(['options', 'Migrations.migrations', 'status']);
         $output = $this->out->output;
-        $expected = "--help -h --verbose -v --quiet -q --plugin -p --connection -c --source -s --ansi --no-ansi";
-        $expected .= " --no-interaction -n --format -f\n";
+        $expected = "--ansi --help -h --no-ansi --no-interaction -n --quiet -q --verbose -v --connection -c";
+        $expected .= " --format -f --plugin -p --source -s\n";
         $this->assertTextEquals($expected, $output);
     }
 }


### PR DESCRIPTION
Due to https://github.com/cakephp/cakephp/pull/8635, the output of options are different.
I made the tests skip on 5.4 because that version of the core where the option was implemented is not supported in 5.4.
And even if it is used with 5.4, it should not be that big of a deal breaker given the nature of the change.

Will merge this as soon as possible in order to take care of pending PR.