### PR TITLE
Add support for specifying a nullable field #203

### DIFF
--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -16,14 +16,14 @@ class ColumnParser
      *
      * @var string
      */
-    protected $regexpParseColumn = '/^(\w*)(?::(\w*\[?\d*\]?))?(?::(\w*))?(?::(\w*))?/';
+    protected $regexpParseColumn = '/^(\w*)(?::(\w*\??\[?\d*\]?))?(?::(\w*))?(?::(\w*))?/';
 
     /**
      * Regex used to parse the field type and length
      *
      * @var string
      */
-    protected $regexpParseField = '/(\w+)\[(\d+)\]/';
+    protected $regexpParseField = '/(\w+\??)\[(\d+)\]/';
 
     /**
      * Parses a list of arguments into an array of fields
@@ -51,11 +51,14 @@ class ColumnParser
                 }
             }
 
+            $nullable = substr($type, -1) == '?';
+            $type = $nullable ? substr($type, 0, strlen($type)-1) : $type;
+
             list($type, $length) = $this->getTypeAndLength($field, $type);
             $fields[$field] = [
                 'columnType' => $type,
                 'options' => [
-                    'null' => false,
+                    'null' => $nullable,
                     'default' => null,
                 ]
             ];

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -52,7 +52,7 @@ class ColumnParser
             }
 
             $nullable = substr($type, -1) === '?';
-            $type = $nullable ? substr($type, 0, strlen($type) - 1) : $type;
+            $type = $nullable ? substr($type, 0, -1) : $type;
 
             list($type, $length) = $this->getTypeAndLength($field, $type);
             $fields[$field] = [

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -51,8 +51,8 @@ class ColumnParser
                 }
             }
 
-            $nullable = substr($type, -1) == '?';
-            $type = $nullable ? substr($type, 0, strlen($type)-1) : $type;
+            $nullable = substr($type, -1) === '?';
+            $type = $nullable ? substr($type, 0, strlen($type) - 1) : $type;
 
             list($type, $length) = $this->getTypeAndLength($field, $type);
             $fields[$field] = [

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -77,23 +77,7 @@ class ColumnParserTest extends TestCase
                     'limit' => 255,
                 ],
             ],
-            'description' => [
-                'columnType' => 'string',
-                'options' => [
-                    'null' => true,
-                    'default' => null,
-                    'limit' => 255,
-                ],
-            ],
-            'age' => [
-                'columnType' => 'integer',
-                'options' => [
-                    'null' => true,
-                    'default' => null,
-                    'limit' => 11,
-                ],
-            ],
-        ], $this->columnParser->parseFields(['id', 'name:string', 'description:string?', 'age:integer?']));
+        ], $this->columnParser->parseFields(['id', 'name']));
 
         $this->assertEquals([
             'id' => [
@@ -144,7 +128,23 @@ class ColumnParserTest extends TestCase
                     'limit' => 255,
                 ],
             ],
-        ], $this->columnParser->parseFields(['id', 'name']));
+            'description' => [
+                'columnType' => 'string',
+                'options' => [
+                    'null' => true,
+                    'default' => null,
+                    'limit' => 255,
+                ],
+            ],
+            'age' => [
+                'columnType' => 'integer',
+                'options' => [
+                    'null' => true,
+                    'default' => null,
+                    'limit' => 11,
+                ],
+            ],
+        ], $this->columnParser->parseFields(['id', 'name:string', 'description:string?', 'age:integer?']));
     }
 
     /**

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -77,7 +77,22 @@ class ColumnParserTest extends TestCase
                     'limit' => 255,
                 ],
             ],
-        ], $this->columnParser->parseFields(['id', 'name']));
+            'description' => [
+                'columnType' => 'string',
+                'options' => [
+                    'null' => true,
+                    'default' => null,
+                    'limit' => 255,
+                ],
+            ],
+            'age' => [
+                'columnType' => 'integer',
+                'options' => [
+                    'null' => true,
+                    'default' => null,
+                ],
+            ],
+        ], $this->columnParser->parseFields(['id', 'name:string', 'description:string?', 'age:integer?']));
 
         $this->assertEquals([
             'id' => [
@@ -123,12 +138,29 @@ class ColumnParserTest extends TestCase
             'name' => [
                 'columnType' => 'string',
                 'options' => [
-                    'null' => true,
+                    'null' => false,
                     'default' => null,
                     'limit' => 255,
                 ],
             ],
-        ], $this->columnParser->parseFields(['id', 'name:string?']));
+            'name' => [
+                'columnType' => 'string',
+                'options' => [
+                    'null' => false,
+                    'default' => null,
+                    'limit' => 255,
+                ],
+            ],
+
+            'name' => [
+                'columnType' => 'string',
+                'options' => [
+                    'null' => false,
+                    'default' => null,
+                    'limit' => 255,
+                ],
+            ],
+        ], $this->columnParser->parseFields(['id', 'name']));
     }
 
     /**

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -90,6 +90,7 @@ class ColumnParserTest extends TestCase
                 'options' => [
                     'null' => true,
                     'default' => null,
+                    'limit' => 11,
                 ],
             ],
         ], $this->columnParser->parseFields(['id', 'name:string', 'description:string?', 'age:integer?']));

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -144,23 +144,6 @@ class ColumnParserTest extends TestCase
                     'limit' => 255,
                 ],
             ],
-            'name' => [
-                'columnType' => 'string',
-                'options' => [
-                    'null' => false,
-                    'default' => null,
-                    'limit' => 255,
-                ],
-            ],
-
-            'name' => [
-                'columnType' => 'string',
-                'options' => [
-                    'null' => false,
-                    'default' => null,
-                    'limit' => 255,
-                ],
-            ],
         ], $this->columnParser->parseFields(['id', 'name']));
     }
 

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -110,6 +110,25 @@ class ColumnParserTest extends TestCase
                 ],
             ],
         ], $this->columnParser->parseFields(['id', 'created', 'modified', 'updated']));
+
+        $this->assertEquals([
+            'id' => [
+                'columnType' => 'integer',
+                'options' => [
+                    'null' => false,
+                    'default' => null,
+                    'limit' => 11
+                ],
+            ],
+            'name' => [
+                'columnType' => 'string',
+                'options' => [
+                    'null' => true,
+                    'default' => null,
+                    'limit' => 255,
+                ],
+            ],
+        ], $this->columnParser->parseFields(['id', 'name:string?']));
     }
 
     /**

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -111,7 +111,7 @@ class ColumnParserTest extends TestCase
             ],
         ], $this->columnParser->parseFields(['id', 'created', 'modified', 'updated']));
 
-        $this->assertEquals([
+        $expected = [
             'id' => [
                 'columnType' => 'integer',
                 'options' => [
@@ -144,7 +144,9 @@ class ColumnParserTest extends TestCase
                     'limit' => 11,
                 ],
             ],
-        ], $this->columnParser->parseFields(['id', 'name:string', 'description:string?', 'age:integer?']));
+        ];
+        $actual = $this->columnParser->parseFields(['id', 'name:string', 'description:string?', 'age:integer?']);
+        $this->assertEquals($expected, $actual);
     }
 
     /**


### PR DESCRIPTION
This patch provides the ability to specify that a column is nullable in a migration from the CakePHP bake command line by adding a question mark as a suffix to the column data type.

Example:
`bin/cake bake migration CreatePerson name:string description:string? age:integer?`

The patch applies to the ColumnParser class in src/Util/ColumnParser.php file and the diff can be found at:
https://github.com/nitincoded/migrations/commit/bd453eee3817a6c55d1c4f56c68088041fff84b3

A test was also added to the PHP Unit test in the ColumnParserTest class.