### PR TITLE
updating phinx version to v0.5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "robmorgan/phinx": "0.5.5",
+        "robmorgan/phinx": "0.5.4",
         "cakephp/cakephp": "~3.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "robmorgan/phinx": "0.5.3",
+        "robmorgan/phinx": "0.5.5",
         "cakephp/cakephp": "~3.1"
     },
     "require-dev": {


### PR DESCRIPTION
I'm using Alpine linux for Docker.
There is problem that GLOB_BRACE doesn't supported 😢 
GLOB_BRACE is referenced by phinx.

This problem has been fixed already by the revision https://github.com/robmorgan/phinx/commit/b4cc87eee3d398539c48c39a546438ece85ddb71

I hope you to merge the PR.

PHP version: 7.1.0
CakePHP version: 3.3.11

The problem is the following when I exec `bin/cake migrations migrate`:
```shell
Warning Error: Invalid argument supplied for foreach() in [/usr/share/nginx/html/vendor/robmorgan/phinx/src/Phinx/Migration/Manager.php, line 526]

2016-12-28 06:25:19 Warning: Warning (2): Invalid argument supplied for foreach() in [/usr/share/nginx/html/vendor/robmorgan/phinx/src/Phinx/Migration/Manager.php, line 526]
Trace:
Cake\Error\BaseErrorHandler::handleError() - CORE/src/Error/BaseErrorHandler.php, line 146
Phinx\Migration\Manager::getMigrations() - ROOT/vendor/robmorgan/phinx/src/Phinx/Migration/Manager.php, line 526
Phinx\Migration\Manager::migrate() - ROOT/vendor/robmorgan/phinx/src/Phinx/Migration/Manager.php, line 240
Phinx\Console\Command\Migrate::execute() - ROOT/vendor/robmorgan/phinx/src/Phinx/Console/Command/Migrate.php, line 113
Migrations\Command\Migrate::parentExecute() - ROOT/vendor/cakephp/migrations/src/ConfigurationTrait.php, line 165
Migrations\Command\Migrate::execute() - ROOT/vendor/cakephp/migrations/src/Command/Migrate.php, line 64
Symfony\Component\Console\Command\Command::run() - ROOT/vendor/symfony/console/Command/Command.php, line 255
Symfony\Component\Console\Application::doRunCommand() - ROOT/vendor/symfony/console/Application.php, line 830
Symfony\Component\Console\Application::doRun() - ROOT/vendor/symfony/console/Application.php, line 191
Symfony\Component\Console\Application::run() - ROOT/vendor/symfony/console/Application.php, line 122
Migrations\Shell\MigrationsShell::main() - ROOT/vendor/cakephp/migrations/src/Shell/MigrationsShell.php, line 100
Cake\Console\Shell::runCommand() - CORE/src/Console/Shell.php, line 466
Migrations\Shell\MigrationsShell::runCommand() - ROOT/vendor/cakephp/migrations/src/Shell/MigrationsShell.php, line 155
Cake\Console\ShellDispatcher::_dispatch() - CORE/src/Console/ShellDispatcher.php, line 227
Cake\Console\ShellDispatcher::dispatch() - CORE/src/Console/ShellDispatcher.php, line 182
Cake\Console\ShellDispatcher::run() - CORE/src/Console/ShellDispatcher.php, line 128
[main] - ROOT/bin/cake.php, line 33
```

 