### PR TITLE
Allow 0.12 for Cake3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.6.0",
-        "robmorgan/phinx": "^0.10.3|^0.11.1",
+        "robmorgan/phinx": "^0.10.3|^0.11.1|^0.12.1",
         "cakephp/orm": "^3.6.0",
         "cakephp/cache": "^3.6.0"
     },


### PR DESCRIPTION
I dont think there is any reason why Cake3 people couldn't use this major, if composer allows it
(which means that they are using php72+).
If not compatible PHP wise, it wouldn't be pulled. 
And since we didn't do really BC breaking additions I think that major should fully work with Cake3.