### PR TITLE
Do not try to instanciate non-instanciable classes when resolving tables to bake

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "psr-4": {
             "Cake\\Test\\": "./vendor/cakephp/cakephp/tests",
             "Migrations\\Test\\": "tests",
+            "TestApp\\": "tests/test_app/App",
             "TestBlog\\": "tests/test_app/Plugin/TestBlog/src"
         }
     },

--- a/src/Shell/Task/SnapshotTrait.php
+++ b/src/Shell/Task/SnapshotTrait.php
@@ -11,11 +11,13 @@
  */
 namespace Migrations\Shell\Task;
 
+use Cake\Core\App;
 use Cake\Core\Plugin;
 use Cake\Database\Schema\Collection;
 use Cake\Datasource\ConnectionManager;
 use Cake\Filesystem\Folder;
 use Cake\ORM\TableRegistry;
+use ReflectionClass;
 
 /**
  * Trait needed for all "snapshot" type of bake operations.
@@ -118,6 +120,10 @@ trait SnapshotTrait
         $options = array_merge(['require-table' => false, 'plugin' => null], $options);
         $tables = $collection->listTables();
 
+        if (empty($tables)) {
+            return $tables;
+        }
+
         if ($options['require-table'] === true || $options['plugin']) {
             $tableNamesInModel = $this->getTableNames($options['plugin']);
 
@@ -205,6 +211,12 @@ trait SnapshotTrait
         $className = str_replace('Table.php', '', $className);
         if ($pluginName !== null) {
             $className = $pluginName . '.' . $className;
+        }
+
+        $namespacedClassName = App::className($className, 'Model/Table', 'Table');
+        $reflection = new ReflectionClass($namespacedClassName);
+        if (!$reflection->isInstantiable()) {
+            return $tables;
         }
 
         $table = TableRegistry::get($className);

--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -39,7 +39,8 @@ class <%= $name %> extends AbstractMigration
 
     public function down()
     {
-        <%- foreach ($this->Migration->returnedData['dropForeignKeys'] as $table => $columnsList):
+        <%- if (!empty($this->Migration->returnedData['dropForeignKeys'])):
+            foreach ($this->Migration->returnedData['dropForeignKeys'] as $table => $columnsList):
                 $maxKey = count($columnsList) - 1;
         %>
         $this->table('<%= $table %>')
@@ -49,7 +50,9 @@ class <%= $name %> extends AbstractMigration
             )<%= ($key === $maxKey) ? ';' : '' %>
             <%- endforeach; %>
 
-        <%- endforeach; %>
+        <%- endforeach;
+            endif;
+        %>
         <%- foreach ($tables as $table): %>
         $this->dropTable('<%= $table%>');
         <%- endforeach; %>

--- a/tests/TestCase/Command/DumpTest.php
+++ b/tests/TestCase/Command/DumpTest.php
@@ -112,7 +112,7 @@ class DumpTest extends TestCase
     }
 
     /**
-     * Test executing "dump" with no tables in the database
+     * Test executing "dump" with tables in the database
      *
      * @return void
      */

--- a/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
@@ -15,7 +15,6 @@ use Bake\Shell\Task\BakeTemplateTask;
 use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Database\Schema\Collection;
 use Cake\Datasource\ConnectionManager;
 use Cake\Filesystem\File;
 use Cake\Filesystem\Folder;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,7 +38,7 @@ define('TMP', sys_get_temp_dir() . DS);
 
 Configure::write('debug', true);
 Configure::write('App', [
-    'namespace' => 'App',
+    'namespace' => 'TestApp',
     'paths' => [
         'plugins' => [ROOT . 'Plugin' . DS],
         'templates' => [ROOT . 'App' . DS . 'Template' . DS]

--- a/tests/comparisons/Diff/simple/the_diff_simple_pgsql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_pgsql.php
@@ -22,6 +22,7 @@ class TheDiffSimplePgsql extends AbstractMigration
 
         $this->table('articles')
             ->addColumn('user_id', 'integer', [
+                'default' => null,
                 'length' => 10,
                 'null' => false,
             ])

--- a/tests/test_app/App/Model/Table/LettersTable.php
+++ b/tests/test_app/App/Model/Table/LettersTable.php
@@ -4,7 +4,7 @@ namespace TestApp\Model\Table;;
 use Cake\ORM\Table;
 
 /**
- * Articles Model
+ * Letters Model
  *
  */
 class LettersTable extends Table

--- a/tests/test_app/App/Model/Table/LettersTable.php
+++ b/tests/test_app/App/Model/Table/LettersTable.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
 namespace TestApp\Model\Table;;
 
 use Cake\ORM\Table;

--- a/tests/test_app/App/Model/Table/NumbersTable.php
+++ b/tests/test_app/App/Model/Table/NumbersTable.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
 namespace TestApp\Model\Table;;
 
 use Cake\ORM\Table;

--- a/tests/test_app/App/Model/Table/NumbersTable.php
+++ b/tests/test_app/App/Model/Table/NumbersTable.php
@@ -4,7 +4,7 @@ namespace TestApp\Model\Table;;
 use Cake\ORM\Table;
 
 /**
- * Articles Model
+ * Numbers Model
  *
  */
 class NumbersTable extends Table

--- a/tests/test_app/App/Model/Table/SomeAbstractTable.php
+++ b/tests/test_app/App/Model/Table/SomeAbstractTable.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
 namespace TestApp\Model\Table;
 
 use Cake\ORM\Table;

--- a/tests/test_app/App/Model/Table/SomeAbstractTable.php
+++ b/tests/test_app/App/Model/Table/SomeAbstractTable.php
@@ -1,0 +1,8 @@
+<?php
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+
+abstract class SomeAbstractTable extends Table
+{
+}


### PR DESCRIPTION
When fetching and resolving tables names to add into a baked migration file or a dump file, the shell loads Table classes to use the ``table()`` method to get the real names of the tables.
The problem is that it tries to instanciate any Table classes, including potential abstract class.
This fixes it by using the ``ReflectionClass``.

I also used this PR to add minor fixes and do a bit of cleanup :
- a fix in the Postgres build
- a fix regarding a notice that could appear when baking a snapshot in specific conditions

Refs #229 