### PR TITLE
Skip phinxlog tables in diff

### DIFF
--- a/src/Shell/Task/MigrationDiffTask.php
+++ b/src/Shell/Task/MigrationDiffTask.php
@@ -469,7 +469,7 @@ class MigrationDiffTask extends SimpleMigrationTask
 
         $collection = ConnectionManager::get($this->connection)->schemaCollection();
         foreach ($this->tables as $table) {
-            if (strpos($table, 'phinx') === 0) {
+            if (preg_match("/^.*phinxlog$/", $table) === 1) {
                 continue;
             }
 

--- a/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
@@ -60,7 +60,7 @@ class MigrationDiffTaskTest extends TestCase
             ->setMethods($mockedMethods)
             ->setConstructorArgs([$io])
             ->getMock();
-        
+
         $task->name = 'Migration';
         $task->connection = 'test';
         $task->BakeTemplate = new BakeTemplateTask($io);
@@ -169,6 +169,9 @@ class MigrationDiffTaskTest extends TestCase
             ->delete('phinxlog')
             ->where(['version' => 20160415220805])
             ->execute();
+
+        // Create a _phinxlog table to make sure it's not included in the dump
+        $connection->query("CREATE TABLE articles_phinxlog LIKE phinxlog;");
 
         $this->_compareBasePath = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Diff' . DS;
 


### PR DESCRIPTION
When generating a snapshot all "*phinxlog" tables are skipped. However when baking a diff only "phinxlog" table is skipped, which I guess is wrong.