### PR TITLE
Update Phinx to 0.8.x & use caret operator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.5.9",
-        "robmorgan/phinx": "0.6.6",
+        "robmorgan/phinx": "^0.8",
         "cakephp/cakephp": "~3.2"
     },
     "require-dev": {


### PR DESCRIPTION
https://github.com/robmorgan/phinx/releases/tag/v0.7.0
https://github.com/robmorgan/phinx/releases/tag/v0.7.1
https://github.com/robmorgan/phinx/releases/tag/v0.7.2
https://github.com/robmorgan/phinx/releases/tag/v0.8.0

> The ^ operator behaves very similarly but it sticks closer to semantic versioning, and will always allow non-breaking updates. 
> For pre-1.0 versions it also acts with safety in mind and treats ^0.3 as >=0.3.0 <0.4.0.

https://getcomposer.org/doc/articles/versions.md#caret

This should also fix an issue with MySQL < 5.6 in NO_ZERO_DATE mode 

https://github.com/robmorgan/phinx/pull/977 (PR thus obsolete).