### PR TITLE
Revert #222 migrationtask argument

### DIFF
--- a/src/Shell/Task/MigrationDiffTask.php
+++ b/src/Shell/Task/MigrationDiffTask.php
@@ -486,4 +486,20 @@ class MigrationDiffTask extends SimpleMigrationTask
     {
         return 'Migrations.config/diff';
     }
+
+    /**
+     * Gets the option parser instance and configures it.
+     *
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+
+        $parser->addArgument('name', [
+            'help' => 'Name of the migration to bake. Can use Plugin.name to bake migration files into plugins.',
+            'required' => true
+        ]);
+        return $parser;
+    }
 }

--- a/src/Shell/Task/MigrationSnapshotTask.php
+++ b/src/Shell/Task/MigrationSnapshotTask.php
@@ -126,7 +126,11 @@ class MigrationSnapshotTask extends SimpleMigrationTask
 
         $parser->description(
             'Bake migration snapshot class.'
-        )->addOption('require-table', [
+        )->addArgument('name', [
+            'help' => 'Name of the migration to bake. Can use Plugin.name to bake migration files into plugins.',
+            'required' => true
+        ])
+        ->addOption('require-table', [
             'boolean' => true,
             'default' => false,
             'help' => 'If require-table is set to true, check also that the table class exists.'

--- a/src/Shell/Task/SimpleMigrationTask.php
+++ b/src/Shell/Task/SimpleMigrationTask.php
@@ -115,10 +115,7 @@ abstract class SimpleMigrationTask extends SimpleBakeTask
 
         $parser->description(
             'Bake migration class.'
-        )->addArgument('name', [
-            'help' => 'Name of the migration to bake. Can use Plugin.name to bake migration files into plugins.',
-            'required' => true
-        ])->addOption('plugin', [
+        )->addOption('plugin', [
             'short' => 'p',
             'help' => 'Plugin to bake into.'
         ])->addOption('force', [


### PR DESCRIPTION
Reverts #222 

Issue #226 happened because the argument added in the option parser makes the "simple" migration baking command ask for only one argument (the name). But since the command allows a user to input multiple columns definitions, the shell raises an error because there are too many arguments.
And since it is not possible to define an argument for "multiple space separated values", #222 has to be reverted.

However sub-classes of the ``SimpleMigrationTask`` can have the ``addArgument`` call since they do not need more than the name of the migration to bake. 
