### PR TITLE
Improve support for baking diff including the addition of a column with the `decimal` type

### DIFF
--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -306,6 +306,14 @@ class MigrationHelper extends Helper
         ];
     }
 
+    /**
+     * Compute the final array of options to display in a `addColumn` or `changeColumn` instruction.
+     * The method also takes care of translating properties names between CakePHP database layer and phinx database
+     * layer.
+     *
+     * @param array $options Array of options to compute the final list from.
+     * @return array
+     */
     public function getColumnOption($options)
     {
         $wantedOptions = array_flip([
@@ -334,8 +342,15 @@ class MigrationHelper extends Helper
         } else {
             // due to Phinx using different naming for the precision and scale to CakePHP
             $columnOptions['scale'] = $columnOptions['precision'];
-            $columnOptions['precision'] = $columnOptions['limit'];
-            unset($columnOptions['limit']);
+
+            if (isset($columnOptions['limit'])) {
+                $columnOptions['precision'] = $columnOptions['limit'];
+                unset($columnOptions['limit']);
+            }
+            if (isset($columnOptions['length'])) {
+                $columnOptions['precision'] = $columnOptions['length'];
+                unset($columnOptions['length']);
+            }
         }
 
         return $columnOptions;

--- a/tests/comparisons/Diff/the_diff.php
+++ b/tests/comparisons/Diff/the_diff.php
@@ -63,6 +63,13 @@ class TheDiff extends AbstractMigration
                 'length' => 11,
                 'null' => false,
             ])
+            ->addColumn('average_note', 'decimal', [
+                'after' => 'category_id',
+                'default' => null,
+                'null' => true,
+                'precision' => 5,
+                'scale' => 5,
+            ])
             ->addIndex(
                 [
                     'slug',
@@ -148,6 +155,7 @@ class TheDiff extends AbstractMigration
                 'null' => false,
             ])
             ->removeColumn('category_id')
+            ->removeColumn('average_note')
             ->addIndex(
                 [
                     'slug',

--- a/tests/comparisons/Diff/the_diff_mysql.php
+++ b/tests/comparisons/Diff/the_diff_mysql.php
@@ -63,6 +63,13 @@ class TheDiffMysql extends AbstractMigration
                 'length' => 11,
                 'null' => false,
             ])
+            ->addColumn('average_note', 'decimal', [
+                'after' => 'category_id',
+                'default' => null,
+                'null' => true,
+                'precision' => 5,
+                'scale' => 5,
+            ])
             ->addIndex(
                 [
                     'slug',
@@ -148,6 +155,7 @@ class TheDiffMysql extends AbstractMigration
                 'null' => false,
             ])
             ->removeColumn('category_id')
+            ->removeColumn('average_note')
             ->addIndex(
                 [
                     'slug',

--- a/tests/comparisons/Diff/the_diff_pgsql.php
+++ b/tests/comparisons/Diff/the_diff_pgsql.php
@@ -63,6 +63,13 @@ class TheDiffPgsql extends AbstractMigration
                 'length' => 10,
                 'null' => false,
             ])
+            ->addColumn('average_note', 'decimal', [
+                'after' => 'category_id',
+                'default' => null,
+                'null' => true,
+                'precision' => 5,
+                'scale' => 5,
+            ])
             ->addIndex(
                 [
                     'category_id',
@@ -148,6 +155,7 @@ class TheDiffPgsql extends AbstractMigration
                 'null' => false,
             ])
             ->removeColumn('category_id')
+            ->removeColumn('average_note')
             ->addIndex(
                 [
                     'slug',


### PR DESCRIPTION
Baking a diff with a `decimal` type column would lead to errors and notice emitted (a `Undefined index: limit`) with invalid properties set in the `decimal` type column.
This makes sure it does not happen anymore.

Note : Postgres build will fail really bad. But since it's allowed to fail this is not a big deal but until then it might clock other errors it can have.
I fixed what was wrong with the `decimal` support in Postgres in https://github.com/cakephp/cakephp/pull/9955.
For Postgres build to start getting better and return its usual errors, we will need to wait for the fix in the core to be included in a stable release.