### PR TITLE
Revert "Undersocre migration diff filename"

### DIFF
--- a/src/Shell/Task/SimpleMigrationTask.php
+++ b/src/Shell/Task/SimpleMigrationTask.php
@@ -45,7 +45,7 @@ abstract class SimpleMigrationTask extends SimpleBakeTask
     public function fileName($name)
     {
         $name = $this->getMigrationName($name);
-        return Util::getCurrentTimestamp() . '_' . Inflector::underscore($name) . '.php';
+        return Util::getCurrentTimestamp() . '_' . Inflector::camelize($name) . '.php';
     }
 
     /**

--- a/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationDiffTaskTest.php
@@ -156,7 +156,7 @@ class MigrationDiffTaskTest extends TestCase
         $diffDumpPath = $diffConfigFolder . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
 
         $destinationConfigDir = ROOT . 'config' . DS . 'MigrationsDiff' . DS;
-        $destination = $destinationConfigDir . '20160415220805_the_diff_' . env('DB') . '.php';
+        $destination = $destinationConfigDir . '20160415220805_TheDiff' . ucfirst(env('DB')) . '.php';
         $destinationDumpPath = $destinationConfigDir . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
         copy($diffMigrationsPath, $destination);
 
@@ -204,7 +204,7 @@ class MigrationDiffTaskTest extends TestCase
         $this->assertCorrectSnapshot($bakeName, $result);
 
         $dir = new Folder($destinationConfigDir);
-        $files = $dir->find('(.*)the_diff(.*)');
+        $files = $dir->find('(.*)TheDiff(.*)');
         $file = current($files);
         $file = new File($dir->pwd() . DS . $file);
         $file->open();
@@ -248,7 +248,7 @@ class MigrationDiffTaskTest extends TestCase
         $diffDumpPath = $diffConfigFolder . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
 
         $destinationConfigDir = ROOT . 'config' . DS . 'MigrationsDiffSimple' . DS;
-        $destination = $destinationConfigDir . '20160415220805_the_diff_simple_' . env('DB') . '.php';
+        $destination = $destinationConfigDir . '20160415220805_TheDiffSimple' . ucfirst(env('DB')) . '.php';
         $destinationDumpPath = $destinationConfigDir . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
         copy($diffMigrationsPath, $destination);
 
@@ -288,7 +288,7 @@ class MigrationDiffTaskTest extends TestCase
         $this->assertCorrectSnapshot($bakeName, $result);
 
         $dir = new Folder($destinationConfigDir);
-        $files = $dir->find('(.*)the_diff(.*)');
+        $files = $dir->find('(.*)TheDiff(.*)');
         $file = current($files);
         $file = new File($dir->pwd() . DS . $file);
         $file->open();
@@ -327,7 +327,7 @@ class MigrationDiffTaskTest extends TestCase
         $diffDumpPath = $diffConfigFolder . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
 
         $destinationConfigDir = ROOT . 'config' . DS . 'MigrationsDiffAddRemove' . DS;
-        $destination = $destinationConfigDir . '20160415220805_the_diff_add_remove' . env('DB') . '.php';
+        $destination = $destinationConfigDir . '20160415220805_TheDiffAddRemove' . ucfirst(env('DB')) . '.php';
         $destinationDumpPath = $destinationConfigDir . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
         copy($diffMigrationsPath, $destination);
 
@@ -367,12 +367,11 @@ class MigrationDiffTaskTest extends TestCase
         $this->assertCorrectSnapshot($bakeName, $result);
 
         $dir = new Folder($destinationConfigDir);
-        $files = $dir->find('(.*)the_diff(.*)');
+        $files = $dir->find('(.*)TheDiff(.*)');
         $file = current($files);
         $file = new File($dir->pwd() . DS . $file);
         $file->open();
-        $fileName = $file->name();
-        $migrationName = substr($fileName, strpos($fileName, '_') + 1);
+        $versionParts = explode('_', $file->name());
         $file->close();
         rename($destinationConfigDir . $file->name, $destination);
 
@@ -381,7 +380,7 @@ class MigrationDiffTaskTest extends TestCase
             ->into('phinxlog')
             ->values([
                 'version' => 20160415220805,
-                'migration_name' => $migrationName,
+                'migration_name' => $versionParts[1],
                 'start_time' => '2016-05-22 16:51:46',
                 'end_time' => '2016-05-22 16:51:46',
             ])
@@ -392,10 +391,10 @@ class MigrationDiffTaskTest extends TestCase
     }
 
     /**
-     * Get the baked class name based on the current db environment
+     * Get the baked filename based on the current db environment
      *
      * @param string $name Name of the baked file, unaware of the DB environment
-     * @return string Baked class name
+     * @return string Baked filename
      */
     public function getBakeName($name)
     {

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -151,7 +151,7 @@ class MigrationSnapshotTaskTest extends TestCase
         $bakeName = $this->getBakeName('TestNotEmptySnapshot');
         $result = $this->Task->bake($bakeName);
 
-        $this->assertNotEmpty(glob($this->Task->getPath() . '*_test_not_empty_snapshot*.php'));
+        $this->assertNotEmpty(glob($this->Task->getPath() . '*_TestNotEmptySnapshot*.php'));
         $this->assertCorrectSnapshot($bakeName, $result);
     }
 
@@ -198,7 +198,7 @@ class MigrationSnapshotTaskTest extends TestCase
         $bakeName = $this->getBakeName('TestAutoIdDisabledSnapshot');
         $result = $this->Task->bake($bakeName);
 
-        $this->assertNotEmpty(glob($this->Task->getPath() . '*_test_auto_id_disabled_snapshot*.php'));
+        $this->assertNotEmpty(glob($this->Task->getPath() . '*_TestAutoIdDisabledSnapshot*.php'));
         $this->assertCorrectSnapshot($bakeName, $result);
     }
 

--- a/tests/TestCase/Shell/Task/MigrationTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationTaskTest.php
@@ -115,7 +115,7 @@ class MigrationTaskTest extends TestCase
      * Tests that baking a migration with the name as another will throw an exception.
      *
      * @expectedException \Cake\Console\Exception\StopException
-     * @expectedExceptionMessage A migration with the name `create_users` already exists. Please use a different name.
+     * @expectedExceptionMessage A migration with the name `CreateUsers` already exists. Please use a different name.
      */
     public function testCreateDuplicateName()
     {
@@ -134,8 +134,8 @@ class MigrationTaskTest extends TestCase
         $task->BakeTemplate->initialize();
         $task->BakeTemplate->interactive = false;
 
-        $task->bake('create_users');
-        $task->bake('create_users');
+        $task->bake('CreateUsers');
+        $task->bake('CreateUsers');
     }
 
     /**
@@ -161,13 +161,13 @@ class MigrationTaskTest extends TestCase
 
         $task->bake('CreateUsers');
 
-        $file = glob(ROOT . 'config' . DS . 'Migrations' . DS . '*_create_users.php');
-        $filePath = end($file);
+        $file = glob(ROOT . 'config' . DS . 'Migrations' . DS . '*_CreateUsers.php');
+        $filePath = current($file);
         sleep(1);
 
         $task->bake('CreateUsers');
-        $file = glob(ROOT . 'config' . DS . 'Migrations' . DS . '*_create_users.php');
-        $this->assertNotEquals($filePath, end($file));
+        $file = glob(ROOT . 'config' . DS . 'Migrations' . DS . '*_CreateUsers.php');
+        $this->assertNotEquals($filePath, current($file));
     }
 
     /**


### PR DESCRIPTION
Reverts cakephp/migrations#313

As discussed in #313, CamelBack formatted file name have been pushed in the doc for several month.
PR #299 was created to had the same filename format and sync the behavior of the `bake migration` and `migrations create` commands.

It just was not visible because a few PR were merged after the last release.