### PR TITLE
Added the required symfony/console dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "php": ">=5.6.0",
         "robmorgan/phinx": "~0.10.3",
         "cakephp/orm": "^3.6.0",
-        "cakephp/cache": "^3.6.0"
+        "cakephp/cache": "^3.6.0",
+        "symfony/console": "^2.8|^3.0|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.14|^6.0",


### PR DESCRIPTION
I was checking the code of this repository and found that in some places you are using Symfony classes. For example here:

https://github.com/cakephp/migrations/blob/master/src/Command/CommandTrait.php#L17-L19

Problem is that you are importing Symfony Console classes ... without requiring `symfony/console` as one of the dependencies of this project. At least I can't find where it's required.

So, right now, some of your dependencies require `symfony/console` indirectly and that's why the code is working. If one day that dependency removes `symfony/console`, this code would stop working.

For the new dependency, I used the same version constraints as in this other package:

https://github.com/cakephp/phinx/blob/b91a0fe93123e41debd924abdccb3301e95d415b/composer.json#L31