### PR TITLE
Undersocre migration diff filename

### DIFF
--- a/src/Shell/Task/SimpleMigrationTask.php
+++ b/src/Shell/Task/SimpleMigrationTask.php
@@ -45,7 +45,7 @@ abstract class SimpleMigrationTask extends SimpleBakeTask
     public function fileName($name)
     {
         $name = $this->getMigrationName($name);
-        return Util::getCurrentTimestamp() . '_' . Inflector::camelize($name) . '.php';
+        return Util::getCurrentTimestamp() . '_' . Inflector::underscore($name) . '.php';
     }
 
     /**

--- a/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
@@ -198,7 +198,7 @@ class MigrationDiffTaskTest extends TestCase
         $this->Task->pathFragment = 'config/MigrationsDiff/';
         $this->Task->connection = 'test_comparisons';
 
-        $bakeName = $this->getBakeClassName('TheDiff');
+        $bakeName = $this->getBakeName('TheDiff');
         $result = $this->Task->bake($bakeName);
 
         $this->assertCorrectSnapshot($bakeName, $result);
@@ -282,7 +282,7 @@ class MigrationDiffTaskTest extends TestCase
         $this->Task->pathFragment = 'config/MigrationsDiffSimple/';
         $this->Task->connection = 'test_comparisons';
 
-        $bakeName = $this->getBakeClassName('TheDiffSimple');
+        $bakeName = $this->getBakeName('TheDiffSimple');
         $result = $this->Task->bake($bakeName);
 
         $this->assertCorrectSnapshot($bakeName, $result);
@@ -361,7 +361,7 @@ class MigrationDiffTaskTest extends TestCase
         $this->Task->pathFragment = 'config/MigrationsDiffAddRemove/';
         $this->Task->connection = 'test_comparisons';
 
-        $bakeName = $this->getBakeClassName('TheDiffAddRemove');
+        $bakeName = $this->getBakeName('TheDiffAddRemove');
         $result = $this->Task->bake($bakeName);
 
         $this->assertCorrectSnapshot($bakeName, $result);
@@ -397,9 +397,11 @@ class MigrationDiffTaskTest extends TestCase
      * @param string $name Name of the baked file, unaware of the DB environment
      * @return string Baked class name
      */
-    public function getBakeClassName($name)
+    public function getBakeName($name)
     {
-        return $name . ucfirst(getenv("DB"));
+        $name .= ucfirst(getenv("DB"));
+
+        return $name;
     }
 
     /**

--- a/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
@@ -156,7 +156,7 @@ class MigrationDiffTaskTest extends TestCase
         $diffDumpPath = $diffConfigFolder . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
 
         $destinationConfigDir = ROOT . 'config' . DS . 'MigrationsDiff' . DS;
-        $destination = $destinationConfigDir . '20160415220805_the_diff_' . ucfirst(env('DB')) . '.php';
+        $destination = $destinationConfigDir . '20160415220805_the_diff_' . env('DB') . '.php';
         $destinationDumpPath = $destinationConfigDir . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
         copy($diffMigrationsPath, $destination);
 
@@ -204,7 +204,7 @@ class MigrationDiffTaskTest extends TestCase
         $this->assertCorrectSnapshot($bakeName, $result);
 
         $dir = new Folder($destinationConfigDir);
-        $files = $dir->find('(.*)TheDiff(.*)');
+        $files = $dir->find('(.*)the_diff(.*)');
         $file = current($files);
         $file = new File($dir->pwd() . DS . $file);
         $file->open();
@@ -288,7 +288,7 @@ class MigrationDiffTaskTest extends TestCase
         $this->assertCorrectSnapshot($bakeName, $result);
 
         $dir = new Folder($destinationConfigDir);
-        $files = $dir->find('(.*)TheDiff(.*)');
+        $files = $dir->find('(.*)the_diff(.*)');
         $file = current($files);
         $file = new File($dir->pwd() . DS . $file);
         $file->open();
@@ -327,7 +327,7 @@ class MigrationDiffTaskTest extends TestCase
         $diffDumpPath = $diffConfigFolder . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
 
         $destinationConfigDir = ROOT . 'config' . DS . 'MigrationsDiffAddRemove' . DS;
-        $destination = $destinationConfigDir . '20160415220805_the_diff_add_remove' . ucfirst(env('DB')) . '.php';
+        $destination = $destinationConfigDir . '20160415220805_the_diff_add_remove' . env('DB') . '.php';
         $destinationDumpPath = $destinationConfigDir . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
         copy($diffMigrationsPath, $destination);
 
@@ -399,9 +399,7 @@ class MigrationDiffTaskTest extends TestCase
      */
     public function getBakeName($name)
     {
-        $name .= ucfirst(getenv("DB"));
-
-        return $name;
+        return Inflector::underscore($name) . '_' . getenv("DB");
     }
 
     /**

--- a/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
@@ -156,7 +156,7 @@ class MigrationDiffTaskTest extends TestCase
         $diffDumpPath = $diffConfigFolder . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
 
         $destinationConfigDir = ROOT . 'config' . DS . 'MigrationsDiff' . DS;
-        $destination = $destinationConfigDir . '20160415220805_TheDiff' . ucfirst(env('DB')) . '.php';
+        $destination = $destinationConfigDir . '20160415220805_the_diff_' . ucfirst(env('DB')) . '.php';
         $destinationDumpPath = $destinationConfigDir . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
         copy($diffMigrationsPath, $destination);
 
@@ -248,7 +248,7 @@ class MigrationDiffTaskTest extends TestCase
         $diffDumpPath = $diffConfigFolder . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
 
         $destinationConfigDir = ROOT . 'config' . DS . 'MigrationsDiffSimple' . DS;
-        $destination = $destinationConfigDir . '20160415220805_TheDiffSimple' . ucfirst(env('DB')) . '.php';
+        $destination = $destinationConfigDir . '20160415220805_the_diff_simple' . ucfirst(env('DB')) . '.php';
         $destinationDumpPath = $destinationConfigDir . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
         copy($diffMigrationsPath, $destination);
 
@@ -327,7 +327,7 @@ class MigrationDiffTaskTest extends TestCase
         $diffDumpPath = $diffConfigFolder . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
 
         $destinationConfigDir = ROOT . 'config' . DS . 'MigrationsDiffAddRemove' . DS;
-        $destination = $destinationConfigDir . '20160415220805_TheDiffAddRemove' . ucfirst(env('DB')) . '.php';
+        $destination = $destinationConfigDir . '20160415220805_the_diff_add_remove' . ucfirst(env('DB')) . '.php';
         $destinationDumpPath = $destinationConfigDir . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
         copy($diffMigrationsPath, $destination);
 
@@ -367,11 +367,12 @@ class MigrationDiffTaskTest extends TestCase
         $this->assertCorrectSnapshot($bakeName, $result);
 
         $dir = new Folder($destinationConfigDir);
-        $files = $dir->find('(.*)TheDiff(.*)');
+        $files = $dir->find('(.*)the_diff(.*)');
         $file = current($files);
         $file = new File($dir->pwd() . DS . $file);
         $file->open();
-        $versionParts = explode('_', $file->name());
+        $fileName = $file->name();
+        $migrationName = substr($fileName, strpos($fileName, '_') + 1);
         $file->close();
         rename($destinationConfigDir . $file->name, $destination);
 
@@ -380,7 +381,7 @@ class MigrationDiffTaskTest extends TestCase
             ->into('phinxlog')
             ->values([
                 'version' => 20160415220805,
-                'migration_name' => $versionParts[1],
+                'migration_name' => $migrationName,
                 'start_time' => '2016-05-22 16:51:46',
                 'end_time' => '2016-05-22 16:51:46',
             ])

--- a/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
@@ -198,7 +198,7 @@ class MigrationDiffTaskTest extends TestCase
         $this->Task->pathFragment = 'config/MigrationsDiff/';
         $this->Task->connection = 'test_comparisons';
 
-        $bakeName = $this->getBakeName('TheDiff');
+        $bakeName = $this->getBakeClassName('TheDiff');
         $result = $this->Task->bake($bakeName);
 
         $this->assertCorrectSnapshot($bakeName, $result);
@@ -248,7 +248,7 @@ class MigrationDiffTaskTest extends TestCase
         $diffDumpPath = $diffConfigFolder . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
 
         $destinationConfigDir = ROOT . 'config' . DS . 'MigrationsDiffSimple' . DS;
-        $destination = $destinationConfigDir . '20160415220805_the_diff_simple' . ucfirst(env('DB')) . '.php';
+        $destination = $destinationConfigDir . '20160415220805_the_diff_simple_' . env('DB') . '.php';
         $destinationDumpPath = $destinationConfigDir . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
         copy($diffMigrationsPath, $destination);
 
@@ -282,7 +282,7 @@ class MigrationDiffTaskTest extends TestCase
         $this->Task->pathFragment = 'config/MigrationsDiffSimple/';
         $this->Task->connection = 'test_comparisons';
 
-        $bakeName = $this->getBakeName('TheDiffSimple');
+        $bakeName = $this->getBakeClassName('TheDiffSimple');
         $result = $this->Task->bake($bakeName);
 
         $this->assertCorrectSnapshot($bakeName, $result);
@@ -361,7 +361,7 @@ class MigrationDiffTaskTest extends TestCase
         $this->Task->pathFragment = 'config/MigrationsDiffAddRemove/';
         $this->Task->connection = 'test_comparisons';
 
-        $bakeName = $this->getBakeName('TheDiffAddRemove');
+        $bakeName = $this->getBakeClassName('TheDiffAddRemove');
         $result = $this->Task->bake($bakeName);
 
         $this->assertCorrectSnapshot($bakeName, $result);
@@ -392,14 +392,14 @@ class MigrationDiffTaskTest extends TestCase
     }
 
     /**
-     * Get the baked filename based on the current db environment
+     * Get the baked class name based on the current db environment
      *
      * @param string $name Name of the baked file, unaware of the DB environment
-     * @return string Baked filename
+     * @return string Baked class name
      */
-    public function getBakeName($name)
+    public function getBakeClassName($name)
     {
-        return Inflector::underscore($name) . '_' . getenv("DB");
+        return $name . ucfirst(getenv("DB"));
     }
 
     /**

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -151,7 +151,7 @@ class MigrationSnapshotTaskTest extends TestCase
         $bakeName = $this->getBakeName('TestNotEmptySnapshot');
         $result = $this->Task->bake($bakeName);
 
-        $this->assertNotEmpty(glob($this->Task->getPath() . '*_TestNotEmptySnapshot*.php'));
+        $this->assertNotEmpty(glob($this->Task->getPath() . '*_test_not_empty_snapshot*.php'));
         $this->assertCorrectSnapshot($bakeName, $result);
     }
 
@@ -198,7 +198,7 @@ class MigrationSnapshotTaskTest extends TestCase
         $bakeName = $this->getBakeName('TestAutoIdDisabledSnapshot');
         $result = $this->Task->bake($bakeName);
 
-        $this->assertNotEmpty(glob($this->Task->getPath() . '*_TestAutoIdDisabledSnapshot*.php'));
+        $this->assertNotEmpty(glob($this->Task->getPath() . '*_test_auto_id_disabled_snapshot*.php'));
         $this->assertCorrectSnapshot($bakeName, $result);
     }
 

--- a/tests/TestCase/Shell/Task/MigrationTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationTaskTest.php
@@ -115,7 +115,7 @@ class MigrationTaskTest extends TestCase
      * Tests that baking a migration with the name as another will throw an exception.
      *
      * @expectedException \Cake\Console\Exception\StopException
-     * @expectedExceptionMessage A migration with the name `CreateUsers` already exists. Please use a different name.
+     * @expectedExceptionMessage A migration with the name `create_users` already exists. Please use a different name.
      */
     public function testCreateDuplicateName()
     {
@@ -134,8 +134,8 @@ class MigrationTaskTest extends TestCase
         $task->BakeTemplate->initialize();
         $task->BakeTemplate->interactive = false;
 
-        $task->bake('CreateUsers');
-        $task->bake('CreateUsers');
+        $task->bake('create_users');
+        $task->bake('create_users');
     }
 
     /**
@@ -161,13 +161,13 @@ class MigrationTaskTest extends TestCase
 
         $task->bake('CreateUsers');
 
-        $file = glob(ROOT . 'config' . DS . 'Migrations' . DS . '*_CreateUsers.php');
-        $filePath = current($file);
+        $file = glob(ROOT . 'config' . DS . 'Migrations' . DS . '*_create_users.php');
+        $filePath = end($file);
         sleep(1);
 
         $task->bake('CreateUsers');
-        $file = glob(ROOT . 'config' . DS . 'Migrations' . DS . '*_CreateUsers.php');
-        $this->assertNotEquals($filePath, current($file));
+        $file = glob(ROOT . 'config' . DS . 'Migrations' . DS . '*_create_users.php');
+        $this->assertNotEquals($filePath, end($file));
     }
 
     /**


### PR DESCRIPTION
`bin/cake migrations create` generates files with underscored names. I reckon `bin/cake bake migration_diff` should do it same way.