### PR TITLE
Correctly handle constraints action names on diff

### DIFF
--- a/src/Template/Bake/Element/add-foreign-keys.ctp
+++ b/src/Template/Bake/Element/add-foreign-keys.ctp
@@ -33,8 +33,8 @@ $hasProcessedConstraint = false;
                 '<%= $constraint['references'][0] %>',
                 <%= $columnsReference %>,
                 [
-                    'update' => '<%= strtoupper($constraint['update']) %>',
-                    'delete' => '<%= strtoupper($constraint['delete']) %>'
+                    'update' => '<%= $this->Migration->formatConstraintAction($constraint['update']) %>',
+                    'delete' => '<%= $this->Migration->formatConstraintAction($constraint['delete']) %>'
                 ]
             )
 <% endif; %>

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -203,14 +203,29 @@ class MigrationHelper extends Helper
             foreach ($tableConstraints as $name) {
                 $constraint = $tableSchema->constraint($name);
                 if (isset($constraint['update'])) {
-                    $constraint['update'] = strtoupper(Inflector::underscore($constraint['update']));
-                    $constraint['delete'] = strtoupper(Inflector::underscore($constraint['delete']));
+                    $constraint['update'] = $this->formatConstraintAction($constraint['update']);
+                    $constraint['delete'] = $this->formatConstraintAction($constraint['delete']);
                 }
                 $constraints[$name] = $constraint;
             }
         }
 
         return $constraints;
+    }
+
+    /**
+     * Format a constraint action if it is not already in the format expected by Phinx
+     *
+     * @param string $constraint Constraint action name
+     * @return string Constraint action name altered if needed.
+     */
+    public function formatConstraintAction($constraint)
+    {
+        if (defined('\Phinx\Db\Table\ForeignKey::' . $constraint)) {
+            return $constraint;
+        }
+
+        return strtoupper(Inflector::underscore($constraint));
     }
 
     /**

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -49,8 +49,8 @@ class ArticlesFixture extends TestFixture
                 'type' => 'foreign',
                 'columns' => ['category_id'],
                 'references' => ['categories', 'id'],
-                'update' => 'cascade',
-                'delete' => 'cascade'
+                'update' => 'noAction',
+                'delete' => 'noAction'
             ],
             'product_idx' => [
                 'type' => 'foreign',

--- a/tests/comparisons/Diff/the_diff.php
+++ b/tests/comparisons/Diff/the_diff.php
@@ -94,8 +94,8 @@ class TheDiff extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'RESTRICT',
-                    'delete' => 'RESTRICT'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->update();

--- a/tests/comparisons/Diff/the_diff_mysql.php
+++ b/tests/comparisons/Diff/the_diff_mysql.php
@@ -94,8 +94,8 @@ class TheDiffMysql extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'RESTRICT',
-                    'delete' => 'RESTRICT'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->update();

--- a/tests/comparisons/Diff/the_diff_pgsql.php
+++ b/tests/comparisons/Diff/the_diff_pgsql.php
@@ -94,8 +94,8 @@ class TheDiffPgsql extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'RESTRICT',
-                    'delete' => 'RESTRICT'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
@@ -305,8 +305,8 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->addForeignKey(

--- a/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
@@ -258,8 +258,8 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->addForeignKey(

--- a/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
@@ -118,8 +118,8 @@ class TestPluginBlogPgsql extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->addForeignKey(

--- a/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
@@ -305,8 +305,8 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->addForeignKey(

--- a/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
@@ -258,8 +258,8 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->addForeignKey(

--- a/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
@@ -119,8 +119,8 @@ class TestPluginBlogSqlite extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->addForeignKey(

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -306,8 +306,8 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->addForeignKey(

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
@@ -307,8 +307,8 @@ class TestAutoIdDisabledSnapshot56 extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->addForeignKey(

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -259,8 +259,8 @@ class TestNotEmptySnapshot extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->addForeignKey(

--- a/tests/comparisons/Migration/test_not_empty_snapshot56.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot56.php
@@ -260,8 +260,8 @@ class TestNotEmptySnapshot56 extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->addForeignKey(

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -145,8 +145,8 @@ class TestPluginBlog extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->addForeignKey(

--- a/tests/comparisons/Migration/test_plugin_blog56.php
+++ b/tests/comparisons/Migration/test_plugin_blog56.php
@@ -145,8 +145,8 @@ class TestPluginBlog56 extends AbstractMigration
                 'categories',
                 'id',
                 [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE'
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION'
                 ]
             )
             ->addForeignKey(


### PR DESCRIPTION
Baking diff now correctly writes contraints action names.
While at it, I made sure snapshots already do it properly.

Refs #273 