### PR TITLE
unset `fixed` from schema list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "cakephp/cache": "^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "~8.5.0",
         "cakephp/cakephp": "^4.0",
         "cakephp/bake": "^2.0",
         "cakephp/cakephp-codesniffer": "^4.0"

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
     "require": {
         "php": ">=7.2.0",
         "robmorgan/phinx": "^0.12",
-        "cakephp/orm": "^4.0",
-        "cakephp/cache": "^4.0"
+        "cakephp/orm": "^4.0.5",
+        "cakephp/cache": "^4.0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.5.0",
-        "cakephp/cakephp": "^4.0",
+        "cakephp/cakephp": "^4.0.5",
         "cakephp/bake": "^2.0.9",
         "cakephp/cakephp-codesniffer": "~4.1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     "require-dev": {
         "phpunit/phpunit": "~8.5.0",
         "cakephp/cakephp": "^4.0",
-        "cakephp/bake": "^2.0",
-        "cakephp/cakephp-codesniffer": "^4.0"
+        "cakephp/bake": "^2.0.9",
+        "cakephp/cakephp-codesniffer": "~4.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -259,7 +259,9 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
                 $column = $currentSchema->getColumn($columnName);
                 $oldColumn = $this->dumpSchema[$table]->getColumn($columnName);
                 unset($column['collate']);
+                unset($column['fixed']);
                 unset($oldColumn['collate']);
+                unset($oldColumn['fixed']);
 
                 if (
                     in_array($columnName, $oldColumns, true) &&


### PR DESCRIPTION
`fixed` has been removed from TableSchema
Refs: cakephp/cakephp#13843

tests now should be green

before this change , lock file had `fixed` from cake 3
I did not removed it from test lock file

