### PR TITLE
Fix Travis database config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ php:
 
 sudo: false
 
+services:
+  - mysql
+  - postgresql
+
 env:
   matrix:
     - DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test?encoding=utf8mb4' db_dsn_compare='mysql://root@127.0.0.1/cakephp_comparisons'


### PR DESCRIPTION
Travis on Ubuntu Xenial needs `services` to be defined for databases.

https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment#1-services-support

Currently Travis jobs fails with

`ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)`

and

```
psql: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
```