### PR TITLE
Allows a Seeder to call other Seeders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ sudo: false
 env:
   matrix:
     - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test' db_dsn_compare='mysql://root@0.0.0.0/cakephp_comparisons'
-    - DB=sqlite db_dsn='sqlite:///:memory:'
+    - DB=sqlite
   global:
     - DEFAULT=1
 
@@ -57,7 +57,7 @@ matrix:
       env: PHPCS=1 DEFAULT=0
 
     - php: hhvm
-      env: HHVM=1 DB=sqlite db_dsn='sqlite:///:memory:'
+      env: HHVM=1 DB=sqlite
 
     - php: hhvm
       env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test' db_dsn_compare='mysql://travis@0.0.0.0/cakephp_comparisons'

--- a/src/AbstractSeed.php
+++ b/src/AbstractSeed.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations;
+
+use Cake\Console\ShellDispatcher;
+use Phinx\Seed\AbstractSeed as BaseAbstractSeed;
+
+class AbstractSeed extends BaseAbstractSeed
+{
+
+    public function call($seeder)
+    {
+        $argv = [
+            'dummy',
+            'migrations',
+            'seed',
+            '--seed',
+            $seeder
+        ];
+
+        $this->getOutput()->writeln('');
+        $this->getOutput()->writeln(
+            ' ===='
+            . ' <info>' . $seeder . ':</info>'
+            . ' <comment>seeding</comment>'
+        );
+
+        // Execute the seeder and log the time elapsed.
+        $start = microtime(true);
+        $dispatcher = new ShellDispatcher($argv);
+        $dispatcher->dispatch(['requested' => true]);
+        $end = microtime(true);
+
+        $this->getOutput()->writeln(
+            ' ===='
+            . ' <info>' . $seeder . ':</info>'
+            . ' <comment>seeded'
+            . ' ' . sprintf('%.4fs', $end - $start) . '</comment>'
+        );
+        $this->getOutput()->writeln('');
+    }
+}

--- a/src/AbstractSeed.php
+++ b/src/AbstractSeed.php
@@ -14,9 +14,22 @@ namespace Migrations;
 use Cake\Console\ShellDispatcher;
 use Phinx\Seed\AbstractSeed as BaseAbstractSeed;
 
-class AbstractSeed extends BaseAbstractSeed
+/**
+ * Class AbstractSeed
+ * Extends Phinx base AbstractSeed class in order to extend the features the seed class
+ * offers.
+ */
+abstract class AbstractSeed extends BaseAbstractSeed
 {
 
+    /**
+     * Gives the ability to a seeder to call another seeder.
+     * This is particularly useful if you need to run the seeders of your applications in a specific sequences,
+     * for instance to respect foreign key constraints.
+     *
+     * @param string $seeder Name of the seeder to call from the current seed
+     * @return void
+     */
     public function call($seeder)
     {
         $argv = [

--- a/src/AbstractSeed.php
+++ b/src/AbstractSeed.php
@@ -106,6 +106,7 @@ abstract class AbstractSeed extends BaseAbstractSeed
         $seeder = new $seeder();
         $seeder->setOutput($this->getOutput());
         $seeder->setAdapter($this->getAdapter());
+        $seeder->setInput($this->input);
         $seeder->run();
     }
 

--- a/src/AbstractSeed.php
+++ b/src/AbstractSeed.php
@@ -64,7 +64,7 @@ abstract class AbstractSeed extends BaseAbstractSeed
 
     /**
      * Calls another seeder from this seeder.
-     * It will start up a new shell light-weight application (only the and
+     * It will load the Seed class you are calling and run it.
      *
      * @param string $seeder Name of the seeder to call from the current seed
      * @return void

--- a/src/AbstractSeed.php
+++ b/src/AbstractSeed.php
@@ -14,6 +14,7 @@ namespace Migrations;
 use Migrations\Command\Seed;
 use Phinx\Seed\AbstractSeed as BaseAbstractSeed;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
 
 /**
  * Class AbstractSeed
@@ -32,6 +33,13 @@ abstract class AbstractSeed extends BaseAbstractSeed
     protected $app;
 
     /**
+     * InputInterface this Seed class is being used with.
+     *
+     * @var \Symfony\Component\Console\Input\InputInterface
+     */
+    protected $input;
+
+    /**
      * Gives the ability to a seeder to call another seeder.
      * This is particularly useful if you need to run the seeders of your applications in a specific sequences,
      * for instance to respect foreign key constraints.
@@ -48,7 +56,6 @@ abstract class AbstractSeed extends BaseAbstractSeed
             . ' <comment>seeding</comment>'
         );
 
-        // Execute the seeder and log the time elapsed.
         $start = microtime(true);
         $this->runCall($seeder);
         $end = microtime(true);
@@ -77,8 +84,26 @@ abstract class AbstractSeed extends BaseAbstractSeed
             '--seed',
             $seeder
         ];
-        $input = new ArgvInput($argv);
 
+        $plugin = $this->input->getOption('plugin');
+        if ($plugin !== null) {
+            $argv[] = '--plugin';
+            $argv[] = $plugin;
+        }
+
+        $connection = $this->input->getOption('connection');
+        if ($connection !== null) {
+            $argv[] = '--connection';
+            $argv[] = $connection;
+        }
+
+        $source = $this->input->getOption('source');
+        if ($source !== null) {
+            $argv[] = '--source';
+            $argv[] = $source;
+        }
+
+        $input = new ArgvInput($argv);
         $this->getApp()->run($input);
     }
 
@@ -101,5 +126,16 @@ abstract class AbstractSeed extends BaseAbstractSeed
         }
 
         return $this->app;
+    }
+
+    /**
+     * Sets the InputInterface this Seed class is being used with.
+     *
+     * @param InputInterface $input
+     * @return void
+     */
+    public function setInput(InputInterface $input)
+    {
+        $this->input = $input;
     }
 }

--- a/src/CakeManager.php
+++ b/src/CakeManager.php
@@ -12,6 +12,7 @@
 namespace Migrations;
 
 use Phinx\Migration\Manager;
+use Symfony\Component\Console\Input\InputInterface;
 
 /**
  * Overrides Phinx Manager class in order to provide an interface
@@ -21,6 +22,13 @@ class CakeManager extends Manager
 {
 
     public $maxNameLength = 0;
+
+    /**
+     * Instance of InputInterface the Manager is dealing with for the current shell call
+     *
+     * @var \Symfony\Component\Console\Input\InputInterface
+     */
+    protected $input;
 
     /**
      * Reset the migrations stored in the object
@@ -317,5 +325,39 @@ class CakeManager extends Manager
         }
 
         return $class;
+    }
+
+    /**
+     * Sets the InputInterface the Manager is dealing with for the current shell call
+     *
+     * @param \Symfony\Component\Console\Input\InputInterface $input Instance of InputInterface
+     * @return void
+     */
+    public function setInput(InputInterface $input)
+    {
+        $this->input = $input;
+    }
+
+    /**
+     * Overload the basic behavior to add an instance of the InputInterface the shell call is
+     * using in order to gives the ability to the AbstractSeed::call() method to propagate options
+     * to the other MigrationsDispatcher it is generating.
+     *
+     * {@inheritdoc}
+     */
+    public function getSeeds()
+    {
+        parent::getSeeds();
+        if (empty($this->seeds)) {
+            return $this->seeds;
+        }
+
+        foreach ($this->seeds as $class => $instance) {
+            if ($instance instanceof AbstractSeed) {
+                $instance->setInput($this->input);
+            }
+        }
+
+        return $this->seeds;
     }
 }

--- a/src/Command/Seed.php
+++ b/src/Command/Seed.php
@@ -16,7 +16,6 @@ use Migrations\ConfigurationTrait;
 use Phinx\Console\Command\SeedRun;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Seed extends SeedRun
@@ -26,24 +25,6 @@ class Seed extends SeedRun
         execute as parentExecute;
     }
     use EventDispatcherTrait;
-
-    /**
-     * Whether this command was invoked through an application loaded and requested by another shell
-     * @var bool
-     */
-    protected $requested = false;
-
-    /**
-     * Sets whether this command was invoked through an application loaded and requested by another shell
-     *
-     * @param bool $requested Requested status. If true, it means that this command was invoked through an application
-     * called from another shell
-     * @return void
-     */
-    public function setRequested($requested)
-    {
-        $this->requested = (bool)$requested;
-    }
 
     /**
      * {@inheritdoc}
@@ -72,9 +53,6 @@ class Seed extends SeedRun
         $event = $this->dispatchEvent('Migration.beforeSeed');
         if ($event->isStopped()) {
             return $event->result;
-        }
-        if ($this->requested === true) {
-            $output = new NullOutput();
         }
 
         $this->setInput($input);

--- a/src/Command/Seed.php
+++ b/src/Command/Seed.php
@@ -27,8 +27,19 @@ class Seed extends SeedRun
     }
     use EventDispatcherTrait;
 
+    /**
+     * Whether this command was invoked through an application loaded and requested by another shell
+     * @var bool
+     */
     protected $requested = false;
 
+    /**
+     * Sets whether this command was invoked through an application loaded and requested by another shell
+     *
+     * @param bool $requested Requested status. If true, it means that this command was invoked through an application
+     * called from another shell
+     * @return void
+     */
     public function setRequested($requested)
     {
         $this->requested = (bool)$requested;

--- a/src/Command/Seed.php
+++ b/src/Command/Seed.php
@@ -16,6 +16,7 @@ use Migrations\ConfigurationTrait;
 use Phinx\Console\Command\SeedRun;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Seed extends SeedRun
@@ -25,6 +26,13 @@ class Seed extends SeedRun
         execute as parentExecute;
     }
     use EventDispatcherTrait;
+
+    protected $requested = false;
+
+    public function setRequested($requested)
+    {
+        $this->requested = (bool)$requested;
+    }
 
     /**
      * {@inheritdoc}
@@ -53,6 +61,9 @@ class Seed extends SeedRun
         $event = $this->dispatchEvent('Migration.beforeSeed');
         if ($event->isStopped()) {
             return $event->result;
+        }
+        if ($this->requested === true) {
+            $output = new NullOutput();
         }
         $this->parentExecute($input, $output);
         $this->dispatchEvent('Migration.afterSeed');

--- a/src/Command/Seed.php
+++ b/src/Command/Seed.php
@@ -76,6 +76,10 @@ class Seed extends SeedRun
         if ($this->requested === true) {
             $output = new NullOutput();
         }
+
+        $this->setInput($input);
+        $this->bootstrap($input, $output);
+        $this->getManager()->setInput($input);
         $this->parentExecute($input, $output);
         $this->dispatchEvent('Migration.afterSeed');
     }

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -260,6 +260,7 @@ class Migrations
         $this->setInput($input);
         $newConfig = $this->getConfig(true);
         $manager = $this->getManager($newConfig);
+        $manager->setInput($input);
 
         if (isset($migrationPath) && $newConfig->getMigrationPath() !== $migrationPath) {
             $manager->resetMigrations();

--- a/src/MigrationsDispatcher.php
+++ b/src/MigrationsDispatcher.php
@@ -21,12 +21,6 @@ use Symfony\Component\Console\Application;
 class MigrationsDispatcher extends Application
 {
     /**
-     * Whether this application was loaded and requested through another shell
-     * @var bool
-     */
-    protected $requested = false;
-
-    /**
      * Class Constructor.
      *
      * Initialize the Phinx console application.
@@ -36,35 +30,12 @@ class MigrationsDispatcher extends Application
     public function __construct($version)
     {
         parent::__construct('Migrations plugin, based on Phinx by Rob Morgan.', $version);
-    }
-
-    /**
-     * Bind the commands to the shell application
-     *
-     * @return void
-     */
-    public function bindCommands()
-    {
         $this->add(new Command\Create());
         $this->add(new Command\Dump());
         $this->add(new Command\MarkMigrated());
         $this->add(new Command\Migrate());
         $this->add(new Command\Rollback());
-
-        $seedCommand = new Command\Seed();
-        $seedCommand->setRequested($this->requested);
-        $this->add($seedCommand);
+        $this->add(new Command\Seed());
         $this->add(new Command\Status());
-    }
-
-    /**
-     * Sets whether this application was loaded and requested through another shell
-     *
-     * @param bool $requested Requested status. If true, it means that this shell was invoked through another shell
-     * @return void
-     */
-    public function setRequested($requested)
-    {
-        $this->requested = (bool)$requested;
     }
 }

--- a/src/MigrationsDispatcher.php
+++ b/src/MigrationsDispatcher.php
@@ -20,6 +20,10 @@ use Symfony\Component\Console\Application;
  */
 class MigrationsDispatcher extends Application
 {
+    /**
+     * Whether this application was loaded and requested through another shell
+     * @var bool
+     */
     protected $requested = false;
 
     /**
@@ -34,6 +38,11 @@ class MigrationsDispatcher extends Application
         parent::__construct('Migrations plugin, based on Phinx by Rob Morgan.', $version);
     }
 
+    /**
+     * Bind the commands to the shell application
+     *
+     * @return void
+     */
     public function bindCommands()
     {
         $this->add(new Command\Create());
@@ -48,6 +57,12 @@ class MigrationsDispatcher extends Application
         $this->add(new Command\Status());
     }
 
+    /**
+     * Sets whether this application was loaded and requested through another shell
+     *
+     * @param bool $requested Requested status. If true, it means that this shell was invoked through another shell
+     * @return void
+     */
     public function setRequested($requested)
     {
         $this->requested = (bool)$requested;

--- a/src/MigrationsDispatcher.php
+++ b/src/MigrationsDispatcher.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Application;
  */
 class MigrationsDispatcher extends Application
 {
+    protected $requested = false;
 
     /**
      * Class Constructor.
@@ -31,12 +32,24 @@ class MigrationsDispatcher extends Application
     public function __construct($version)
     {
         parent::__construct('Migrations plugin, based on Phinx by Rob Morgan.', $version);
+    }
+
+    public function bindCommands()
+    {
         $this->add(new Command\Create());
         $this->add(new Command\Dump());
         $this->add(new Command\MarkMigrated());
         $this->add(new Command\Migrate());
         $this->add(new Command\Rollback());
-        $this->add(new Command\Seed());
+
+        $seedCommand = new Command\Seed();
+        $seedCommand->setRequested($this->requested);
+        $this->add($seedCommand);
         $this->add(new Command\Status());
+    }
+
+    public function setRequested($requested)
+    {
+        $this->requested = (bool)$requested;
     }
 }

--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -93,6 +93,11 @@ class MigrationsShell extends Shell
     public function main()
     {
         $app = new MigrationsDispatcher(PHINX_VERSION);
+        if (isset($this->params['requested']) && $this->params['requested'] === true) {
+            $app->setRequested(true);
+        }
+        $app->bindCommands();
+
         $input = new ArgvInput($this->argv);
         $app->setAutoExit(false);
         $exitCode = $app->run($input);

--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -93,11 +93,6 @@ class MigrationsShell extends Shell
     public function main()
     {
         $app = new MigrationsDispatcher(PHINX_VERSION);
-        if (isset($this->params['requested']) && $this->params['requested'] === true) {
-            $app->setRequested(true);
-        }
-        $app->bindCommands();
-
         $input = new ArgvInput($this->argv);
         $app->setAutoExit(false);
         $exitCode = $app->run($input);

--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -75,7 +75,7 @@ class MigrationsShell extends Shell
     public function initialize()
     {
         if (!defined('PHINX_VERSION')) {
-            define('PHINX_VERSION', (0 === strpos('@PHINX_VERSION@', '@PHINX_VERSION')) ? '0.4.1' : '@PHINX_VERSION@');
+            define('PHINX_VERSION', (0 === strpos('@PHINX_VERSION@', '@PHINX_VERSION')) ? '0.4.3' : '@PHINX_VERSION@');
         }
         parent::initialize();
     }

--- a/src/Template/Bake/Seed/seed.ctp
+++ b/src/Template/Bake/Seed/seed.ctp
@@ -14,7 +14,7 @@
  */
 %>
 <?php
-use Phinx\Seed\AbstractSeed;
+use Migrations\AbstractSeed;
 
 /**
  * <%= $name %> seed.

--- a/tests/TestCase/Command/DumpTest.php
+++ b/tests/TestCase/Command/DumpTest.php
@@ -72,6 +72,7 @@ class DumpTest extends TestCase
 
         $this->Connection = ConnectionManager::get('test');
         $application = new MigrationsDispatcher('testing');
+        $application->bindCommands();
         $this->command = $application->find('dump');
         $this->streamOutput = new StreamOutput(fopen('php://memory', 'w', false));
         $this->_compareBasePath = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS;

--- a/tests/TestCase/Command/DumpTest.php
+++ b/tests/TestCase/Command/DumpTest.php
@@ -72,7 +72,6 @@ class DumpTest extends TestCase
 
         $this->Connection = ConnectionManager::get('test');
         $application = new MigrationsDispatcher('testing');
-        $application->bindCommands();
         $this->command = $application->find('dump');
         $this->streamOutput = new StreamOutput(fopen('php://memory', 'w', false));
         $this->_compareBasePath = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS;

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -140,11 +140,10 @@ class MarkMigratedTest extends TestCase
         $env = $this->command->getManager()->getEnvironment('default');
         $migrations = $this->command->getManager()->getMigrations();
 
-        $manager = $this->getMock(
-            '\Migrations\CakeManager',
-            ['getEnvironment', 'markMigrated', 'getMigrations'],
-            [$config, new StreamOutput(fopen('php://memory', 'a', false))]
-        );
+        $manager = $this->getMockBuilder('\Migrations\CakeManager')
+            ->setMethods(['getEnvironment', 'markMigrated', 'getMigrations'])
+            ->setConstructorArgs([$config, new StreamOutput(fopen('php://memory', 'a', false))])
+            ->getMock();
 
         $manager->expects($this->any())
             ->method('getEnvironment')->will($this->returnValue($env));

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -65,7 +65,6 @@ class MarkMigratedTest extends TestCase
         $this->Connection->execute('DROP TABLE IF EXISTS numbers');
 
         $application = new MigrationsDispatcher('testing');
-        $application->bindCommands();
         $this->command = $application->find('mark_migrated');
         $this->commandTester = new CommandTester($this->command);
     }
@@ -155,7 +154,6 @@ class MarkMigratedTest extends TestCase
         $this->Connection->execute('DELETE FROM phinxlog');
 
         $application = new MigrationsDispatcher('testing');
-        $application->bindCommands();
         $buggyCommand = $application->find('mark_migrated');
         $buggyCommand->setManager($manager);
         $buggyCommandTester = new CommandTester($buggyCommand);

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -65,6 +65,7 @@ class MarkMigratedTest extends TestCase
         $this->Connection->execute('DROP TABLE IF EXISTS numbers');
 
         $application = new MigrationsDispatcher('testing');
+        $application->bindCommands();
         $this->command = $application->find('mark_migrated');
         $this->commandTester = new CommandTester($this->command);
     }
@@ -155,6 +156,7 @@ class MarkMigratedTest extends TestCase
         $this->Connection->execute('DELETE FROM phinxlog');
 
         $application = new MigrationsDispatcher('testing');
+        $application->bindCommands();
         $buggyCommand = $application->find('mark_migrated');
         $buggyCommand->setManager($manager);
         $buggyCommandTester = new CommandTester($buggyCommand);

--- a/tests/TestCase/Command/SeedTest.php
+++ b/tests/TestCase/Command/SeedTest.php
@@ -68,7 +68,6 @@ class SeedTest extends TestCase
 
         $this->Connection = ConnectionManager::get('test');
         $application = new MigrationsDispatcher('testing');
-        $application->bindCommands();
         $this->command = $application->find('seed');
         $this->streamOutput = new StreamOutput(fopen('php://memory', 'w', false));
     }

--- a/tests/TestCase/Command/StatusTest.php
+++ b/tests/TestCase/Command/StatusTest.php
@@ -78,7 +78,6 @@ class StatusTest extends TestCase
         $this->Connection->execute('DROP TABLE IF EXISTS numbers');
 
         $application = new MigrationsDispatcher('testing');
-        $application->bindCommands();
         $this->command = $application->find('status');
         $this->streamOutput = new StreamOutput(fopen('php://memory', 'w', false));
     }

--- a/tests/TestCase/Command/StatusTest.php
+++ b/tests/TestCase/Command/StatusTest.php
@@ -78,6 +78,7 @@ class StatusTest extends TestCase
         $this->Connection->execute('DROP TABLE IF EXISTS numbers');
 
         $application = new MigrationsDispatcher('testing');
+        $application->bindCommands();
         $this->command = $application->find('status');
         $this->streamOutput = new StreamOutput(fopen('php://memory', 'w', false));
     }

--- a/tests/TestCase/ConfigurationTraitTest.php
+++ b/tests/TestCase/ConfigurationTraitTest.php
@@ -42,9 +42,9 @@ class ConfigurationTraitTest extends TestCase
     public function driversProvider()
     {
         return [
-            ['mysql', $this->getMock('Cake\Database\Driver\Mysql')],
-            ['pgsql', $this->getMock('Cake\Database\Driver\Postgres')],
-            ['sqlite', $this->getMock('Cake\Database\Driver\Sqlite')]
+            ['mysql', $this->getMockBuilder('\Cake\Database\Driver\Mysql')->getMock()],
+            ['pgsql', $this->getMockBuilder('\Cake\Database\Driver\Postgres')->getMock()],
+            ['sqlite', $this->getMockBuilder('\Cake\Database\Driver\Sqlite')->getMock()]
         ];
     }
 
@@ -86,7 +86,7 @@ class ConfigurationTraitTest extends TestCase
             ]
         ]);
 
-        $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
+        $input = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')->getMock();
         $this->command->setInput($input);
         $config = $this->command->getConfig();
         $this->assertInstanceOf('Phinx\Config\Config', $config);
@@ -122,7 +122,7 @@ class ConfigurationTraitTest extends TestCase
     public function testCacheMetadataDisabled()
     {
         $input = new ArrayInput([], $this->command->getDefinition());
-        $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+        $output = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')->getMock();
         $this->command->setInput($input);
 
         $input->setOption('connection', 'test');
@@ -140,7 +140,7 @@ class ConfigurationTraitTest extends TestCase
     {
         $tmpPath = rtrim(sys_get_temp_dir(), DS) . DS;
         Plugin::load('MyPlugin', ['path' => $tmpPath]);
-        $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
+        $input = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')->getMock();
         $this->command->setInput($input);
 
         $input->expects($this->at(1))
@@ -182,7 +182,7 @@ class ConfigurationTraitTest extends TestCase
             ]
         ]);
 
-        $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
+        $input = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')->getMock();
         $this->command->setInput($input);
 
         $input->expects($this->at(5))

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -791,6 +791,14 @@ class MigrationsTest extends TestCase
             [
                 'id' => '2',
                 'letter' => 'b'
+            ],
+            [
+                'id' => '3',
+                'letter' => 'c'
+            ],
+            [
+                'id' => '4',
+                'letter' => 'd'
             ]
         ];
         $this->assertEquals($expected, $result);
@@ -838,7 +846,7 @@ class MigrationsTest extends TestCase
             $result = $this->migrations->migrate(['source' => 'SnapshotTests']);
             $this->assertTrue($result);
 
-            $this->migrations->rollback(['source' => 'SnapshotTests']);
+            $this->migrations->rollback(['target' => 0, 'source' => 'SnapshotTests']);
             unlink($destination . $copiedFileName);
         }
     }

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -799,6 +799,14 @@ class MigrationsTest extends TestCase
             [
                 'id' => '4',
                 'letter' => 'd'
+            ],
+            [
+                'id' => '5',
+                'letter' => 'e'
+            ],
+            [
+                'id' => '6',
+                'letter' => 'f'
             ]
         ];
         $this->assertEquals($expected, $result);

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -754,6 +754,51 @@ class MigrationsTest extends TestCase
     }
 
     /**
+     * Tests seeding the database with seeder
+     *
+     * @return void
+     */
+    public function testSeedCallSeeder()
+    {
+        $this->migrations->migrate();
+
+        $seed = $this->migrations->seed(['source' => 'CallSeeds', 'seed' => 'DatabaseSeed']);
+        $this->assertTrue($seed);
+        $result = $this->Connection->newQuery()
+            ->select(['*'])
+            ->from('numbers')
+            ->execute()->fetchAll('assoc');
+
+        $expected = [
+            [
+                'id' => '1',
+                'number' => '10',
+                'radix' => '10'
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+
+        $result = $this->Connection->newQuery()
+            ->select(['*'])
+            ->from('letters')
+            ->execute()->fetchAll('assoc');
+
+        $expected = [
+            [
+                'id' => '1',
+                'letter' => 'a'
+            ],
+            [
+                'id' => '2',
+                'letter' => 'b'
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+
+        $this->migrations->rollback(['target' => 0]);
+    }
+
+    /**
      * Tests that requesting a unexistant seed throws an exception
      *
      * @expectedException \InvalidArgumentException

--- a/tests/TestCase/Shell/Task/CommandTaskTest.php
+++ b/tests/TestCase/Shell/Task/CommandTaskTest.php
@@ -43,17 +43,16 @@ class CommandTaskTest extends TestCase
         $this->out = new TestCompletionStringOutput();
         $io = new ConsoleIo($this->out);
 
-        $this->Shell = $this->getMock(
-            'Cake\Shell\CompletionShell',
-            ['in', '_stop', 'clear'],
-            [$io]
-        );
 
-        $this->Shell->Command = $this->getMock(
-            'Cake\Shell\Task\CommandTask',
-            ['in', '_stop', 'clear'],
-            [$io]
-        );
+        $this->Shell = $this->getMockBuilder('\Cake\Shell\CompletionShell')
+            ->setMethods(['in', '_stop', 'clear'])
+            ->setConstructorArgs([$io])
+            ->getMock();
+
+        $this->Shell->Command = $this->getMockBuilder('\Cake\Shell\Task\CommandTask')
+            ->setMethods(['in', '_stop', 'clear'])
+            ->setConstructorArgs([$io])
+            ->getMock();
     }
 
     /**

--- a/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
@@ -56,11 +56,11 @@ class MigrationDiffTaskTest extends TestCase
         $this->out = new TestCompletionStringOutput();
         $io = new ConsoleIo($this->out);
 
-        $task = $this->getMock(
-            'Migrations\Shell\Task\MigrationDiffTask',
-            $mockedMethods,
-            [$io]
-        );
+        $task = $this->getMockBuilder('\Migrations\Shell\Task\MigrationDiffTask')
+            ->setMethods($mockedMethods)
+            ->setConstructorArgs([$io])
+            ->getMock();
+        
         $task->name = 'Migration';
         $task->connection = 'test';
         $task->BakeTemplate = new BakeTemplateTask($io);

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -60,13 +60,15 @@ class MigrationSnapshotTaskTest extends TestCase
     public function getTaskMock($mockedMethods = [])
     {
         $mockedMethods = $mockedMethods ?: ['in', 'err', 'dispatchShell', '_stop', 'findTables', 'fetchTableName'];
-        $inputOutput = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
+        $inputOutput = $this->getMockBuilder('\Cake\Console\ConsoleIo')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $task = $this->getMock(
-            'Migrations\Shell\Task\MigrationSnapshotTask',
-            $mockedMethods,
-            [$inputOutput]
-        );
+        $task = $this->getMockBuilder('\Migrations\Shell\Task\MigrationSnapshotTask')
+            ->setMethods($mockedMethods)
+            ->setConstructorArgs([$inputOutput])
+            ->getMock();
+
         $task->name = 'Migration';
         $task->connection = 'test';
         $task->BakeTemplate = new BakeTemplateTask($inputOutput);
@@ -83,10 +85,9 @@ class MigrationSnapshotTaskTest extends TestCase
      */
     public function testGetTableNames()
     {
-        $class = $this->getMock(
-            'Migrations\Test\TestCase\Shell\TestClassWithSnapshotTrait',
-            ['findTables', 'fetchTableName']
-        );
+        $class = $this->getMockBuilder('\Migrations\Test\TestCase\Shell\TestClassWithSnapshotTrait')
+            ->setMethods(['findTables', 'fetchTableName'])
+            ->getMock();
 
         $class->expects($this->any())
             ->method('findTables')

--- a/tests/TestCase/Shell/Task/MigrationTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationTaskTest.php
@@ -32,13 +32,15 @@ class MigrationTaskTest extends TestCase
     {
         parent::setUp();
         $this->_compareBasePath = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS;
-        $inputOutput = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
+        $inputOutput = $this->getMockBuilder('\Cake\Console\ConsoleIo')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $this->Task = $this->getMock(
-            'Migrations\Shell\Task\MigrationTask',
-            ['in', 'err', 'createFile', '_stop', 'error'],
-            [$inputOutput]
-        );
+        $this->Task = $this->getMockBuilder('\Migrations\Shell\Task\MigrationTask')
+            ->setMethods(['in', 'err', 'createFile', '_stop', 'error'])
+            ->setConstructorArgs([$inputOutput])
+            ->getMock();
+
         $this->Task->name = 'Migration';
         $this->Task->connection = 'test';
         $this->Task->BakeTemplate = new BakeTemplateTask($inputOutput);

--- a/tests/TestCase/Shell/Task/SeedTaskTest.php
+++ b/tests/TestCase/Shell/Task/SeedTaskTest.php
@@ -32,13 +32,15 @@ class SeedTaskTest extends TestCase
     {
         parent::setUp();
         $this->_compareBasePath = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Seeds' . DS;
-        $inputOutput = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
+        $inputOutput = $this->getMockBuilder('Cake\Console\ConsoleIo')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $this->Task = $this->getMock(
-            'Migrations\Shell\Task\SeedTask',
-            ['in', 'err', 'createFile', '_stop', 'error'],
-            [$inputOutput]
-        );
+        $this->Task = $this->getMockBuilder('\Migrations\Shell\Task\SeedTask')
+            ->setMethods(['in', 'err', 'createFile', '_stop', 'error'])
+            ->setConstructorArgs([$inputOutput])
+            ->getMock();
+
         $this->Task->name = 'Seeds';
         $this->Task->connection = 'test';
         $this->Task->BakeTemplate = new BakeTemplateTask($inputOutput);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -61,7 +61,7 @@ Cake\Cache\Cache::config([
 ]);
 
 if (!getenv('db_dsn')) {
-    putenv('db_dsn=sqlite:///:memory:');
+    putenv('db_dsn=sqlite://127.0.0.1/cakephp_test');
 }
 if (!getenv('DB')) {
     putenv('DB=sqlite');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -75,3 +75,6 @@ Plugin::load('Migrations', [
 Plugin::load('TestBlog', [
     'path' => ROOT . 'Plugin' . DS . 'TestBlog' . DS,
 ]);
+if (!defined('PHINX_VERSION')) {
+    define('PHINX_VERSION', (0 === strpos('@PHINX_VERSION@', '@PHINX_VERSION')) ? '0.4.3' : '@PHINX_VERSION@');
+}

--- a/tests/comparisons/Seeds/testBasicBaking.php
+++ b/tests/comparisons/Seeds/testBasicBaking.php
@@ -1,5 +1,5 @@
 <?php
-use Phinx\Seed\AbstractSeed;
+use Migrations\AbstractSeed;
 
 /**
  * Articles seed.

--- a/tests/test_app/Plugin/TestBlog/config/CallSeeds/PluginLettersSeed.php
+++ b/tests/test_app/Plugin/TestBlog/config/CallSeeds/PluginLettersSeed.php
@@ -4,7 +4,7 @@ use Migrations\AbstractSeed;
 /**
  * NumbersSeed seed.
  */
-class DatabaseSeed extends AbstractSeed
+class PluginLettersSeed extends AbstractSeed
 {
     /**
      * Run Method.
@@ -16,8 +16,16 @@ class DatabaseSeed extends AbstractSeed
      */
     public function run()
     {
-        $this->call('NumbersCallSeed');
-        $this->call('LettersSeed');
-        $this->call('TestBlog.PluginLettersSeed');
+        $data = [
+            [
+                'letter' => 'c'
+            ],
+            [
+                'letter' => 'd'
+            ]
+        ];
+
+        $table = $this->table('letters');
+        $table->insert($data)->save();
     }
 }

--- a/tests/test_app/Plugin/TestBlog/config/CallSeeds/PluginSubLettersSeed.php
+++ b/tests/test_app/Plugin/TestBlog/config/CallSeeds/PluginSubLettersSeed.php
@@ -4,7 +4,7 @@ use Migrations\AbstractSeed;
 /**
  * NumbersSeed seed.
  */
-class PluginLettersSeed extends AbstractSeed
+class PluginSubLettersSeed extends AbstractSeed
 {
     /**
      * Run Method.
@@ -18,16 +18,14 @@ class PluginLettersSeed extends AbstractSeed
     {
         $data = [
             [
-                'letter' => 'c'
+                'letter' => 'e'
             ],
             [
-                'letter' => 'd'
+                'letter' => 'f'
             ]
         ];
 
         $table = $this->table('letters');
         $table->insert($data)->save();
-
-        $this->call('TestBlog.PluginSubLettersSeed');
     }
 }

--- a/tests/test_app/Plugin/TestBlog/src/Model/Table/CategoriesTable.php
+++ b/tests/test_app/Plugin/TestBlog/src/Model/Table/CategoriesTable.php
@@ -11,17 +11,6 @@ class CategoriesTable extends Table
 {
     public function initialize(array $config)
     {
-        $db = getenv('DB');
-        switch($db) {
-            case 'sqlite':
-                $dbName = ':memory:.';
-                break;
-            case 'mysql':
-            case 'pgsql':
-                $dbName = 'cakephp_test.';
-                break;
-        }
-        $dbName .= 'categories';
-        $this->table($dbName);
+        $this->table('cakephp_test.categories');
     }
 }

--- a/tests/test_app/config/CallSeeds/DatabaseSeed.php
+++ b/tests/test_app/config/CallSeeds/DatabaseSeed.php
@@ -4,7 +4,7 @@ use Migrations\AbstractSeed;
 /**
  * NumbersSeed seed.
  */
-class NumbersSeed extends AbstractSeed
+class DatabaseSeed extends AbstractSeed
 {
     /**
      * Run Method.
@@ -16,14 +16,7 @@ class NumbersSeed extends AbstractSeed
      */
     public function run()
     {
-        $data = [
-            [
-                'number' => '10',
-                'radix' => '10'
-            ]
-        ];
-
-        $table = $this->table('numbers');
-        $table->insert($data)->save();
+        $this->call('NumbersCallSeed');
+        $this->call('LettersSeed');
     }
 }

--- a/tests/test_app/config/CallSeeds/LettersSeed.php
+++ b/tests/test_app/config/CallSeeds/LettersSeed.php
@@ -4,7 +4,7 @@ use Migrations\AbstractSeed;
 /**
  * NumbersSeed seed.
  */
-class NumbersSeed extends AbstractSeed
+class LettersSeed extends AbstractSeed
 {
     /**
      * Run Method.
@@ -18,12 +18,14 @@ class NumbersSeed extends AbstractSeed
     {
         $data = [
             [
-                'number' => '10',
-                'radix' => '10'
+                'letter' => 'a'
+            ],
+            [
+                'letter' => 'b'
             ]
         ];
 
-        $table = $this->table('numbers');
+        $table = $this->table('letters');
         $table->insert($data)->save();
     }
 }

--- a/tests/test_app/config/CallSeeds/NumbersCallSeed.php
+++ b/tests/test_app/config/CallSeeds/NumbersCallSeed.php
@@ -4,7 +4,7 @@ use Migrations\AbstractSeed;
 /**
  * NumbersSeed seed.
  */
-class NumbersSeed extends AbstractSeed
+class NumbersCallSeed extends AbstractSeed
 {
     /**
      * Run Method.


### PR DESCRIPTION
Usually when seeding, the order in which to insert the data must be respected to not encounter constraints violations.
Since Seeders are executed in the alphabetical order, there is currently no way to have one CLI call to do this in a clean way. This PR aims to fix this.

A new ``AbstractSeed`` class has been created which implements a ``call()`` method. This methods expects the name of the Seeder to call. The plugin dot syntax can be used to call seeders from a plugin.
Nested ``call()`` calls are also supported (a called Seeder can call other Seeders, because inception and everything).

I fixed all the ``getMock()`` calls in the tests as well.

Refs #212 