### PR TITLE
Use CONFIG constant if defined

### DIFF
--- a/src/Util/UtilTrait.php
+++ b/src/Util/UtilTrait.php
@@ -66,7 +66,7 @@ trait UtilTrait
 
         $dir = ROOT . DS . 'config' . DS . $folder;
 
-        if(defined('CONFIG')) {
+        if (defined('CONFIG')) {
             $dir = CONFIG . $folder;
         }
 

--- a/src/Util/UtilTrait.php
+++ b/src/Util/UtilTrait.php
@@ -65,6 +65,11 @@ trait UtilTrait
         $folder = $input->getOption('source') ?: $default;
 
         $dir = ROOT . DS . 'config' . DS . $folder;
+
+        if(defined('CONFIG')) {
+            $dir = CONFIG . $folder;
+        }
+
         $plugin = $this->getPlugin($input);
 
         if ($plugin !== null) {

--- a/tests/PHPStan/bootstrap.phpstan.php
+++ b/tests/PHPStan/bootstrap.phpstan.php
@@ -14,3 +14,4 @@
 define('ROOT', '');
 define('APP', 'app');
 define('PHINX_VERSION', '0.8.1');
+define('CONFIG', ROOT . DS . 'config' . DS);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,7 +37,9 @@ define('APP_DIR', 'App');
 define('APP', ROOT . 'App' . DS);
 define('TMP', sys_get_temp_dir() . DS);
 define('CACHE', sys_get_temp_dir() . DS . 'cache' . DS);
-
+if (!defined('CONFIG')) {
+    define('CONFIG', ROOT . DS . 'config' . DS);
+}
 Configure::write('debug', true);
 Configure::write('App', [
     'namespace' => 'TestApp',


### PR DESCRIPTION
I have a custom config location, but I saw that migration ignores them. 
