### PR TITLE
Dump command and require-table

### DIFF
--- a/src/Command/Dump.php
+++ b/src/Command/Dump.php
@@ -78,7 +78,7 @@ class Dump extends AbstractCommand
         $collection = $connection->schemaCollection();
 
         $options = [
-            'require-table' => true,
+            'require-table' => false,
             'plugin' => $this->getPlugin($input)
         ];
         $tables = $this->getTablesToBake($collection, $options);


### PR DESCRIPTION
The ``dump`` command should not set ``require-table`` to true when fetching the tables to add to the dump because it can lead to unexpected results as reported in #232 and #244.

It turned out the issue experienced by @ypnos-web and @dereuromark are because of this option.

@lorenzo As specified in #232, it should be known that tables from plugins will also be added to the dump when migrating or rolling back a set of migrations (basically, the system will now add every tables it finds in the dump), potentially creating a situations where tables from plugin will be added in diffs.
Maybe there could be an option in the migration diff command to exclude tables :
- by specifying a list of table names
- by specifying a plugin name. When used it will fetch all ORM table classes in the said plugin and exclude them from the diff. 

We can keep the idea on the side right now and consider it if you have users reporting this issue. What do you think ?