### PR TITLE
Don't catch exceptions in migrations (fixes #258)

### DIFF
--- a/src/MigrationsDispatcher.php
+++ b/src/MigrationsDispatcher.php
@@ -37,5 +37,6 @@ class MigrationsDispatcher extends Application
         $this->add(new Command\Rollback());
         $this->add(new Command\Seed());
         $this->add(new Command\Status());
+        $this->setCatchExceptions(false);
     }
 }


### PR DESCRIPTION
This is the change I propose to fix the code swallowing info on exceptions thrown by migrations.