### PR TITLE
Enable dry-run for migrations

### DIFF
--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -73,8 +73,8 @@ class MigrationsShell extends Shell
             ->addOption('no-interaction', ['short' => 'n'])
             ->addOption('template', ['short' => 't'])
             ->addOption('format', ['short' => 'f'])
-	    ->addOption('only', ['short' => 'o'])
-	    ->addOption('dry-run', ['short' => 'x'])
+            ->addOption('only', ['short' => 'o'])
+            ->addOption('dry-run', ['short' => 'x'])
             ->addOption('exclude', ['short' => 'e']);
     }
 

--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -73,7 +73,8 @@ class MigrationsShell extends Shell
             ->addOption('no-interaction', ['short' => 'n'])
             ->addOption('template', ['short' => 't'])
             ->addOption('format', ['short' => 'f'])
-            ->addOption('only', ['short' => 'o'])
+	    ->addOption('only', ['short' => 'o'])
+	    ->addOption('dry-run', ['short' => 'x'])
             ->addOption('exclude', ['short' => 'e']);
     }
 


### PR DESCRIPTION
The dry-run feature from Phinx wasn't working for migrations. This fixes it.
