### PR TITLE
Fix expected results from tests

### DIFF
--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -12,7 +12,6 @@
 namespace Migrations\Test;
 
 use Cake\Cache\Cache;
-use Cake\Core\Configure;
 use Cake\Database\Schema\Collection;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -12,6 +12,7 @@
 namespace Migrations\Test;
 
 use Cake\Cache\Cache;
+use Cake\Core\Configure;
 use Cake\Database\Schema\Collection;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
@@ -47,8 +48,9 @@ class MigrationHelperTest extends TestCase
         $this->loadFixtures('Users');
         $this->loadFixtures('SpecialTags');
 
+        $nullDef = version_compare(PHP_VERSION, '5.5', '<') ? 'NULL' : null;
         $this->values = [
-            'null' => 'NULL',
+            'null' => $nullDef,
             'integerNull' => null,
             'integerLimit' => null,
             'comment' => null,

--- a/tests/comparisons/Diff/the_diff_pgsql.php
+++ b/tests/comparisons/Diff/the_diff_pgsql.php
@@ -100,7 +100,7 @@ class TheDiffPgsql extends AbstractMigration
             )
             ->update();
 
-            $this->dropTable('tags');
+        $this->dropTable('tags');
     }
 
     public function down()


### PR DESCRIPTION
- Changes the way ``default null`` for SQLite is handled for build >= 5.5 (due to the recent change in the core regarding this). The build for 5.4 is still expecting the old way of doing this.
- Fix a bake comparison file for the diff baking feature for Postgres