### PR TITLE
Allow next major

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.6.0",
-        "robmorgan/phinx": "^0.10.3",
+        "robmorgan/phinx": "^0.10.3|^0.11.1",
         "cakephp/orm": "^3.6.0",
         "cakephp/cache": "^3.6.0"
     },


### PR DESCRIPTION
Since 0.11 was a bad release in terms of semver (should have been 0.10.x), we should especially now try to support asap.
It should be rather easy to include as it was pretty much full BC.

Thx to prefer-lowest in travis we can also be sure the old version still is fine on future patches.