### PR TITLE
Stop pluralizing table name when baking migrations

### DIFF
--- a/src/Shell/Task/MigrationTask.php
+++ b/src/Shell/Task/MigrationTask.php
@@ -108,16 +108,16 @@ class MigrationTask extends SimpleMigrationTask
     {
         if (preg_match('/^(Create|Drop)(.*)/', $name, $matches)) {
             $action = strtolower($matches[1]) . '_table';
-            $table = Inflector::tableize(Inflector::pluralize($matches[2]));
+            $table = Inflector::underscore($matches[2]);
         } elseif (preg_match('/^(Add).+?(?:To)(.*)/', $name, $matches)) {
             $action = 'add_field';
-            $table = Inflector::tableize(Inflector::pluralize($matches[2]));
+            $table = Inflector::underscore($matches[2]);
         } elseif (preg_match('/^(Remove).+?(?:From)(.*)/', $name, $matches)) {
             $action = 'drop_field';
-            $table = Inflector::tableize(Inflector::pluralize($matches[2]));
+            $table = Inflector::underscore($matches[2]);
         } elseif (preg_match('/^(Alter)(.*)/', $name, $matches)) {
             $action = 'alter_table';
-            $table = Inflector::tableize(Inflector::pluralize($matches[2]));
+            $table = Inflector::underscore($matches[2]);
         } else {
             return [];
         }

--- a/tests/TestCase/Shell/Task/MigrationTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationTaskTest.php
@@ -153,6 +153,10 @@ class MigrationTaskTest extends TestCase
             ['create_table', 'groups_users'],
             $this->Task->detectAction('CreateGroupsUsers')
         );
+        $this->assertEquals(
+            ['create_table', 'articles_i18n'],
+            $this->Task->detectAction('CreateArticlesI18n')
+        );
 
         $this->assertEquals(
             ['drop_table', 'groups'],
@@ -165,6 +169,10 @@ class MigrationTaskTest extends TestCase
         $this->assertEquals(
             ['drop_table', 'groups_users'],
             $this->Task->detectAction('DropGroupsUsers')
+        );
+        $this->assertEquals(
+            ['drop_table', 'articles_i18n'],
+            $this->Task->detectAction('DropArticlesI18n')
         );
 
         $this->assertEquals(
@@ -199,6 +207,10 @@ class MigrationTaskTest extends TestCase
             ['add_field', 'todos'],
             $this->Task->detectAction('AddSomeFieldToTodos')
         );
+        $this->assertEquals(
+            ['add_field', 'articles_i18n'],
+            $this->Task->detectAction('AddSomeFieldToArticlesI18n')
+        );
 
         $this->assertEquals(
             ['drop_field', 'groups'],
@@ -232,6 +244,10 @@ class MigrationTaskTest extends TestCase
             ['drop_field', 'fromages'],
             $this->Task->detectAction('RemoveFromageFromFromages')
         );
+        $this->assertEquals(
+            ['drop_field', 'articles_i18n'],
+            $this->Task->detectAction('RemoveFromageFromArticlesI18n')
+        );
 
         $this->assertEquals(
             ['alter_table', 'groups'],
@@ -244,6 +260,10 @@ class MigrationTaskTest extends TestCase
         $this->assertEquals(
             ['alter_table', 'groups_users'],
             $this->Task->detectAction('AlterGroupsUsers')
+        );
+        $this->assertEquals(
+            ['alter_table', 'articles_i18n'],
+            $this->Task->detectAction('AlterArticlesI18n')
         );
 
         $this->assertSame(


### PR DESCRIPTION
When the name of migrations provided when calling a `bake` command follows the "action" convention, the computed table name should not be pluralized and should follow the input of the user