### PR TITLE
Exclude more files from being exported

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -39,3 +39,6 @@ Makefile export-ignore
 phpunit.xml.dist export-ignore
 .travis.yml export-ignore
 /tests export-ignore
+.stickler.yml export-ignore
+phpcs.xml.dist export-ignore
+phpstan.neon export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -42,3 +42,4 @@ phpunit.xml.dist export-ignore
 .stickler.yml export-ignore
 phpcs.xml.dist export-ignore
 phpstan.neon export-ignore
+.github export-ignore


### PR DESCRIPTION
I was toying around with a deployment script and noticed these unnecessary (in a deployment context) files.