### PR TITLE
No need to convert the seed parameter to an array if it is already an array

### DIFF
--- a/src/Command/Seed.php
+++ b/src/Command/Seed.php
@@ -61,8 +61,8 @@ class Seed extends SeedRun
         }
 
         $seed = $input->getOption('seed');
-        if (!empty($seed)) {
-            $input->setOption('seed', [$input->getOption('seed')]);
+        if (!empty($seed) && !is_array($seed)) {
+            $input->setOption('seed', [$seed]);
         }
 
         $this->setInput($input);


### PR DESCRIPTION
No need to convert the seed parameter to an array if it is already an array

Refs #297 