### PR TITLE
When baking a diff, the attribute `length` / `limit`, `default` and ` null` are always included in `changeColumn` instructions.

### DIFF
--- a/src/Shell/Task/MigrationDiffTask.php
+++ b/src/Shell/Task/MigrationDiffTask.php
@@ -248,9 +248,24 @@ class MigrationDiffTask extends SimpleMigrationTask
                 ) {
                     $changedAttributes = array_diff($column, $oldColumn);
 
-                    if (!isset($changedAttributes['type'])) {
-                        $changedAttributes['type'] = $column['type'];
+                    foreach (['type', 'length', 'null', 'default'] as $attribute) {
+                        $phinxAttributeName = $attribute;
+                        if ($attribute == 'length') {
+                            $phinxAttributeName = 'limit';
+                        }
+                        if (!isset($changedAttributes[$phinxAttributeName])) {
+                            $changedAttributes[$phinxAttributeName] = $column[$attribute];
+                        }
                     }
+
+                    if (isset($changedAttributes['length'])) {
+                        if (!isset($changedAttributes['limit'])) {
+                            $changedAttributes['limit'] = $changedAttributes['length'];
+                        }
+
+                        unset($changedAttributes['length']);
+                    }
+
                     $this->templateData[$table]['columns']['changed'][$columnName] = $changedAttributes;
                 }
             }

--- a/tests/comparisons/Diff/the_diff.php
+++ b/tests/comparisons/Diff/the_diff.php
@@ -15,9 +15,15 @@ class TheDiff extends AbstractMigration
 
         $this->table('articles')
             ->removeColumn('content')
-            ->changeColumn('title', 'text')
+            ->changeColumn('title', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+            ])
             ->changeColumn('name', 'string', [
-                'length' => 50,
+                'default' => null,
+                'limit' => 50,
+                'null' => false,
             ])
             ->update();
 

--- a/tests/comparisons/Diff/the_diff_mysql.php
+++ b/tests/comparisons/Diff/the_diff_mysql.php
@@ -15,9 +15,15 @@ class TheDiffMysql extends AbstractMigration
 
         $this->table('articles')
             ->removeColumn('content')
-            ->changeColumn('title', 'text')
+            ->changeColumn('title', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+            ])
             ->changeColumn('name', 'string', [
-                'length' => 50,
+                'default' => null,
+                'limit' => 50,
+                'null' => false,
             ])
             ->update();
 

--- a/tests/comparisons/Diff/the_diff_pgsql.php
+++ b/tests/comparisons/Diff/the_diff_pgsql.php
@@ -15,9 +15,15 @@ class TheDiffPgsql extends AbstractMigration
 
         $this->table('articles')
             ->removeColumn('content')
-            ->changeColumn('title', 'text')
+            ->changeColumn('title', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+            ])
             ->changeColumn('name', 'string', [
-                'length' => 50,
+                'default' => null,
+                'limit' => 50,
+                'null' => false,
             ])
             ->update();
 


### PR DESCRIPTION
When baking a diff, the attribute `length` / `limit`, `default` and ` null` are always included in `changeColumn` instructions.

Since when some of these attributes are not here, phinx uses a default value, this could lead to data desynchronization of value from these attributes when rolling back and migrating again.

Refs #274 