### PR TITLE
Upgrade to Phinx 0.6.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "robmorgan/phinx": "0.5.3",
+        "robmorgan/phinx": "0.6.5",
         "cakephp/cakephp": "~3.1"
     },
     "require-dev": {

--- a/src/CakeAdapter.php
+++ b/src/CakeAdapter.php
@@ -20,6 +20,7 @@ use Phinx\Db\Table\Column;
 use Phinx\Db\Table\ForeignKey;
 use Phinx\Db\Table\Index;
 use Phinx\Migration\MigrationInterface;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -684,5 +685,50 @@ class CakeAdapter implements AdapterInterface
     public function dropDatabase($name)
     {
         $this->adapter->dropDatabase($name);
+    }
+
+    /**
+     * Sets the console input.
+     *
+     * @param InputInterface $input Input
+     * @return AdapterInterface
+     */
+    public function setInput(InputInterface $input)
+    {
+        $this->adapter->setInput($input);
+        return $this;
+    }
+
+    /**
+     * Gets the console input.
+     *
+     * @return InputInterface
+     */
+    public function getInput()
+    {
+        return $this->adapter->getInput();
+    }
+
+    /**
+     * Toggle a migration breakpoint.
+     *
+     * @param MigrationInterface $migration
+     *
+     * @return AdapterInterface
+     */
+    public function toggleBreakpoint(MigrationInterface $migration)
+    {
+        $this->adapter->toggleBreakpoint($migration);
+        return $this;
+    }
+
+    /**
+     * Reset all migration breakpoints.
+     *
+     * @return int The number of breakpoints reset
+     */
+    public function resetAllBreakpoints()
+    {
+        return $this->adapter->resetAllBreakpoints();
     }
 }

--- a/src/CakeAdapter.php
+++ b/src/CakeAdapter.php
@@ -103,7 +103,7 @@ class CakeAdapter implements AdapterInterface
      * Set adapter configuration options.
      *
      * @param  array $options
-     * @return AdapterInterface
+     * @return $this
      */
     public function setOptions(array $options)
     {
@@ -146,7 +146,7 @@ class CakeAdapter implements AdapterInterface
      * Sets the console output.
      *
      * @param OutputInterface $output Output
-     * @return AdapterInterface
+     * @return $this
      */
     public function setOutput(OutputInterface $output)
     {
@@ -167,7 +167,7 @@ class CakeAdapter implements AdapterInterface
      * Sets the command start time
      *
      * @param int $time
-     * @return AdapterInterface
+     * @return $this
      */
     public function setCommandStartTime($time)
     {
@@ -224,7 +224,7 @@ class CakeAdapter implements AdapterInterface
      * @param string $direction Direction
      * @param int $startTime Start Time
      * @param int $endTime End Time
-     * @return AdapterInterface
+     * @return $this
      */
     public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime)
     {
@@ -691,7 +691,7 @@ class CakeAdapter implements AdapterInterface
      * Sets the console input.
      *
      * @param InputInterface $input Input
-     * @return AdapterInterface
+     * @return $this
      */
     public function setInput(InputInterface $input)
     {
@@ -714,7 +714,7 @@ class CakeAdapter implements AdapterInterface
      *
      * @param MigrationInterface $migration
      *
-     * @return AdapterInterface
+     * @return $this
      */
     public function toggleBreakpoint(MigrationInterface $migration)
     {

--- a/src/CakeManager.php
+++ b/src/CakeManager.php
@@ -172,7 +172,7 @@ class CakeManager extends Manager
         $versionToRollback = $versions[$index];
 
         $this->getOutput()->writeln('Rolling back to version ' . $versionToRollback);
-        $this->rollback($environment, $versionToRollback, $force = false);
+        $this->rollback($environment, $versionToRollback, $force);
     }
 
     /**

--- a/src/CakeManager.php
+++ b/src/CakeManager.php
@@ -144,7 +144,7 @@ class CakeManager extends Manager
     /**
      * {@inheritdoc}
      */
-    public function rollbackToDateTime($environment, \DateTime $dateTime)
+    public function rollbackToDateTime($environment, \DateTime $dateTime, $force = false)
     {
         $env = $this->getEnvironment($environment);
         $versions = $env->getVersions();
@@ -172,7 +172,7 @@ class CakeManager extends Manager
         $versionToRollback = $versions[$index];
 
         $this->getOutput()->writeln('Rolling back to version ' . $versionToRollback);
-        $this->rollback($environment, $versionToRollback);
+        $this->rollback($environment, $versionToRollback, $force = false);
     }
 
     /**

--- a/src/Command/Rollback.php
+++ b/src/Command/Rollback.php
@@ -39,6 +39,7 @@ class Rollback extends RollbackCommand
             ->addOption('--plugin', '-p', InputOption::VALUE_REQUIRED, 'The plugin containing the migrations')
             ->addOption('--connection', '-c', InputOption::VALUE_REQUIRED, 'The datasource connection to use')
             ->addOption('--source', '-s', InputOption::VALUE_REQUIRED, 'The folder where migrations are in')
+            ->addOption('--force', '-f', InputOption::VALUE_NONE, 'Force rollback to ignore breakpoints')
             ->addOption(
                 '--no-lock',
                 null,

--- a/src/Command/Seed.php
+++ b/src/Command/Seed.php
@@ -34,7 +34,7 @@ class Seed extends SeedRun
         $this->setName('seed')
             ->setDescription('Seed the database with data')
             ->setHelp('runs all available migrations, optionally up to a specific version')
-            ->addOption('--seed', null, InputOption::VALUE_REQUIRED, 'What is the name of the seeder?')
+            ->addOption('--seed', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'What is the name of the seeder?')
             ->addOption('--plugin', '-p', InputOption::VALUE_REQUIRED, 'The plugin containing the migrations')
             ->addOption('--connection', '-c', InputOption::VALUE_REQUIRED, 'The datasource connection to use')
             ->addOption('--source', '-s', InputOption::VALUE_REQUIRED, 'The folder where migrations are in');
@@ -53,6 +53,11 @@ class Seed extends SeedRun
         $event = $this->dispatchEvent('Migration.beforeSeed');
         if ($event->isStopped()) {
             return $event->result;
+        }
+
+        $seed = $input->getOption('seed');
+        if (!empty($seed)) {
+            $input->setOption('seed', [$input->getOption('seed')]);
         }
 
         $this->setInput($input);

--- a/src/Command/Seed.php
+++ b/src/Command/Seed.php
@@ -34,7 +34,12 @@ class Seed extends SeedRun
         $this->setName('seed')
             ->setDescription('Seed the database with data')
             ->setHelp('runs all available migrations, optionally up to a specific version')
-            ->addOption('--seed', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'What is the name of the seeder?')
+            ->addOption(
+                '--seed',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'What is the name of the seeder?'
+            )
             ->addOption('--plugin', '-p', InputOption::VALUE_REQUIRED, 'The plugin containing the migrations')
             ->addOption('--connection', '-c', InputOption::VALUE_REQUIRED, 'The datasource connection to use')
             ->addOption('--source', '-s', InputOption::VALUE_REQUIRED, 'The folder where migrations are in');

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -212,7 +212,7 @@ trait ConfigurationTrait
         $manager = $this->getManager();
 
         if (!$manager instanceof CakeManager) {
-            $this->setManager(new CakeManager($this->getConfig(), $output));
+            $this->setManager(new CakeManager($this->getConfig(), $input, $output));
         }
         $env = $this->getManager()->getEnvironment('default');
         $adapter = $env->getAdapter();

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -58,6 +58,14 @@ class Migrations
     protected $command;
 
     /**
+     * Stub input to feed the manager class since we might not have an input ready when we get the Manager using
+     * the `getManager()` method
+     *
+     * @var ArrayInput
+     */
+    protected $stubInput;
+
+    /**
      * Constructor
      * @param array $default Default option to be used when calling a method.
      * Available options are :
@@ -294,7 +302,7 @@ class Migrations
                 );
             }
 
-            $input = empty($this->input) ? $this->stubInput : $this->input;
+            $input = $input = $this->input ?: $this->stubInput;
             $this->manager = new CakeManager($config, $input, $this->output);
         } elseif ($config !== null) {
             $defaultEnvironment = $config->getEnvironment('default');

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -61,7 +61,7 @@ class Migrations
      * Stub input to feed the manager class since we might not have an input ready when we get the Manager using
      * the `getManager()` method
      *
-     * @var ArrayInput
+     * @var \Symfony\Component\Console\Input\ArrayInput
      */
     protected $stubInput;
 
@@ -302,7 +302,7 @@ class Migrations
                 );
             }
 
-            $input = $input = $this->input ?: $this->stubInput;
+            $input = $this->input ?: $this->stubInput;
             $this->manager = new CakeManager($config, $input, $this->output);
         } elseif ($config !== null) {
             $defaultEnvironment = $config->getEnvironment('default');

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -68,6 +68,7 @@ class Migrations
     public function __construct(array $default = [])
     {
         $this->output = new NullOutput();
+        $this->stubInput = new ArrayInput([]);
 
         if (!empty($default)) {
             $this->default = $default;
@@ -235,8 +236,14 @@ class Migrations
     {
         $this->setCommand('seed');
         $input = $this->getInput('Seed', [], $options);
-        $params = ['default', $input->getOption('seed')];
-        $this->run('Seed', $params, $input);
+
+        $seed = $input->getOption('seed');
+        if (empty($seed)) {
+            $seed = null;
+        }
+
+        $params = ['default', $seed];
+        $this->run('seed', $params, $input);
         return true;
     }
 
@@ -287,7 +294,8 @@ class Migrations
                 );
             }
 
-            $this->manager = new CakeManager($config, $this->output);
+            $input = empty($this->input) ? $this->stubInput : $this->input;
+            $this->manager = new CakeManager($config, $input, $this->output);
         } elseif ($config !== null) {
             $defaultEnvironment = $config->getEnvironment('default');
             try {

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -78,7 +78,7 @@ class Migrations
         $this->output = new NullOutput();
         $this->stubInput = new ArrayInput([]);
 
-        if (!empty($default)) {
+        if ($default) {
             $this->default = $default;
         }
     }
@@ -377,7 +377,7 @@ class Migrations
     protected function prepareOptions($options = [])
     {
         $options = array_merge($this->default, $options);
-        if (empty($options)) {
+        if (!$options) {
             return $options;
         }
 

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -246,7 +246,7 @@ class Migrations
         $input = $this->getInput('Seed', [], $options);
 
         $seed = $input->getOption('seed');
-        if (empty($seed)) {
+        if (!$seed) {
             $seed = null;
         }
 

--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -61,6 +61,7 @@ class MigrationsShell extends Shell
             ->addOption('ansi')
             ->addOption('no-ansi')
             ->addOption('no-lock', ['boolean' => true])
+            ->addOption('force', ['boolean' => true])
             ->addOption('version', ['short' => 'V'])
             ->addOption('no-interaction', ['short' => 'n'])
             ->addOption('template', ['short' => 't'])

--- a/tests/TestCase/Command/DumpTest.php
+++ b/tests/TestCase/Command/DumpTest.php
@@ -165,7 +165,7 @@ class DumpTest extends TestCase
 
         $input = new ArrayInput($params, $this->command->getDefinition());
         $this->command->setInput($input);
-        $manager = new CakeManager($this->command->getConfig(), $this->streamOutput);
+        $manager = new CakeManager($this->command->getConfig(), $input, $this->streamOutput);
         $manager->getEnvironment('default')->getAdapter()->setConnection($this->Connection->driver()->connection());
         $this->command->setManager($manager);
         $commandTester = new CommandTester($this->command);

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -14,6 +14,7 @@ namespace Migrations\Test\Command;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Migrations\MigrationsDispatcher;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -141,7 +142,7 @@ class MarkMigratedTest extends TestCase
 
         $manager = $this->getMockBuilder('\Migrations\CakeManager')
             ->setMethods(['getEnvironment', 'markMigrated', 'getMigrations'])
-            ->setConstructorArgs([$config, new StreamOutput(fopen('php://memory', 'a', false))])
+            ->setConstructorArgs([$config, new ArgvInput([]), new StreamOutput(fopen('php://memory', 'a', false))])
             ->getMock();
 
         $manager->expects($this->any())

--- a/tests/TestCase/Command/SeedTest.php
+++ b/tests/TestCase/Command/SeedTest.php
@@ -236,7 +236,7 @@ class SeedTest extends TestCase
 
         $input = new ArrayInput($params, $this->command->getDefinition());
         $this->command->setInput($input);
-        $manager = new CakeManager($this->command->getConfig(), $this->streamOutput);
+        $manager = new CakeManager($this->command->getConfig(), $input, $this->streamOutput);
         $manager->getEnvironment('default')->getAdapter()->setConnection($this->Connection->driver()->connection());
         $this->command->setManager($manager);
         $commandTester = new CommandTester($this->command);

--- a/tests/TestCase/Command/StatusTest.php
+++ b/tests/TestCase/Command/StatusTest.php
@@ -217,7 +217,7 @@ class StatusTest extends TestCase
     {
         $input = new ArrayInput($params, $this->command->getDefinition());
         $this->command->setInput($input);
-        $manager = new CakeManager($this->command->getConfig(), $this->streamOutput);
+        $manager = new CakeManager($this->command->getConfig(), $input, $this->streamOutput);
         $manager->getEnvironment('default')->getAdapter()->setConnection($this->Connection->driver()->connection());
         $this->command->setManager($manager);
         $commandTester = new CommandTester($this->command);


### PR DESCRIPTION
I upgraded with the idea in mind of having our test suite passing.

There is no guarantee that all new Phinx features between 0.5.3 (the current version pinned) and 0.6.5 (the latest) will work out of the box but I'm thinking we can go from there (with the plugin working as expected) and patch things up as we go.