### PR TITLE
4.x - Updated calls to TableSchema::primaryKey() to getPrimaryKey()

### DIFF
--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -167,7 +167,7 @@ class MigrationHelper extends Helper
             $tableSchema = $this->schema($table);
         }
         $columns = [];
-        $tablePrimaryKeys = $tableSchema->primaryKey();
+        $tablePrimaryKeys = $tableSchema->getPrimaryKey();
         foreach ($tableSchema->columns() as $column) {
             if (in_array($column, $tablePrimaryKeys)) {
                 continue;
@@ -268,7 +268,7 @@ class MigrationHelper extends Helper
             $tableSchema = $this->schema($table);
         }
         $primaryKeys = [];
-        $tablePrimaryKeys = $tableSchema->primaryKey();
+        $tablePrimaryKeys = $tableSchema->getPrimaryKey();
         foreach ($tableSchema->columns() as $column) {
             if (in_array($column, $tablePrimaryKeys)) {
                 $primaryKeys[] = ['name' => $column, 'info' => $this->column($tableSchema, $column)];
@@ -292,7 +292,7 @@ class MigrationHelper extends Helper
             if (!($table instanceof TableSchema)) {
                 $tableSchema = $this->schema($table);
             }
-            $tablePrimaryKeys = $tableSchema->primaryKey();
+            $tablePrimaryKeys = $tableSchema->getPrimaryKey();
 
             foreach ($tablePrimaryKeys as $primaryKey) {
                 $column = $tableSchema->getColumn($primaryKey);

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -165,7 +165,7 @@ class MigrationsTest extends TestCase
         $columns = $numbersTable->getSchema()->columns();
         $expected = ['id', 'number', 'radix'];
         $this->assertEquals($columns, $expected);
-        $primaryKey = $numbersTable->getSchema()->primaryKey();
+        $primaryKey = $numbersTable->getSchema()->getPrimaryKey();
         $this->assertEquals($primaryKey, ['id']);
 
         $lettersTable = TableRegistry::get('Letters', ['connection' => $this->Connection]);
@@ -174,7 +174,7 @@ class MigrationsTest extends TestCase
         $this->assertEquals($expected, $columns);
         $idColumn = $lettersTable->getSchema()->getColumn('id');
         $this->assertEquals(true, $idColumn['autoIncrement']);
-        $primaryKey = $lettersTable->getSchema()->primaryKey();
+        $primaryKey = $lettersTable->getSchema()->getPrimaryKey();
         $this->assertEquals($primaryKey, ['id']);
 
         // Rollback last


### PR DESCRIPTION
https://github.com/cakephp/cakephp/pull/14017

Updated calls to deprecated primaryKey() in case this is merged.