### PR TITLE
Use database default collation when creating a table if none is provided

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ sudo: false
 
 env:
   matrix:
-    - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test' db_dsn_compare='mysql://root@0.0.0.0/cakephp_comparisons'
+    - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test?encoding=utf8mb4' db_dsn_compare='mysql://root@0.0.0.0/cakephp_comparisons'
     - DB=sqlite
   global:
     - DEFAULT=1
@@ -17,14 +17,14 @@ env:
 matrix:
   allow_failures:
     - php: hhvm
-    - env: CODECOVERAGE=1 DEFAULT=0 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test' db_dsn_compare='mysql://root@0.0.0.0/cakephp_comparisons'
+    - env: CODECOVERAGE=1 DEFAULT=0 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test?encoding=utf8mb4' db_dsn_compare='mysql://root@0.0.0.0/cakephp_comparisons'
     - env: DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test' db_dsn_compare='postgres://postgres@127.0.0.1/cakephp_comparisons'
 
   fast_finish: true
 
   include:
     - php: 7.0
-      env: CODECOVERAGE=1 DEFAULT=0 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test' db_dsn_compare='mysql://root@0.0.0.0/cakephp_comparisons'
+      env: CODECOVERAGE=1 DEFAULT=0 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test?encoding=utf8mb4' db_dsn_compare='mysql://root@0.0.0.0/cakephp_comparisons'
 
     - php: 5.5
       env: DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test' db_dsn_compare='postgres://postgres@127.0.0.1/cakephp_comparisons'
@@ -32,7 +32,7 @@ matrix:
     - php: 5.6
       dist: trusty
       sudo: required
-      env: DB=mysql db_dsn='mysql://root@0.0.0.0/cakephp_test' DBV=56 db_dsn_compare='mysql://root@0.0.0.0/cakephp_comparisons'
+      env: DB=mysql db_dsn='mysql://root@0.0.0.0/cakephp_test?encoding=utf8mb4' DBV=56 db_dsn_compare='mysql://root@0.0.0.0/cakephp_comparisons'
       addons:
         apt:
           packages:
@@ -53,7 +53,7 @@ matrix:
       env: HHVM=1 DB=sqlite
 
     - php: hhvm
-      env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test' db_dsn_compare='mysql://travis@0.0.0.0/cakephp_comparisons'
+      env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test?encoding=utf8mb4' db_dsn_compare='mysql://travis@0.0.0.0/cakephp_comparisons'
 
 before_script:
   - sh -c "if [ '$HHVM' != '1' ]; then phpenv config-rm xdebug.ini; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_script:
   - sh -c "if [ '$PREFER_LOWEST' != '1' ]; then composer install --prefer-source --no-interaction; fi"
   - sh -c "if [ '$PREFER_LOWEST' = '1' ]; then composer update --prefer-source --no-interaction --prefer-lowest --prefer-stable; fi"
 
-  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test; CREATE DATABASE cakephp_comparisons;'; fi"
+  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test DEFAULT COLLATE=utf8mb4_general_ci; CREATE DATABASE cakephp_comparisons;'; fi"
 
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_comparisons;' -U postgres; fi"

--- a/src/CakeAdapter.php
+++ b/src/CakeAdapter.php
@@ -70,13 +70,23 @@ class CakeAdapter implements AdapterInterface
     }
 
     /**
-     * Gets the database connection
+     * Gets the database PDO connection object.
      *
      * @return \PDO
      */
     public function getConnection()
     {
         return $this->adapter->getConnection();
+    }
+
+    /**
+     * Gets the CakePHP Connection object.
+     *
+     * @return \Cake\Database\Connection
+     */
+    public function getCakeConnection()
+    {
+        return $this->connection;
     }
 
     /**

--- a/tests/Fixture/CategoriesFixture.php
+++ b/tests/Fixture/CategoriesFixture.php
@@ -31,7 +31,7 @@ class CategoriesFixture extends TestFixture
         'id' => ['type' => 'integer'],
         'parent_id' => ['type' => 'integer', 'length' => 11],
         'title' => ['type' => 'string', 'null' => true, 'length' => 255],
-        'slug' => ['type' => 'string', 'null' => true, 'length' => 255],
+        'slug' => ['type' => 'string', 'null' => true, 'length' => 100],
         'created' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         '_constraints' => [

--- a/tests/Fixture/CompositePkFixture.php
+++ b/tests/Fixture/CompositePkFixture.php
@@ -28,7 +28,7 @@ class CompositePkFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'uuid', 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7', 'null' => false ],
-        'name' => ['type' => 'string', 'length' => 50, 'default' => '', 'null' => false],
+        'name' => ['type' => 'string', 'length' => 10, 'default' => '', 'null' => false],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'name']]]
     ];
 }

--- a/tests/Fixture/ProductsFixture.php
+++ b/tests/Fixture/ProductsFixture.php
@@ -33,7 +33,7 @@ class ProductsFixture extends TestFixture
     public $fields = [
         'id' => ['type' => 'integer'],
         'title' => ['type' => 'string', 'null' => true, 'length' => 255],
-        'slug' => ['type' => 'string', 'null' => true, 'length' => 255],
+        'slug' => ['type' => 'string', 'null' => true, 'length' => 100],
         'category_id' => ['type' => 'integer', 'length' => 11],
         'created' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -188,6 +188,31 @@ class MigrationsTest extends TestCase
     }
 
     /**
+     * Tests the collation table behavior when using MySQL
+     *
+     * @return void
+     */
+    public function testCreateWithEncoding()
+    {
+        $this->skipIf(env('DB') !== 'mysql');
+
+        $migrate = $this->migrations->migrate();
+        $this->assertTrue($migrate);
+
+        // Tests that if a collation is defined, it is used
+        $numbersTable = TableRegistry::get('Numbers', ['connection' => $this->Connection]);
+        $options = $numbersTable->schema()->options();
+        $this->assertEquals('utf8_bin', $options['collation']);
+
+        // Tests that if a collation is not defined, it will use the database default one
+        $lettersTable = TableRegistry::get('Letters', ['connection' => $this->Connection]);
+        $options = $lettersTable->schema()->options();
+        $this->assertEquals('utf8mb4_general_ci', $options['collation']);
+
+        $this->migrations->rollback(['target' => 0]);
+    }
+
+    /**
      * Tests calling Migrations::markMigrated without params marks everything
      * as migrated
      *

--- a/tests/comparisons/Diff/the_diff.php
+++ b/tests/comparisons/Diff/the_diff.php
@@ -22,7 +22,7 @@ class TheDiff extends AbstractMigration
             ])
             ->changeColumn('name', 'string', [
                 'default' => null,
-                'limit' => 50,
+                'limit' => 10,
                 'null' => false,
             ])
             ->update();

--- a/tests/comparisons/Diff/the_diff_mysql.php
+++ b/tests/comparisons/Diff/the_diff_mysql.php
@@ -22,7 +22,7 @@ class TheDiffMysql extends AbstractMigration
             ])
             ->changeColumn('name', 'string', [
                 'default' => null,
-                'limit' => 50,
+                'limit' => 10,
                 'null' => false,
             ])
             ->update();

--- a/tests/comparisons/Diff/the_diff_pgsql.php
+++ b/tests/comparisons/Diff/the_diff_pgsql.php
@@ -22,7 +22,7 @@ class TheDiffPgsql extends AbstractMigration
             ])
             ->changeColumn('name', 'string', [
                 'default' => null,
-                'limit' => 50,
+                'limit' => 10,
                 'null' => false,
             ])
             ->update();

--- a/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
@@ -95,7 +95,7 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => 'NULL::character varying',
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -124,7 +124,7 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
             ])
             ->addColumn('name', 'string', [
                 'default' => '',
-                'limit' => 50,
+                'limit' => 10,
                 'null' => false,
             ])
             ->addPrimaryKey(['id', 'name'])
@@ -171,7 +171,7 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => 'NULL::character varying',
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [

--- a/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
@@ -78,7 +78,7 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => 'NULL::character varying',
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -107,7 +107,7 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
             ])
             ->addColumn('name', 'string', [
                 'default' => '',
-                'limit' => 50,
+                'limit' => 10,
                 'null' => false,
             ])
             ->create();
@@ -139,7 +139,7 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => 'NULL::character varying',
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [

--- a/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
@@ -95,7 +95,7 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -124,7 +124,7 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
             ])
             ->addColumn('name', 'string', [
                 'default' => '',
-                'limit' => 50,
+                'limit' => 10,
                 'null' => false,
             ])
             ->addPrimaryKey(['id', 'name'])
@@ -171,7 +171,7 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [

--- a/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
@@ -78,7 +78,7 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -107,7 +107,7 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
             ])
             ->addColumn('name', 'string', [
                 'default' => '',
-                'limit' => 50,
+                'limit' => 10,
                 'null' => false,
             ])
             ->create();
@@ -139,7 +139,7 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [

--- a/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
@@ -78,7 +78,7 @@ class TestPluginBlogSqlite extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -96,7 +96,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -125,7 +125,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ])
             ->addColumn('name', 'string', [
                 'default' => '',
-                'limit' => 50,
+                'limit' => 10,
                 'null' => false,
             ])
             ->addPrimaryKey(['id', 'name'])
@@ -172,7 +172,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
@@ -96,7 +96,7 @@ class TestAutoIdDisabledSnapshot56 extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -125,7 +125,7 @@ class TestAutoIdDisabledSnapshot56 extends AbstractMigration
             ])
             ->addColumn('name', 'string', [
                 'default' => '',
-                'limit' => 50,
+                'limit' => 10,
                 'null' => false,
             ])
             ->addPrimaryKey(['id', 'name'])
@@ -172,7 +172,7 @@ class TestAutoIdDisabledSnapshot56 extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -79,7 +79,7 @@ class TestNotEmptySnapshot extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -108,7 +108,7 @@ class TestNotEmptySnapshot extends AbstractMigration
             ])
             ->addColumn('name', 'string', [
                 'default' => '',
-                'limit' => 50,
+                'limit' => 10,
                 'null' => false,
             ])
             ->create();
@@ -140,7 +140,7 @@ class TestNotEmptySnapshot extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [

--- a/tests/comparisons/Migration/test_not_empty_snapshot56.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot56.php
@@ -79,7 +79,7 @@ class TestNotEmptySnapshot56 extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -108,7 +108,7 @@ class TestNotEmptySnapshot56 extends AbstractMigration
             ])
             ->addColumn('name', 'string', [
                 'default' => '',
-                'limit' => 50,
+                'limit' => 10,
                 'null' => false,
             ])
             ->create();
@@ -140,7 +140,7 @@ class TestNotEmptySnapshot56 extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('category_id', 'integer', [

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -96,7 +96,7 @@ class TestPluginBlog extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [

--- a/tests/comparisons/Migration/test_plugin_blog56.php
+++ b/tests/comparisons/Migration/test_plugin_blog56.php
@@ -96,7 +96,7 @@ class TestPluginBlog56 extends AbstractMigration
             ])
             ->addColumn('slug', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [

--- a/tests/test_app/config/TestsMigrations/20150704160200_create_numbers_table.php
+++ b/tests/test_app/config/TestsMigrations/20150704160200_create_numbers_table.php
@@ -6,7 +6,7 @@ class CreateNumbersTable extends AbstractMigration
 
     public function up()
     {
-        $table = $this->table('numbers');
+        $table = $this->table('numbers', ['collation' => 'utf8_bin']);
         $table
             ->addColumn('number', 'integer', [
                 'default' => null,


### PR DESCRIPTION
When creating a table, the Table::create() method will apply the database default collation is none is provided in the Table object options.

This only works for MySQL as phinx only support table collation for this database driver.

Refs #278