### PR TITLE
disable  cache

### DIFF
--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -536,7 +536,9 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             return $schema;
         }
 
-        $collection = ConnectionManager::get($this->connection)->getSchemaCollection();
+        $connection = ConnectionManager::get($this->connection);
+        $connection->cacheMetadata(false);
+        $collection = $connection->getSchemaCollection();
         foreach ($this->tables as $table) {
             if (preg_match("/^.*phinxlog$/", $table) === 1) {
                 continue;


### PR DESCRIPTION
cache causes invalid result in migration diff command

should we disable the cache at all?
also there are other places