### PR TITLE
Move trait method aliasing to the "correct" use statement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpunit/phpunit": "^5.7.14|^6.0",
         "cakephp/cakephp": "^3.6.0",
         "cakephp/bake": "^1.7.0",
-        "cakephp/cakephp-codesniffer": "dev-master"
+        "cakephp/cakephp-codesniffer": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Command/Create.php
+++ b/src/Command/Create.php
@@ -22,10 +22,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Create extends CreateCommand
 {
-    use CommandTrait;
-    use ConfigurationTrait {
+    use CommandTrait {
         execute as parentExecute;
     }
+    use ConfigurationTrait;
 
     /**
      * {@inheritdoc}

--- a/src/Command/Migrate.php
+++ b/src/Command/Migrate.php
@@ -20,10 +20,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Migrate extends MigrateCommand
 {
-    use CommandTrait;
-    use ConfigurationTrait {
+    use CommandTrait {
         execute as parentExecute;
     }
+    use ConfigurationTrait;
     use EventDispatcherTrait;
 
     /**

--- a/src/Command/Rollback.php
+++ b/src/Command/Rollback.php
@@ -20,10 +20,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Rollback extends RollbackCommand
 {
-    use CommandTrait;
-    use ConfigurationTrait {
+    use CommandTrait {
         execute as parentExecute;
     }
+    use ConfigurationTrait;
     use EventDispatcherTrait;
 
     /**


### PR DESCRIPTION
While technically valid, having the aliasing on other use statements
can be quite confusing, and it seems to trip IDE code completion.