### PR TITLE
Enabling decimal through cake bake and infering types latitude and longitude

### DIFF
--- a/src/Template/Bake/config/skeleton.ctp
+++ b/src/Template/Bake/config/skeleton.ctp
@@ -13,7 +13,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-$wantedOptions = array_flip(['length', 'limit', 'default', 'unsigned', 'null', 'comment', 'autoIncrement']);
+$wantedOptions = array_flip(['length', 'limit', 'default', 'unsigned', 'null', 'comment', 'autoIncrement', 'precision', 'scale']);
 $tableMethod = $this->Migration->tableMethod($action);
 $columnMethod = $this->Migration->columnMethod($action);
 $indexMethod = $this->Migration->indexMethod($action);

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -16,7 +16,19 @@ class ColumnParser
      *
      * @var string
      */
-    protected $regexpParseColumn = '/^(\w+)(?::(\w+\??(?:\[(?:[0-9]|[1-9][0-9]+)(?:,(?:[0-9]|[1-9][0-9]+))?\])?))?(?::(\w+))?(?::(\w+))?$/';
+    protected $regexpParseColumn = '/
+        ^
+        (\w+)
+        (?::(\w+\??
+            (?:\[
+                (?:[0-9]|[1-9][0-9]+)
+                (?:,(?:[0-9]|[1-9][0-9]+))?
+            \])?
+        ))?
+        (?::(\w+))?
+        (?::(\w+))?
+        $
+        /x';
 
     /**
      * Regex used to parse the field type and length

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -51,7 +51,7 @@ class ColumnParser
                 }
             }
 
-            $nullable = (bool)preg_match('/\w+\?(\[[0-9]+\])?/', $type);
+            $nullable = (bool)preg_match('/(\w+\??)\[([0-9]+)(\,[0-9]+)?\]/', $type);
             $type = $nullable ? str_replace('?', '', $type) : $type;
 
             list($type, $length) = $this->getTypeAndLength($field, $type);

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -64,7 +64,7 @@ class ColumnParser
             ];
 
             if ($length !== null) {
-                if(is_array($length)) {
+                if (is_array($length)) {
                     list($fields[$field]['options']['precision'], $fields[$field]['options']['scale']) = $length;
                 } else {
                     $fields[$field]['options']['limit'] = $length;
@@ -176,9 +176,10 @@ class ColumnParser
     public function getTypeAndLength($field, $type)
     {
         if (preg_match($this->regexpParseField, $type, $matches)) {
-            if(strpos($matches[2], ',') !== false) {
+            if (strpos($matches[2], ',') !== false) {
                 $matches[2] = explode(',', $matches[2]);
             }
+
             return [$matches[1], $matches[2]];
         }
 
@@ -238,7 +239,7 @@ class ColumnParser
         } elseif ($type === 'biginteger') {
             $length = 20;
         } elseif ($type === 'decimal') {
-            $length = [10,6];
+            $length = [10, 6];
         }
 
         return $length;

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -50,7 +50,7 @@ class ColumnParser
                     $type = 'primary';
                 }
             }
-            $nullable = (bool)preg_match('/(\w+\?)(?:(\[(([1-9][0-9]|[1-9]){1,2})(?:(\,([1-9][0-9]|[1-9]))*)\]))*/', $type);
+            $nullable = (bool)strpos($type, '?');
             $type = $nullable ? str_replace('?', '', $type) : $type;
 
             list($type, $length) = $this->getTypeAndLength($field, $type);

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -16,7 +16,7 @@ class ColumnParser
      *
      * @var string
      */
-    protected $regexpParseColumn = '/^(\w*)(?::(\w*\??\[?(?:\d|[0-9,])*\]?))?(?::(\w*))?(?::(\w*))?/';
+    protected $regexpParseColumn = '/^(\w+)(?::(\w+\??(?:\[(?:[0-9]|[1-9][0-9]+)(?:,(?:[0-9]|[1-9][0-9]+))?\])?))?(?::(\w+))?(?::(\w+))?$/';
 
     /**
      * Regex used to parse the field type and length

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -50,8 +50,7 @@ class ColumnParser
                     $type = 'primary';
                 }
             }
-
-            $nullable = (bool)preg_match('/(\w+\??)\[([0-9]+)(\,[0-9]+)?\]/', $type);
+            $nullable = (bool)preg_match('/(\w+\?)(?:(\[(([1-9][0-9]|[1-9]){1,2})(?:(\,([1-9][0-9]|[1-9]))*)\]))*/', $type);
             $type = $nullable ? str_replace('?', '', $type) : $type;
 
             list($type, $length) = $this->getTypeAndLength($field, $type);
@@ -204,7 +203,6 @@ class ColumnParser
         $validTypes = $collection->filter(function ($value, $constant) {
             return substr($constant, 0, strlen('PHINX_TYPE_')) === 'PHINX_TYPE_';
         })->toArray();
-
         $fieldType = $type;
         if ($type === null || !in_array($type, $validTypes)) {
             if ($type === 'primary') {

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -16,7 +16,7 @@ class ColumnParser
      *
      * @var string
      */
-    protected $regexpParseColumn = '/^(\w*)(?::(\w*\??\[?[0-9,]+\]?))?(?::(\w*))?(?::(\w*))?/';
+    protected $regexpParseColumn = '/^(\w*)(?::(\w*\??\[?(?:\d|[0-9,])*\]?))?(?::(\w*))?(?::(\w*))?/';
 
     /**
      * Regex used to parse the field type and length

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -116,7 +116,25 @@ class ColumnParserTest extends TestCase
                     'default' => null,
                 ],
             ],
-        ], $this->columnParser->parseFields(['id', 'created', 'modified', 'updated', 'deleted_at']));
+            'latitude' => [
+                'columnType' => 'decimal',
+                'options' => [
+                    'default' => false,
+                    'null' => false,
+                    'precision' => 10,
+                    'scale' => 6,
+                ]
+            ],
+            'longitude' => [
+                'columnType' => 'decimal',
+                'options' => [
+                    'default' => false,
+                    'null' => false,
+                    'precision' => 10,
+                    'scale' => 6,
+                ]
+            ],
+        ], $this->columnParser->parseFields(['id', 'created', 'modified', 'updated', 'deleted_at', 'latitude', 'longitude']));
 
         $expected = [
             'id' => [
@@ -151,8 +169,17 @@ class ColumnParserTest extends TestCase
                     'limit' => 11,
                 ],
             ],
+            'amount' => [
+                'columnType' => 'decimal',
+                'options' => [
+                    'null' => true,
+                    'default' => null,
+                    'precision' => 6,
+                    'scale' => 3,
+                ],
+            ],
         ];
-        $actual = $this->columnParser->parseFields(['id', 'name:string', 'description:string?', 'age:integer?']);
+        $actual = $this->columnParser->parseFields(['id', 'name:string', 'description:string?', 'age:integer?', 'amount:decimal?[6,3]']);
         $this->assertEquals($expected, $actual);
 
         $expected = [
@@ -311,6 +338,8 @@ class ColumnParserTest extends TestCase
         $this->assertEquals('string', $this->columnParser->getType('some_field', 'string'));
         $this->assertEquals('boolean', $this->columnParser->getType('field', 'boolean'));
         $this->assertEquals('polygon', $this->columnParser->getType('field', 'polygon'));
+        $this->assertEquals('decimal', $this->columnParser->getType('latitude', null));
+        $this->assertEquals('decimal', $this->columnParser->getType('longitude', null));
     }
 
     /**
@@ -327,6 +356,7 @@ class ColumnParserTest extends TestCase
         $this->assertEquals(['string', 255], $this->columnParser->getTypeAndLength('username', null));
         $this->assertEquals(['datetime', null], $this->columnParser->getTypeAndLength('created', null));
         $this->assertEquals(['datetime', null], $this->columnParser->getTypeAndLength('changed_at', null));
+        $this->assertEquals(['decimal', [10,6]], $this->columnParser->getTypeAndLength('latitude', 'decimal[10,6]'));
     }
 
     /**
@@ -337,6 +367,7 @@ class ColumnParserTest extends TestCase
         $this->assertEquals(255, $this->columnParser->getLength('string'));
         $this->assertEquals(11, $this->columnParser->getLength('integer'));
         $this->assertEquals(20, $this->columnParser->getLength('biginteger'));
+        $this->assertEquals([10,6], $this->columnParser->getLength('decimal'));
         $this->assertNull($this->columnParser->getLength('text'));
     }
 

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -356,7 +356,7 @@ class ColumnParserTest extends TestCase
         $this->assertEquals(['string', 255], $this->columnParser->getTypeAndLength('username', null));
         $this->assertEquals(['datetime', null], $this->columnParser->getTypeAndLength('created', null));
         $this->assertEquals(['datetime', null], $this->columnParser->getTypeAndLength('changed_at', null));
-        $this->assertEquals(['decimal', [10,6]], $this->columnParser->getTypeAndLength('latitude', 'decimal[10,6]'));
+        $this->assertEquals(['decimal', [10, 6]], $this->columnParser->getTypeAndLength('latitude', 'decimal[10,6]'));
     }
 
     /**
@@ -367,7 +367,7 @@ class ColumnParserTest extends TestCase
         $this->assertEquals(255, $this->columnParser->getLength('string'));
         $this->assertEquals(11, $this->columnParser->getLength('integer'));
         $this->assertEquals(20, $this->columnParser->getLength('biginteger'));
-        $this->assertEquals([10,6], $this->columnParser->getLength('decimal'));
+        $this->assertEquals([10, 6], $this->columnParser->getLength('decimal'));
         $this->assertNull($this->columnParser->getLength('text'));
     }
 


### PR DESCRIPTION
Following the discussion on #388 

This PR focuses on enabling the usage of `decimal` .
The idea is to default `longitude` and `latitude` to be infered as `decimal(10,6)` while also enabling use-cases where a user might want to calculate taxes and store amount which has decimal value.