### PR TITLE
Passing the theme to the TemplateRenderer

### DIFF
--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -122,7 +122,7 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
             }
         }
 
-        $renderer = new TemplateRenderer();
+        $renderer = new TemplateRenderer($this->theme);
         $renderer->set('name', $name);
         $renderer->set($this->templateData($args));
         $contents = $renderer->generate($this->template());


### PR DESCRIPTION
Currently if you wish to override say `templates/bake/element/add-foreign-keys.twig` you would need to do so by placing this file in the app's `templates/bake/element`, but if you are building a plugin/theme and you wish to override `templates/bake/element/add-foreign-keys.twig` you can not without also extending and overriding some class files like `BakeSimpleMigrationCommand.php` for example. Currently the theme is not passed down to the TemplateRenderer so you can not override a template using a theme. Example: currently executing something like `bin/cake bake migration_diff AlterSomething -t MyTheme` would always use `templates/bake/element/add-foreign-keys.twig` from cakephp/migrations not mypackage/my-theme. 