### PR TITLE
Fix MySQL build

### DIFF
--- a/src/Shell/Task/MigrationDiffTask.php
+++ b/src/Shell/Task/MigrationDiffTask.php
@@ -234,6 +234,7 @@ class MigrationDiffTask extends SimpleMigrationTask
             // changes in columns meta-data
             foreach ($currentColumns as $columnName) {
                 $column = $currentSchema->column($columnName);
+                unset($column['collate']);
                 $oldColumn = $this->dumpSchema[$table]->column($columnName);
 
                 if (in_array($columnName, $oldColumns) &&


### PR DESCRIPTION
This should fix the build which is currently failing.
It failed because of https://github.com/cakephp/cakephp/pull/8978 which added a new property (column collation) in columns reflection which is not supported by phinx (for the version the plugin is pinned to at least).

For the time being, I'll just remove the property. Maybe when we bump up phinx supported version, it might go away, in case per-column collation is supported.
