### PR TITLE
Refactoring tests

### DIFF
--- a/tests/TestCase/Command/DumpTest.php
+++ b/tests/TestCase/Command/DumpTest.php
@@ -112,7 +112,7 @@ class DumpTest extends TestCase
         ]);
 
         $dumpPath = ROOT . 'config' . DS . 'TestsMigrations' . DS . 'schema-dump-test.lock';
-        $this->assertEquals(serialize([]), file_get_contents($dumpPath));
+        $this->assertStringEqualsFile($dumpPath, serialize([]));
     }
 
     /**
@@ -137,7 +137,7 @@ class DumpTest extends TestCase
         ]);
 
         $dumpFilePath = ROOT . 'config' . DS . 'TestsMigrations' . DS . 'schema-dump-test.lock';
-        $this->assertTrue(file_exists($dumpFilePath));
+        $this->assertFileExists($dumpFilePath);
 
         $generatedDump = unserialize(file_get_contents($dumpFilePath));
 

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -416,7 +416,7 @@ class MarkMigratedTest extends TestCase
         );
 
         $result = $this->Connection->newQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         $this->assertEquals('20150724233100', $result[0]['version']);
     }
 


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertStringEqualsFile` when comparing a `string` and a file;
- `assertFileExists` instead of `file_exists`.