### PR TITLE
Use relative path instead of plugin path

### DIFF
--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -81,7 +81,7 @@ trait ConfigurationTrait
         $connectionConfig = ConnectionManager::getConfig($connection);
         $adapterName = $this->getAdapterName($connectionConfig['driver']);
 
-        $templatePath = CorePlugin::path('Migrations') . 'src' . DS . 'Template' . DS;
+        $templatePath = __DIR__ . DS . 'Template' . DS;
         $config = [
             'paths' => [
                 'migrations' => $migrationsPath,


### PR DESCRIPTION
This makes Migrations::status() independent of the Migrations plugin being loaded first.

Refs: https://github.com/orca-services/cakephp-heartbeat/issues/18