### PR TITLE
When baking migrations, we should prevent duplicate names

### DIFF
--- a/src/Shell/Task/SimpleMigrationTask.php
+++ b/src/Shell/Task/SimpleMigrationTask.php
@@ -67,7 +67,20 @@ abstract class SimpleMigrationTask extends SimpleBakeTask
     {
         $migrationWithSameName = glob($this->getPath() . '*_' . $name . '.php');
         if (!empty($migrationWithSameName)) {
-            $this->abort(sprintf('A migration with the name `%s` already exists. Please use a different name.', $name));
+            $force = $this->param('force');
+            if (!$force) {
+                $this->abort(sprintf('A migration with the name `%s` already exists. Please use a different name.', $name));
+            }
+
+            $this->info(sprintf('A migration with the name `%s` already exists, it will be deleted.', $name));
+            foreach ($migrationWithSameName as $migration) {
+                $this->info(sprintf('Deleting migration file `%s`...', $migration));
+                if (unlink($migration)) {
+                    $this->success(sprintf('Deleted `%s`', $migration));
+                } else {
+                    $this->err(sprintf('An error occurred while deleting `%s`', $migration));
+                }
+            }
         }
 
         $this->params['no-test'] = true;
@@ -118,22 +131,26 @@ abstract class SimpleMigrationTask extends SimpleBakeTask
 
         $parser->description(
             'Bake migration class.'
-        )->addOption('plugin', [
-            'short' => 'p',
-            'help' => 'Plugin to bake into.'
-        ])->addOption('force', [
-            'short' => 'f',
-            'boolean' => true,
-            'help' => 'Force overwriting existing files without prompting.'
-        ])->addOption('connection', [
-            'short' => 'c',
-            'default' => 'default',
-            'help' => 'The datasource connection to get data from.'
-        ])->addOption('theme', [
-            'short' => 't',
-            'help' => 'The theme to use when baking code.',
-            'choices' => $bakeThemes
-        ]);
+            )
+            ->addOption('plugin', [
+                'short' => 'p',
+                'help' => 'Plugin to bake into.'
+            ])
+            ->addOption('force', [
+                'short' => 'f',
+                'boolean' => true,
+                'help' => 'Force overwriting existing file if a migration already exists with the same name.'
+            ])
+            ->addOption('connection', [
+                'short' => 'c',
+                'default' => 'default',
+                'help' => 'The datasource connection to get data from.'
+            ])
+            ->addOption('theme', [
+                'short' => 't',
+                'help' => 'The theme to use when baking code.',
+                'choices' => $bakeThemes
+            ]);
 
         return $parser;
     }

--- a/src/Shell/Task/SimpleMigrationTask.php
+++ b/src/Shell/Task/SimpleMigrationTask.php
@@ -65,6 +65,11 @@ abstract class SimpleMigrationTask extends SimpleBakeTask
      */
     public function bake($name)
     {
+        $migrationWithSameName = glob($this->getPath() . '*_' . $name . '.php');
+        if (!empty($migrationWithSameName)) {
+            $this->abort(sprintf('A migration with the name `%s` already exists. Please use a different name.', $name));
+        }
+
         $this->params['no-test'] = true;
         return parent::bake($name);
     }
@@ -80,16 +85,14 @@ abstract class SimpleMigrationTask extends SimpleBakeTask
     protected function getMigrationName($name = null)
     {
         if (empty($name)) {
-            $this->error('Choose a migration name to bake in CamelCase format');
-            return null;
+            $this->abort('Choose a migration name to bake in CamelCase format');
         }
 
         $name = $this->_getName($name);
         $name = Inflector::camelize($name);
 
         if (!preg_match('/^[A-Z]{1}[a-zA-Z0-9]+$/', $name)) {
-            $this->error('The className is not correct. The className can only contain "A-Z" and "0-9".');
-            return null;
+            $this->abort('The className is not correct. The className can only contain "A-Z" and "0-9".');
         }
 
         return $name;

--- a/src/Shell/Task/SimpleMigrationTask.php
+++ b/src/Shell/Task/SimpleMigrationTask.php
@@ -69,7 +69,12 @@ abstract class SimpleMigrationTask extends SimpleBakeTask
         if (!empty($migrationWithSameName)) {
             $force = $this->param('force');
             if (!$force) {
-                $this->abort(sprintf('A migration with the name `%s` already exists. Please use a different name.', $name));
+                $this->abort(
+                    sprintf(
+                        'A migration with the name `%s` already exists. Please use a different name.',
+                        $name
+                    )
+                );
             }
 
             $this->info(sprintf('A migration with the name `%s` already exists, it will be deleted.', $name));
@@ -131,26 +136,26 @@ abstract class SimpleMigrationTask extends SimpleBakeTask
 
         $parser->description(
             'Bake migration class.'
-            )
-            ->addOption('plugin', [
-                'short' => 'p',
-                'help' => 'Plugin to bake into.'
-            ])
-            ->addOption('force', [
-                'short' => 'f',
-                'boolean' => true,
-                'help' => 'Force overwriting existing file if a migration already exists with the same name.'
-            ])
-            ->addOption('connection', [
-                'short' => 'c',
-                'default' => 'default',
-                'help' => 'The datasource connection to get data from.'
-            ])
-            ->addOption('theme', [
-                'short' => 't',
-                'help' => 'The theme to use when baking code.',
-                'choices' => $bakeThemes
-            ]);
+        )
+        ->addOption('plugin', [
+            'short' => 'p',
+            'help' => 'Plugin to bake into.'
+        ])
+        ->addOption('force', [
+            'short' => 'f',
+            'boolean' => true,
+            'help' => 'Force overwriting existing file if a migration already exists with the same name.'
+        ])
+        ->addOption('connection', [
+            'short' => 'c',
+            'default' => 'default',
+            'help' => 'The datasource connection to get data from.'
+        ])
+        ->addOption('theme', [
+            'short' => 't',
+            'help' => 'The theme to use when baking code.',
+            'choices' => $bakeThemes
+        ]);
 
         return $parser;
     }

--- a/tests/TestCase/Shell/Task/MigrationTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationTaskTest.php
@@ -139,6 +139,38 @@ class MigrationTaskTest extends TestCase
     }
 
     /**
+     * Tests that baking a migration with the name as another with the parameter "force", will delete the existing file.
+     */
+    public function testCreateDuplicateNameWithForce()
+    {
+        $inputOutput = $this->getMockBuilder('\Cake\Console\ConsoleIo')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $task = $this->getMockBuilder('\Migrations\Shell\Task\MigrationTask')
+            ->setMethods(['in', 'err', '_stop', 'error'])
+            ->setConstructorArgs([$inputOutput])
+            ->getMock();
+
+        $task->name = 'Migration';
+        $task->connection = 'test';
+        $task->params['force'] = true;
+        $task->BakeTemplate = new BakeTemplateTask($inputOutput);
+        $task->BakeTemplate->initialize();
+        $task->BakeTemplate->interactive = false;
+
+        $task->bake('CreateUsers');
+
+        $file = glob(ROOT . 'config' . DS . 'Migrations' . DS . '*_CreateUsers.php');
+        $filePath = current($file);
+        sleep(1);
+
+        $task->bake('CreateUsers');
+        $file = glob(ROOT . 'config' . DS . 'Migrations' . DS . '*_CreateUsers.php');
+        $this->assertNotEquals($filePath, current($file));
+    }
+
+    /**
      * Test that adding a field or altering a table with a primary
      * key will error out
      *

--- a/tests/TestCase/Shell/Task/MigrationTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationTaskTest.php
@@ -112,6 +112,33 @@ class MigrationTaskTest extends TestCase
     }
 
     /**
+     * Tests that baking a migration with the name as another will throw an exception.
+     *
+     * @expectedException \Cake\Console\Exception\StopException
+     * @expectedExceptionMessage A migration with the name `CreateUsers` already exists. Please use a different name.
+     */
+    public function testCreateDuplicateName()
+    {
+        $inputOutput = $this->getMockBuilder('\Cake\Console\ConsoleIo')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $task = $this->getMockBuilder('\Migrations\Shell\Task\MigrationTask')
+            ->setMethods(['in', 'err', '_stop', 'error'])
+            ->setConstructorArgs([$inputOutput])
+            ->getMock();
+
+        $task->name = 'Migration';
+        $task->connection = 'test';
+        $task->BakeTemplate = new BakeTemplateTask($inputOutput);
+        $task->BakeTemplate->initialize();
+        $task->BakeTemplate->interactive = false;
+
+        $task->bake('CreateUsers');
+        $task->bake('CreateUsers');
+    }
+
+    /**
      * Test that adding a field or altering a table with a primary
      * key will error out
      *


### PR DESCRIPTION
If you use this command multiple times :

`bin/cake bake migration TestCreate`

It will create the same file with the same class name each time which will, in the end, trigger an exception when migrating.
The problems should be caught early on and this PR implements a mechanism that prevents to create a migration if it already has the same name as another one in the target directory.