### PR TITLE
Sets the connection name to the commands

### DIFF
--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -37,6 +37,13 @@ trait ConfigurationTrait
     protected $configuration;
 
     /**
+     * Connection name to be used for this request
+     *
+     * @var string
+     */
+    protected $connection;
+
+    /**
      * The console input instance
      *
      * @var \Symfony\Component\Console\Input\Input
@@ -198,6 +205,7 @@ trait ConfigurationTrait
     {
         parent::bootstrap($input, $output);
         $name = $this->getConnectionName($input);
+        $this->connection = $name;
         ConnectionManager::alias($name, 'default');
         $connection = ConnectionManager::get($name);
 

--- a/src/Shell/Task/SnapshotTrait.php
+++ b/src/Shell/Task/SnapshotTrait.php
@@ -132,6 +132,16 @@ trait SnapshotTrait
             }
 
             foreach ($tableNamesInModel as $num => $table) {
+                if (strpos($table, '.') !== false) {
+                    $splitted = array_reverse(explode('.', $table, 2));
+
+                    $config = ConnectionManager::config($this->connection);
+                    $key = isset($config['schema']) ? 'schema' : 'database';
+                    if ($config[$key] === $splitted[1]) {
+                        $table = $splitted[0];
+                    }
+                }
+
                 if (!in_array($table, $tables)) {
                     unset($tableNamesInModel[$num]);
                 }
@@ -214,6 +224,11 @@ trait SnapshotTrait
         }
 
         $namespacedClassName = App::className($className, 'Model/Table', 'Table');
+
+        if (!class_exists($namespacedClassName)) {
+            return $tables;
+        }
+
         $reflection = new ReflectionClass($namespacedClassName);
         if (!$reflection->isInstantiable()) {
             return $tables;

--- a/tests/test_app/App/Model/Table/NumbersTable.php
+++ b/tests/test_app/App/Model/Table/NumbersTable.php
@@ -9,7 +9,7 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace TestApp\Model\Table;;
+namespace TestApp\Model\Table;
 
 use Cake\ORM\Table;
 
@@ -19,4 +19,14 @@ use Cake\ORM\Table;
  */
 class NumbersTable extends Table
 {
+    public function initialize(array $config)
+    {
+        $db = env('DB');
+        $schema = 'cakephp_test.';
+        if ($db === 'pgsql') {
+            $schema = '';
+        }
+
+        $this->table($schema . 'numbers');
+    }
 }


### PR DESCRIPTION
This PR aims to fix #239 
It sets the connection name to the commands (really in the ConfigurationTrait) when the command is bootstrapped.
This is kind of a special case for the dump command which uses methods normally reserved to the Bake tasks.

It also fixes a problem with tables name filtering when the table is set with a schema name (``$this->table('schema.table')``) in Table classes. Tables name set this way are removed from the tables to be dumped / baked if there is a mismatch between the schema of the connection passed and the one from the table.