### PR TITLE
Update doc block of change, up and down method

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -65,7 +65,7 @@ Here's an example of a migration::
          * Change Method.
          *
          * More information on this method is available here:
-         * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+         * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
          * @return void
          */
         public function change()
@@ -286,7 +286,7 @@ The command line above will generate a migration file that resembles::
          * Change Method.
          *
          * More information on this method is available here:
-         * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+         * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
          * @return void
          */
         public function change()

--- a/docs/fr/index.rst
+++ b/docs/fr/index.rst
@@ -66,7 +66,7 @@ Ci-dessous un exemple de migration::
          * Change Method.
          *
          * More information on this method is available here:
-         * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+         * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
          * @return void
          */
         public function change()
@@ -285,7 +285,7 @@ La ligne de commande ci-dessus va générer un fichier de migration qui ressembl
          * Change Method.
          *
          * More information on this method is available here:
-         * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+         * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
          * @return void
          */
         public function change()

--- a/docs/ja/index.rst
+++ b/docs/ja/index.rst
@@ -65,7 +65,7 @@ Migrations
          * Change Method.
          *
          * More information on this method is available here:
-         * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+         * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
          * @return void
          */
         public function change()
@@ -267,7 +267,7 @@ fieldType の後のクエスチョンマークは、ヌルを許可するカラ�
          * Change Method.
          *
          * More information on this method is available here:
-         * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+         * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
          * @return void
          */
         public function change()

--- a/docs/pt/index.rst
+++ b/docs/pt/index.rst
@@ -63,7 +63,7 @@ Aqui segue um exemplo de migração::
          * Change Method.
          *
          * More information on this method is available here:
-         * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+         * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
          * @return void
          */
         public function change()
@@ -265,7 +265,7 @@ A linha de comando acima irá gerar um arquivo de migração parecido com este::
          * Change Method.
          *
          * More information on this method is available here:
-         * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+         * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
          * @return void
          */
         public function change()

--- a/docs/ru/index.rst
+++ b/docs/ru/index.rst
@@ -60,7 +60,7 @@
          * Метод изменения.
          *
          * Более подробная информация об этом методе доступна здесь:
-         * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+         * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
          * @return void
          */
         public function change()
@@ -260,7 +260,7 @@
          * Метод изменения.
          *
          * Более подробная информация об этом методе доступна здесь:
-         * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+         * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
          * @return void
          */
         public function change()

--- a/templates/Phinx/create.php.template
+++ b/templates/Phinx/create.php.template
@@ -6,12 +6,12 @@ use $useClassName;
 class $className extends $baseClassName
 {
     /**
-    * Change Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
-    * @return void
-    */
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     * @return void
+     */
     public function change()
     {
     }

--- a/templates/Phinx/create.php.template
+++ b/templates/Phinx/create.php.template
@@ -6,12 +6,12 @@ use $useClassName;
 class $className extends $baseClassName
 {
     /**
-     * Change Method.
-     *
-     * More information on this method is available here:
-     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
-     * @return void
-     */
+    * Change Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+    * @return void
+    */
     public function change()
     {
     }

--- a/templates/Phinx/create.php.template
+++ b/templates/Phinx/create.php.template
@@ -9,7 +9,7 @@ class $className extends $baseClassName
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()

--- a/templates/bake/config/diff.twig
+++ b/templates/bake/config/diff.twig
@@ -33,12 +33,12 @@ class {{ name }} extends AbstractMigration
 
 {% endif %}
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
 {%    for tableName, tableDiff in data %}
@@ -123,12 +123,12 @@ not empty %}
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
 {%  set returnedData = Migration.getReturnedData() %}

--- a/templates/bake/config/diff.twig
+++ b/templates/bake/config/diff.twig
@@ -32,6 +32,13 @@ class {{ name }} extends AbstractMigration
     public $autoId = false;
 
 {% endif %}
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
 {%    for tableName, tableDiff in data %}
@@ -115,6 +122,13 @@ not empty %}
 {%     endif %}
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
 {%  set returnedData = Migration.getReturnedData() %}

--- a/templates/bake/config/skeleton.twig
+++ b/templates/bake/config/skeleton.twig
@@ -32,7 +32,7 @@ class {{ name }} extends AbstractMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()

--- a/templates/bake/config/snapshot.twig
+++ b/templates/bake/config/snapshot.twig
@@ -31,6 +31,13 @@ class {{ name }} extends AbstractMigration
     public $autoId = false;
 
 {% endif %}
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
 {% element 'Migrations.create-tables' {
@@ -40,6 +47,13 @@ class {{ name }} extends AbstractMigration
 } %}
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
 {%  set returnedData = Migration.getReturnedData() %}

--- a/templates/bake/config/snapshot.twig
+++ b/templates/bake/config/snapshot.twig
@@ -32,12 +32,12 @@ class {{ name }} extends AbstractMigration
 
 {% endif %}
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
 {% element 'Migrations.create-tables' {
@@ -48,12 +48,12 @@ class {{ name }} extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
 {%  set returnedData = Migration.getReturnedData() %}

--- a/tests/comparisons/Create/TestCreate.php
+++ b/tests/comparisons/Create/TestCreate.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TestCreate extends AbstractMigration
 {
     /**
-    * Change Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
-    * @return void
-    */
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     * @return void
+     */
     public function change()
     {
     }

--- a/tests/comparisons/Create/TestCreate.php
+++ b/tests/comparisons/Create/TestCreate.php
@@ -9,7 +9,7 @@ class TestCreate extends AbstractMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()

--- a/tests/comparisons/Create/TestCreate.php
+++ b/tests/comparisons/Create/TestCreate.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TestCreate extends AbstractMigration
 {
     /**
-     * Change Method.
-     *
-     * More information on this method is available here:
-     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
-     * @return void
-     */
+    * Change Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+    * @return void
+    */
     public function change()
     {
     }

--- a/tests/comparisons/Diff/addremove/the_diff_add_remove_mysql.php
+++ b/tests/comparisons/Diff/addremove/the_diff_add_remove_mysql.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TheDiffAddRemoveMysql extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
 
@@ -22,6 +29,13 @@ class TheDiffAddRemoveMysql extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
 

--- a/tests/comparisons/Diff/addremove/the_diff_add_remove_mysql.php
+++ b/tests/comparisons/Diff/addremove/the_diff_add_remove_mysql.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TheDiffAddRemoveMysql extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
 
@@ -30,12 +30,12 @@ class TheDiffAddRemoveMysql extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
 

--- a/tests/comparisons/Diff/addremove/the_diff_add_remove_pgsql.php
+++ b/tests/comparisons/Diff/addremove/the_diff_add_remove_pgsql.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TheDiffAddRemovePgsql extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
 
@@ -30,12 +30,12 @@ class TheDiffAddRemovePgsql extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
 

--- a/tests/comparisons/Diff/addremove/the_diff_add_remove_pgsql.php
+++ b/tests/comparisons/Diff/addremove/the_diff_add_remove_pgsql.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TheDiffAddRemovePgsql extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
 
@@ -22,6 +29,13 @@ class TheDiffAddRemovePgsql extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
 

--- a/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TheDiffSimpleMysql extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('users')
@@ -50,6 +57,13 @@ class TheDiffSimpleMysql extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TheDiffSimpleMysql extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('users')
@@ -58,12 +58,12 @@ class TheDiffSimpleMysql extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Diff/simple/the_diff_simple_pgsql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_pgsql.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TheDiffSimplePgsql extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('users')
@@ -50,6 +57,13 @@ class TheDiffSimplePgsql extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Diff/simple/the_diff_simple_pgsql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_pgsql.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TheDiffSimplePgsql extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('users')
@@ -58,12 +58,12 @@ class TheDiffSimplePgsql extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Diff/the_diff.php
+++ b/tests/comparisons/Diff/the_diff.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TheDiff extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -126,12 +126,12 @@ class TheDiff extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('categories')

--- a/tests/comparisons/Diff/the_diff.php
+++ b/tests/comparisons/Diff/the_diff.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TheDiff extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')
@@ -118,6 +125,13 @@ class TheDiff extends AbstractMigration
         $this->table('tags')->drop()->save();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('categories')

--- a/tests/comparisons/Diff/the_diff_mysql.php
+++ b/tests/comparisons/Diff/the_diff_mysql.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TheDiffMysql extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -126,12 +126,12 @@ class TheDiffMysql extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('categories')

--- a/tests/comparisons/Diff/the_diff_mysql.php
+++ b/tests/comparisons/Diff/the_diff_mysql.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TheDiffMysql extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')
@@ -118,6 +125,13 @@ class TheDiffMysql extends AbstractMigration
         $this->table('tags')->drop()->save();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('categories')

--- a/tests/comparisons/Diff/the_diff_pgsql.php
+++ b/tests/comparisons/Diff/the_diff_pgsql.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TheDiffPgsql extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')
@@ -118,6 +125,13 @@ class TheDiffPgsql extends AbstractMigration
         $this->table('tags')->drop()->save();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('categories')

--- a/tests/comparisons/Diff/the_diff_pgsql.php
+++ b/tests/comparisons/Diff/the_diff_pgsql.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TheDiffPgsql extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -126,12 +126,12 @@ class TheDiffPgsql extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('categories')

--- a/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
@@ -8,12 +8,12 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
     public $autoId = false;
 
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -372,12 +372,12 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
@@ -7,6 +7,13 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
 {
     public $autoId = false;
 
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')
@@ -364,6 +371,13 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TestNotEmptySnapshotPgsql extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -326,12 +326,12 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TestNotEmptySnapshotPgsql extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')
@@ -318,6 +325,13 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TestPluginBlogPgsql extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -143,12 +143,12 @@ class TestPluginBlogPgsql extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TestPluginBlogPgsql extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')
@@ -135,6 +142,13 @@ class TestPluginBlogPgsql extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
@@ -7,6 +7,13 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
 {
     public $autoId = false;
 
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')
@@ -385,6 +392,13 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
@@ -8,12 +8,12 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
     public $autoId = false;
 
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -393,12 +393,12 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TestNotEmptySnapshotSqlite extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -340,12 +340,12 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TestNotEmptySnapshotSqlite extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')
@@ -332,6 +339,13 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TestPluginBlogSqlite extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')
@@ -136,6 +143,13 @@ class TestPluginBlogSqlite extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TestPluginBlogSqlite extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -144,12 +144,12 @@ class TestPluginBlogSqlite extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/testCreate.php
+++ b/tests/comparisons/Migration/testCreate.php
@@ -9,7 +9,7 @@ class CreateUsers extends AbstractMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()

--- a/tests/comparisons/Migration/testCreateDatetime.php
+++ b/tests/comparisons/Migration/testCreateDatetime.php
@@ -9,7 +9,7 @@ class CreateUsers extends AbstractMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()

--- a/tests/comparisons/Migration/testCreateFieldLength.php
+++ b/tests/comparisons/Migration/testCreateFieldLength.php
@@ -9,7 +9,7 @@ class CreateUsers extends AbstractMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()

--- a/tests/comparisons/Migration/testCreatePrimaryKey.php
+++ b/tests/comparisons/Migration/testCreatePrimaryKey.php
@@ -11,7 +11,7 @@ class CreateUsers extends AbstractMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()

--- a/tests/comparisons/Migration/testCreatePrimaryKeyUuid.php
+++ b/tests/comparisons/Migration/testCreatePrimaryKeyUuid.php
@@ -11,7 +11,7 @@ class CreateUsers extends AbstractMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()

--- a/tests/comparisons/Migration/testNoContents.php
+++ b/tests/comparisons/Migration/testNoContents.php
@@ -9,7 +9,7 @@ class NoContents extends AbstractMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -8,12 +8,12 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
     public $autoId = false;
 
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -394,12 +394,12 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -7,6 +7,13 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
 {
     public $autoId = false;
 
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')
@@ -386,6 +393,13 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
@@ -8,12 +8,12 @@ class TestAutoIdDisabledSnapshot56 extends AbstractMigration
     public $autoId = false;
 
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -395,12 +395,12 @@ class TestAutoIdDisabledSnapshot56 extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
@@ -387,6 +387,13 @@ class TestAutoIdDisabledSnapshot56 extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
@@ -7,6 +7,13 @@ class TestAutoIdDisabledSnapshot56 extends AbstractMigration
 {
     public $autoId = false;
 
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TestNotEmptySnapshot extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -341,12 +341,12 @@ class TestNotEmptySnapshot extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TestNotEmptySnapshot extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')
@@ -333,6 +340,13 @@ class TestNotEmptySnapshot extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/test_not_empty_snapshot56.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot56.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TestNotEmptySnapshot56 extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')
@@ -334,6 +341,13 @@ class TestNotEmptySnapshot56 extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/test_not_empty_snapshot56.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot56.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TestNotEmptySnapshot56 extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -342,12 +342,12 @@ class TestNotEmptySnapshot56 extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TestPluginBlog extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -145,12 +145,12 @@ class TestPluginBlog extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TestPluginBlog extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')
@@ -137,6 +144,13 @@ class TestPluginBlog extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/test_plugin_blog56.php
+++ b/tests/comparisons/Migration/test_plugin_blog56.php
@@ -5,6 +5,13 @@ use Migrations\AbstractMigration;
 
 class TestPluginBlog56 extends AbstractMigration
 {
+    /**
+    * Up Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+    * @return void
+    */
     public function up()
     {
         $this->table('articles')
@@ -137,6 +144,13 @@ class TestPluginBlog56 extends AbstractMigration
             ->update();
     }
 
+    /**
+    * Down Method.
+    *
+    * More information on this method is available here:
+    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+    * @return void
+    */
     public function down()
     {
         $this->table('articles')

--- a/tests/comparisons/Migration/test_plugin_blog56.php
+++ b/tests/comparisons/Migration/test_plugin_blog56.php
@@ -6,12 +6,12 @@ use Migrations\AbstractMigration;
 class TestPluginBlog56 extends AbstractMigration
 {
     /**
-    * Up Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
-    * @return void
-    */
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
     public function up()
     {
         $this->table('articles')
@@ -145,12 +145,12 @@ class TestPluginBlog56 extends AbstractMigration
     }
 
     /**
-    * Down Method.
-    *
-    * More information on this method is available here:
-    * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
-    * @return void
-    */
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
     public function down()
     {
         $this->table('articles')

--- a/tests/test_app/config/MigrationsDiff/20160128183623_AlterArticles.php
+++ b/tests/test_app/config/MigrationsDiff/20160128183623_AlterArticles.php
@@ -8,7 +8,7 @@ class AlterArticles extends AbstractMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()

--- a/tests/test_app/config/MigrationsDiff/20160128183652_AlterArticlesSlug.php
+++ b/tests/test_app/config/MigrationsDiff/20160128183652_AlterArticlesSlug.php
@@ -8,7 +8,7 @@ class AlterArticlesSlug extends AbstractMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()

--- a/tests/test_app/config/MigrationsDiff/20160128183952_CreateUsers.php
+++ b/tests/test_app/config/MigrationsDiff/20160128183952_CreateUsers.php
@@ -8,7 +8,7 @@ class CreateUsers extends AbstractMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()

--- a/tests/test_app/config/MigrationsDiff/20160128184109_AlterArticlesFk.php
+++ b/tests/test_app/config/MigrationsDiff/20160128184109_AlterArticlesFk.php
@@ -8,7 +8,7 @@ class AlterArticlesFk extends AbstractMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()

--- a/tests/test_app/config/MigrationsDiff/20160414193900_CreateTags.php
+++ b/tests/test_app/config/MigrationsDiff/20160414193900_CreateTags.php
@@ -8,7 +8,7 @@ class CreateTags extends AbstractMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()

--- a/tests/test_app/config/MigrationsDiffSimple/20160128183623_AlterArticlesSimple.php
+++ b/tests/test_app/config/MigrationsDiffSimple/20160128183623_AlterArticlesSimple.php
@@ -8,7 +8,7 @@ class AlterArticlesSimple extends AbstractMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
      * @return void
      */
     public function change()


### PR DESCRIPTION
The doc blocks of the `change`, `up` and `down` methods where missing or point to a 404 error.

I changed
```
http://docs.phinx.org/en/latest/migrations.html#the-change-method
```
to
```
https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
```