### PR TITLE
Change type of `default` values

### DIFF
--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -331,7 +331,7 @@ class MigrationHelper extends Helper
      * @param string $value A value to represent as a string
      * @return mixed
      */
-    public function value($value)
+    public function value($value, $numbersAsString = false)
     {
         if ($value === null || $value === 'null' || $value === 'NULL') {
             return 'null';
@@ -345,7 +345,7 @@ class MigrationHelper extends Helper
             return $value ? 'true' : 'false';
         }
 
-        if (is_numeric($value) || ctype_digit($value)) {
+        if (!$numbersAsString && (is_numeric($value) || ctype_digit($value))) {
             return (float)$value;
         }
 
@@ -428,7 +428,7 @@ class MigrationHelper extends Helper
                 ]);
                 $v = sprintf('[%s]', $v);
             } else {
-                $v = $this->value($v);
+                $v = $this->value($v, $k === 'default');
             }
             if (!is_numeric($k)) {
                 $v = "'$k' => $v";

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -32,6 +32,7 @@ class ArticlesFixture extends TestFixture
         'title' => ['type' => 'string', 'null' => true, 'length' => 255, 'comment' => 'Article title'],
         'category_id' => ['type' => 'integer', 'length' => 11],
         'product_id' => ['type' => 'integer', 'length' => 11],
+        'note' => ['type' => 'string', 'default' => '7.4', 'length' => 255],
         'counter' => ['type' => 'integer', 'length' => 11, 'unsigned' => true],
         'active' => ['type' => 'boolean', 'default' => 0],
         'created' => ['type' => 'timestamp', 'null' => true, 'default' => null],

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -245,6 +245,10 @@ class MigrationHelperTest extends TestCase
         $this->assertEquals(1.5, $this->Helper->value('1.5'));
         $this->assertEquals(1, $this->Helper->value('1'));
         $this->assertInternalType('float', $this->Helper->value('1'));
+        $this->assertInternalType('string', $this->Helper->value('1', true));
+        $this->assertInternalType('string', $this->Helper->value('1.5', true));
+        $this->assertInternalType('string', $this->Helper->value(1, true));
+        $this->assertInternalType('string', $this->Helper->value(1.5, true));
         $this->assertEquals("'one'", $this->Helper->value('one'));
         $this->assertEquals("'o\\\"ne'", $this->Helper->value('o"ne'));
     }

--- a/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
@@ -33,6 +33,11 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
                 'limit' => 10,
                 'null' => true,
             ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
                 'limit' => 10,

--- a/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
@@ -23,6 +23,11 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                 'limit' => 10,
                 'null' => true,
             ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
                 'limit' => 10,

--- a/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
@@ -23,6 +23,11 @@ class TestPluginBlogPgsql extends AbstractMigration
                 'limit' => 10,
                 'null' => true,
             ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
                 'limit' => 10,

--- a/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
@@ -32,6 +32,11 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
                 'limit' => 11,

--- a/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
@@ -22,6 +22,11 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
                 'limit' => 11,

--- a/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
@@ -22,6 +22,11 @@ class TestPluginBlogSqlite extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
                 'limit' => 11,

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -33,6 +33,11 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
                 'limit' => 11,

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
@@ -33,6 +33,11 @@ class TestAutoIdDisabledSnapshot56 extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
                 'limit' => 11,

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -23,6 +23,11 @@ class TestNotEmptySnapshot extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
                 'limit' => 11,

--- a/tests/comparisons/Migration/test_not_empty_snapshot56.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot56.php
@@ -23,6 +23,11 @@ class TestNotEmptySnapshot56 extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
                 'limit' => 11,

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -33,6 +33,11 @@ class TestPluginBlog extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
                 'limit' => 11,

--- a/tests/comparisons/Migration/test_plugin_blog56.php
+++ b/tests/comparisons/Migration/test_plugin_blog56.php
@@ -33,6 +33,11 @@ class TestPluginBlog56 extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
                 'limit' => 11,


### PR DESCRIPTION
This is proposition to fix issue #266.

By forcing `default` values to be treated as strings, we should prevent localized float typecast to build erroring migration files.
