### PR TITLE
Remove version part

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Migrations\Command;
+
+use Symfony\Component\Console\Command\Command;
+
+abstract class BaseCommand extends Command
+{
+    const CODE_SUCCESS = 0;
+    const CODE_ERROR = 1;
+}

--- a/src/Command/CacheBuild.php
+++ b/src/Command/CacheBuild.php
@@ -2,13 +2,12 @@
 namespace Migrations\Command;
 
 use Migrations\Util\SchemaTrait;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CacheBuild extends Command
+class CacheBuild extends BaseCommand
 {
     use SchemaTrait;
 
@@ -42,7 +41,7 @@ class CacheBuild extends Command
         $name = $input->getArgument('name');
         $schema = $this->_getSchema($input, $output);
         if (!$schema) {
-            return false;
+            return static::CODE_ERROR;
         }
         $tables = [$name];
         if (empty($name)) {
@@ -54,6 +53,6 @@ class CacheBuild extends Command
         }
         $output->writeln('<info>Cache build complete</info>');
 
-        return true;
+        return static::CODE_SUCCESS;
     }
 }

--- a/src/Command/CacheClear.php
+++ b/src/Command/CacheClear.php
@@ -3,13 +3,12 @@ namespace Migrations\Command;
 
 use Cake\Cache\Cache;
 use Migrations\Util\SchemaTrait;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CacheClear extends Command
+class CacheClear extends BaseCommand
 {
     use SchemaTrait;
 
@@ -43,7 +42,7 @@ class CacheClear extends Command
         $schema = $this->_getSchema($input, $output);
         $name = $input->getArgument('name');
         if (!$schema) {
-            return false;
+            return static::CODE_ERROR;
         }
         $tables = [$name];
         if (empty($name)) {
@@ -62,6 +61,6 @@ class CacheClear extends Command
         }
         $output->writeln('<info>Cache clear complete<info>');
 
-        return true;
+        return static::CODE_SUCCESS;
     }
 }

--- a/src/Command/CommandTrait.php
+++ b/src/Command/CommandTrait.php
@@ -20,7 +20,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 trait CommandTrait
 {
-
     /**
      * Overrides the action execute method in order to vanish the idea of environments
      * from phinx. CakePHP does not believe in the idea of having in-app environments

--- a/src/Command/Create.php
+++ b/src/Command/Create.php
@@ -64,7 +64,7 @@ class Create extends CreateCommand
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input the input object
      * @param \Symfony\Component\Console\Output\OutputInterface $output the output object
-     * @return mixed
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -93,5 +93,7 @@ class Create extends CreateCommand
                 $output->writeln(sprintf('<info>An error occurred while renaming file to %s</info>', $newPath));
             }
         }
+
+        return BaseCommand::CODE_SUCCESS;
     }
 }

--- a/src/Command/Dump.php
+++ b/src/Command/Dump.php
@@ -72,7 +72,7 @@ class Dump extends AbstractCommand
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input the input object
      * @param \Symfony\Component\Console\Output\OutputInterface $output the output object
-     * @return bool Success of the call.
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -104,7 +104,7 @@ class Dump extends AbstractCommand
         if (file_put_contents($filePath, serialize($dump))) {
             $output->writeln(sprintf('<info>Dump file `%s` was successfully written</info>', $filePath));
 
-            return true;
+            return BaseCommand::CODE_SUCCESS;
         }
 
         $output->writeln(sprintf(
@@ -112,6 +112,6 @@ class Dump extends AbstractCommand
             $filePath
         ));
 
-        return false;
+        return BaseCommand::CODE_ERROR;
     }
 }

--- a/src/Command/MarkMigrated.php
+++ b/src/Command/MarkMigrated.php
@@ -97,7 +97,7 @@ class MarkMigrated extends AbstractCommand
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input the input object
      * @param \Symfony\Component\Console\Output\OutputInterface $output the output object
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -113,7 +113,7 @@ class MarkMigrated extends AbstractCommand
                 "<error>You should use `--exclude` OR `--only` (not both) along with a `--target` !</error>"
             );
 
-            return;
+            return BaseCommand::CODE_ERROR;
         }
 
         if ($this->isUsingDeprecatedAll()) {
@@ -129,10 +129,12 @@ class MarkMigrated extends AbstractCommand
         } catch (InvalidArgumentException $e) {
             $output->writeln(sprintf("<error>%s</error>", $e->getMessage()));
 
-            return;
+            return BaseCommand::CODE_ERROR;
         }
 
         $this->getManager()->markVersionsAsMigrated($path, $versions, $output);
+
+        return BaseCommand::CODE_SUCCESS;
     }
 
     /**

--- a/src/Command/Migrate.php
+++ b/src/Command/Migrate.php
@@ -55,15 +55,17 @@ class Migrate extends MigrateCommand
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input the input object
      * @param \Symfony\Component\Console\Output\OutputInterface $output the output object
-     * @return mixed
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $event = $this->dispatchEvent('Migration.beforeMigrate');
         if ($event->isStopped()) {
-            return $event->result;
+            return $event->result ? BaseCommand::CODE_SUCCESS: BaseCommand::CODE_ERROR;
         }
         $this->parentExecute($input, $output);
         $this->dispatchEvent('Migration.afterMigrate');
+
+        return BaseCommand::CODE_SUCCESS;
     }
 }

--- a/src/Command/Migrate.php
+++ b/src/Command/Migrate.php
@@ -61,7 +61,7 @@ class Migrate extends MigrateCommand
     {
         $event = $this->dispatchEvent('Migration.beforeMigrate');
         if ($event->isStopped()) {
-            return $event->result ? BaseCommand::CODE_SUCCESS: BaseCommand::CODE_ERROR;
+            return $event->result ? BaseCommand::CODE_SUCCESS : BaseCommand::CODE_ERROR;
         }
         $this->parentExecute($input, $output);
         $this->dispatchEvent('Migration.afterMigrate');

--- a/src/Command/Rollback.php
+++ b/src/Command/Rollback.php
@@ -62,7 +62,7 @@ class Rollback extends RollbackCommand
     {
         $event = $this->dispatchEvent('Migration.beforeRollback');
         if ($event->isStopped()) {
-            return $event->result ? BaseCommand::CODE_SUCCESS: BaseCommand::CODE_ERROR;
+            return $event->result ? BaseCommand::CODE_SUCCESS : BaseCommand::CODE_ERROR;
         }
         $this->parentExecute($input, $output);
         $this->dispatchEvent('Migration.afterRollback');

--- a/src/Command/Rollback.php
+++ b/src/Command/Rollback.php
@@ -62,9 +62,11 @@ class Rollback extends RollbackCommand
     {
         $event = $this->dispatchEvent('Migration.beforeRollback');
         if ($event->isStopped()) {
-            return $event->result;
+            return $event->result ? BaseCommand::CODE_SUCCESS: BaseCommand::CODE_ERROR;
         }
         $this->parentExecute($input, $output);
         $this->dispatchEvent('Migration.afterRollback');
+
+        return BaseCommand::CODE_SUCCESS;
     }
 }

--- a/src/Command/Seed.php
+++ b/src/Command/Seed.php
@@ -57,7 +57,7 @@ class Seed extends SeedRun
     {
         $event = $this->dispatchEvent('Migration.beforeSeed');
         if ($event->isStopped()) {
-            return $event->result ? BaseCommand::CODE_SUCCESS: BaseCommand::CODE_ERROR;
+            return $event->result ? BaseCommand::CODE_SUCCESS : BaseCommand::CODE_ERROR;
         }
 
         $seed = $input->getOption('seed');

--- a/src/Command/Seed.php
+++ b/src/Command/Seed.php
@@ -57,7 +57,7 @@ class Seed extends SeedRun
     {
         $event = $this->dispatchEvent('Migration.beforeSeed');
         if ($event->isStopped()) {
-            return $event->result;
+            return $event->result ? BaseCommand::CODE_SUCCESS: BaseCommand::CODE_ERROR;
         }
 
         $seed = $input->getOption('seed');
@@ -70,5 +70,7 @@ class Seed extends SeedRun
         $this->getManager()->setInput($input);
         $this->parentExecute($input, $output);
         $this->dispatchEvent('Migration.afterSeed');
+
+        return BaseCommand::CODE_SUCCESS;
     }
 }

--- a/src/Command/Status.php
+++ b/src/Command/Status.php
@@ -46,7 +46,7 @@ class Status extends StatusCommand
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input the input object
      * @param \Symfony\Component\Console\Output\OutputInterface $output the output object
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -77,6 +77,8 @@ class Status extends StatusCommand
                 $this->display($migrations);
                 break;
         }
+
+        return BaseCommand::CODE_SUCCESS;
     }
 
     /**

--- a/src/Shell/MigrationsShell.php
+++ b/src/Shell/MigrationsShell.php
@@ -30,7 +30,6 @@ use Symfony\Component\Console\Output\ConsoleOutput;
  */
 class MigrationsShell extends Shell
 {
-
     /**
      * {@inheritDoc}
      */
@@ -85,11 +84,8 @@ class MigrationsShell extends Shell
      */
     public function initialize()
     {
-        $composerConfig = ROOT . DS . 'vendor' . DS . 'robmorgan' . DS . 'phinx' . DS . 'composer.json';
-        $version = file_exists($composerConfig) ? json_decode(file_get_contents($composerConfig))->version : '0';
-
         if (!defined('PHINX_VERSION')) {
-            define('PHINX_VERSION', $version);
+            define('PHINX_VERSION', 'UNKNOWN');
         }
         parent::initialize();
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -85,5 +85,5 @@ Plugin::getCollection()->add(new \Migrations\Plugin());
 Plugin::getCollection()->add(new \TestBlog\Plugin());
 
 if (!defined('PHINX_VERSION')) {
-    define('PHINX_VERSION', (0 === strpos('@PHINX_VERSION@', '@PHINX_VERSION')) ? '0.4.3' : '@PHINX_VERSION@');
+    define('PHINX_VERSION', (0 === strpos('@PHINX_VERSION@', '@PHINX_VERSION')) ? 'UNKNOWN' : '@PHINX_VERSION@');
 }

--- a/tests/bootstrap.phpstan.php
+++ b/tests/bootstrap.phpstan.php
@@ -13,5 +13,5 @@
  */
 define('ROOT', '');
 define('APP', 'app');
-define('PHINX_VERSION', '0.8.1');
+define('PHINX_VERSION', 'UNKNOWN');
 define('CONFIG', ROOT . DS . 'config' . DS);


### PR DESCRIPTION
This is required for https://github.com/cakephp/phinx/pull/1653 to not throw warnings now.

Also fixed up return types for newer symfony versions and their expections

> 1) Migrations\Test\Command\CacheBuildTest::testExecute
TypeError: Return value of "Migrations\Command\CacheBuild::execute()" must be of the type int, boolean returned.


I can prepare a patch release here.
