### PR TITLE
Remove cakephp/cakephp from require. Add orm and cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,12 @@
     "require": {
         "php": ">=5.5.9",
         "robmorgan/phinx": "0.6.6",
-        "cakephp/cakephp": "~3.2"
+        "cakephp/orm": "~3.2",
+        "cakephp/cache": "~3.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",
+        "cakephp/cakephp": "~3.2",
         "cakephp/bake": "@stable"
     },
     "autoload": {


### PR DESCRIPTION
Hi, 

I have removed `cakephp/cakephp` from require and moved to require-dev , this helps to use it as a standalone without installing cakephp framework itself.

Thank you.