### PR TITLE
An empty database should create an empty dump file

### DIFF
--- a/src/Command/Dump.php
+++ b/src/Command/Dump.php
@@ -84,14 +84,11 @@ class Dump extends AbstractCommand
         $tables = $this->getTablesToBake($collection, $options);
 
         $dump = [];
-        if (empty($tables)) {
-            $this->output()->writeln('<info>No tables were found : the dump file was not created</info>');
-            return false;
-        }
-
-        foreach ($tables as $table) {
-            $schema = $collection->describe($table);
-            $dump[$table] = $schema;
+        if ($tables) {
+            foreach ($tables as $table) {
+                $schema = $collection->describe($table);
+                $dump[$table] = $schema;
+            }
         }
 
         $filePath = $path . DS . 'schema-dump-' . $connectionName . '.lock';

--- a/tests/TestCase/Command/DumpTest.php
+++ b/tests/TestCase/Command/DumpTest.php
@@ -107,8 +107,8 @@ class DumpTest extends TestCase
             '--source' => 'TestsMigrations'
         ]);
 
-        $display = $commandTester->getDisplay();
-        $this->assertTextContains('No tables were found : the dump file was not created', $display);
+        $dumpPath = ROOT . 'config' . DS . 'TestsMigrations' . DS . 'schema-dump-test.lock';
+        $this->assertEquals(serialize([]), file_get_contents($dumpPath));
     }
 
     /**


### PR DESCRIPTION
When running the `dump` command on an empty database, it should create an empty `dump.lock` file (well, not completely empty, but with the content of a serialized empty array).

Otherwise, when rolling back the last migration, the dump file was left in its current state which does not make much sense.

Refs #294 