### PR TITLE
Fix snapshot creation for tables with no primary keys

### DIFF
--- a/src/Template/Bake/Element/create-tables.ctp
+++ b/src/Template/Bake/Element/create-tables.ctp
@@ -5,11 +5,14 @@
 $foreignKeys = [];
 $primaryKeysColumns = $this->Migration->primaryKeysColumnsList($tableArgForMethods);
 $primaryKeys = $this->Migration->primaryKeys($tableArgForMethods);
-$specialPk = (count($primaryKeys) > 1 || $primaryKeys[0]['name'] !== 'id' || $primaryKeys[0]['info']['columnType'] !== 'integer') && $autoId;
+$specialPk = $primaryKeys && (count($primaryKeys) > 1 || $primaryKeys[0]['name'] !== 'id' || $primaryKeys[0]['info']['columnType'] !== 'integer') && $autoId;
 %>
 <% if ($specialPk): %>
 
         $this->table('<%= $tableArgForArray %>', ['id' => false, 'primary_key' => ['<%= implode("', '", \Cake\Utility\Hash::extract($primaryKeys, '{n}.name')) %>']])
+<% elseif (!$primaryKeys && $autoId): %>
+
+        $this->table('<%= $tableArgForArray %>', ['id' => false])
 <% else: %>
 
         $this->table('<%= $tableArgForArray %>')
@@ -22,7 +25,7 @@ $specialPk = (count($primaryKeys) > 1 || $primaryKeys[0]['name'] !== 'id' || $pr
             echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
             %>])
 <% endforeach; %>
-<% if (!$autoId): %>
+<% if (!$autoId && $primaryKeys): %>
             ->addPrimaryKey(['<%= implode("', '", \Cake\Utility\Hash::extract($primaryKeys, '{n}.name')) %>'])
 <% endif; %>
 <% endif;

--- a/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
+++ b/tests/TestCase/Shell/Task/MigrationSnapshotTaskTest.php
@@ -35,7 +35,8 @@ class MigrationSnapshotTaskTest extends TestCase
         'plugin.migrations.products',
         'plugin.migrations.categories',
         'plugin.migrations.orders',
-        'plugin.migrations.articles'
+        'plugin.migrations.articles',
+        'plugin.migrations.texts',
     ];
 
     /**

--- a/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
@@ -269,6 +269,19 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
             )
             ->create();
 
+        $this->table('texts')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
         $this->table('users')
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
@@ -381,6 +394,7 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
         $this->table('products')->drop()->save();
         $this->table('special_pks')->drop()->save();
         $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
         $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
@@ -229,6 +229,19 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
             )
             ->create();
 
+        $this->table('texts', ['id' => false])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
         $this->table('users')
             ->addColumn('username', 'string', [
                 'default' => 'NULL::character varying',
@@ -334,6 +347,7 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
         $this->table('products')->drop()->save();
         $this->table('special_pks')->drop()->save();
         $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
         $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
@@ -269,6 +269,19 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
             )
             ->create();
 
+        $this->table('texts')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
         $this->table('users')
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
@@ -381,6 +394,7 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
         $this->table('products')->drop()->save();
         $this->table('special_pks')->drop()->save();
         $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
         $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
@@ -229,6 +229,19 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
             )
             ->create();
 
+        $this->table('texts', ['id' => false])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
         $this->table('users')
             ->addColumn('username', 'string', [
                 'default' => null,
@@ -334,6 +347,7 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
         $this->table('products')->drop()->save();
         $this->table('special_pks')->drop()->save();
         $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
         $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -270,6 +270,19 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             )
             ->create();
 
+        $this->table('texts')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
         $this->table('users')
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
@@ -382,6 +395,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
         $this->table('products')->drop()->save();
         $this->table('special_pks')->drop()->save();
         $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
         $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
@@ -271,6 +271,19 @@ class TestAutoIdDisabledSnapshot56 extends AbstractMigration
             )
             ->create();
 
+        $this->table('texts')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
         $this->table('users')
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
@@ -383,6 +396,7 @@ class TestAutoIdDisabledSnapshot56 extends AbstractMigration
         $this->table('products')->drop()->save();
         $this->table('special_pks')->drop()->save();
         $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
         $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -230,6 +230,19 @@ class TestNotEmptySnapshot extends AbstractMigration
             )
             ->create();
 
+        $this->table('texts', ['id' => false])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
         $this->table('users')
             ->addColumn('username', 'string', [
                 'default' => null,
@@ -335,6 +348,7 @@ class TestNotEmptySnapshot extends AbstractMigration
         $this->table('products')->drop()->save();
         $this->table('special_pks')->drop()->save();
         $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
         $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/test_not_empty_snapshot56.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot56.php
@@ -231,6 +231,19 @@ class TestNotEmptySnapshot56 extends AbstractMigration
             )
             ->create();
 
+        $this->table('texts', ['id' => false])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
         $this->table('users')
             ->addColumn('username', 'string', [
                 'default' => null,
@@ -336,6 +349,7 @@ class TestNotEmptySnapshot56 extends AbstractMigration
         $this->table('products')->drop()->save();
         $this->table('special_pks')->drop()->save();
         $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
         $this->table('users')->drop()->save();
     }
 }


### PR DESCRIPTION
Fixes #369, fixes #349.

When table has no primary keys, `bin/cake bake migration_snapshot` throws `Undefined offset` notices.