### PR TITLE
Fix deprecations.

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Migrations;
 
 use Cake\Collection\Collection;
-use Cake\ORM\TableRegistry;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Phinx\Db\Table as BaseTable;
 use Phinx\Db\Table\Column;
 
@@ -23,6 +23,8 @@ use Phinx\Db\Table\Column;
  */
 class Table extends BaseTable
 {
+    use LocatorAwareTrait;
+
     /**
      * Primary key for this table.
      * Can either be a string or an array in case of composite
@@ -150,7 +152,7 @@ class Table extends BaseTable
     public function update()
     {
         parent::update();
-        TableRegistry::getTableLocator()->clear();
+        $this->getTableLocator()->clear();
     }
 
     /**

--- a/tests/TestCase/Command/Phinx/DumpTest.php
+++ b/tests/TestCase/Command/Phinx/DumpTest.php
@@ -11,13 +11,12 @@ declare(strict_types=1);
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Migrations\Test\Command\Phinx;
+namespace Migrations\Test\TestCase\Command\Phinx;
 
 use Cake\Core\Plugin;
 use Cake\Database\Schema\Collection;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\StringCompareTrait;
 use Cake\TestSuite\TestCase;
 use Migrations\CakeManager;
@@ -221,7 +220,7 @@ class DumpTest extends TestCase
 
         $tables = (new Collection($this->Connection))->listTables();
         if (in_array('phinxlog', $tables)) {
-            $ormTable = TableRegistry::get('phinxlog', ['connection' => $this->Connection]);
+            $ormTable = $this->getTableLocator()->get('phinxlog', ['connection' => $this->Connection]);
             $query = $this->Connection->getDriver()->schemaDialect()->truncateTableSql($ormTable->getSchema());
             foreach ($query as $stmt) {
                 $this->Connection->execute($stmt);

--- a/tests/TestCase/Command/Phinx/MarkMigratedTest.php
+++ b/tests/TestCase/Command/Phinx/MarkMigratedTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Migrations\Test\Command\Phinx;
+namespace Migrations\Test\TestCase\Command\Phinx;
 
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Command/Phinx/SeedTest.php
+++ b/tests/TestCase/Command/Phinx/SeedTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Migrations\Test\Command\Phinx;
+namespace Migrations\Test\TestCase\Command\Phinx;
 
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Command/Phinx/StatusTest.php
+++ b/tests/TestCase/Command/Phinx/StatusTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Migrations\Test\Command\Phinx;
+namespace Migrations\Test\TestCase\Command\Phinx;
 
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -16,7 +16,6 @@ namespace Migrations\Test\TestCase;
 use Cake\Core\Plugin;
 use Cake\Database\Schema\Collection;
 use Cake\Datasource\ConnectionManager;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Migrations\CakeAdapter;
 use Migrations\Migrations;
@@ -89,7 +88,7 @@ class MigrationsTest extends TestCase
             $this->Connection->execute("DROP TABLE IF EXISTS {$table}");
         }
         if (in_array('phinxlog', $tables)) {
-            $ormTable = TableRegistry::get('phinxlog', ['connection' => $this->Connection]);
+            $ormTable = $this->getTableLocator()->get('phinxlog', ['connection' => $this->Connection]);
             $query = $this->Connection->getDriver()->schemaDialect()->truncateTableSql($ormTable->getSchema());
             foreach ($query as $stmt) {
                 $this->Connection->execute($stmt);
@@ -180,14 +179,14 @@ class MigrationsTest extends TestCase
         ];
         $this->assertEquals($expectedStatus, $status);
 
-        $numbersTable = TableRegistry::get('Numbers', ['connection' => $this->Connection]);
+        $numbersTable = $this->getTableLocator()->get('Numbers', ['connection' => $this->Connection]);
         $columns = $numbersTable->getSchema()->columns();
         $expected = ['id', 'number', 'radix'];
         $this->assertEquals($columns, $expected);
         $primaryKey = $numbersTable->getSchema()->getPrimaryKey();
         $this->assertEquals($primaryKey, ['id']);
 
-        $lettersTable = TableRegistry::get('Letters', ['connection' => $this->Connection]);
+        $lettersTable = $this->getTableLocator()->get('Letters', ['connection' => $this->Connection]);
         $columns = $lettersTable->getSchema()->columns();
         $expected = ['id', 'letter'];
         $this->assertEquals($expected, $columns);
@@ -225,12 +224,12 @@ class MigrationsTest extends TestCase
         $this->assertTrue($migrate);
 
         // Tests that if a collation is defined, it is used
-        $numbersTable = TableRegistry::get('Numbers', ['connection' => $this->Connection]);
+        $numbersTable = $this->getTableLocator()->get('Numbers', ['connection' => $this->Connection]);
         $options = $numbersTable->getSchema()->getOptions();
         $this->assertEquals('utf8_bin', $options['collation']);
 
         // Tests that if a collation is not defined, it will use the database default one
-        $lettersTable = TableRegistry::get('Letters', ['connection' => $this->Connection]);
+        $lettersTable = $this->getTableLocator()->get('Letters', ['connection' => $this->Connection]);
         $options = $lettersTable->getSchema()->getOptions();
         $this->assertEquals('utf8mb4_general_ci', $options['collation']);
 

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -198,7 +198,7 @@ class MigrationHelperTest extends TestCase
      */
     public function testColumn()
     {
-        $tableSchema = $this->Collection->describe('users');
+        $tableSchema = $this->collection->describe('users');
         $this->assertEquals([
             'columnType' => 'integer',
             'options' => [

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Migrations\Test\TestCase\Helper;
+namespace Migrations\Test\TestCase\View\Helper;
 
 use Cake\Cache\Cache;
 use Cake\Database\Schema\Collection;
@@ -34,6 +34,31 @@ class MigrationHelperTest extends TestCase
     ];
 
     /**
+     * @var \Cake\Datasource\ConnectionInterface
+     */
+    protected $connection;
+
+    /**
+     * @var \Cake\Database\Schema\Collection
+     */
+    protected $collection;
+
+    /**
+     * @var \Cake\View\View
+     */
+    protected $view;
+
+    /**
+     * @var \Migrations\View\Helper\MigrationHelper
+     */
+    protected $helper;
+
+    /**
+     * @var array
+     */
+    protected $values;
+
+    /**
      * setUp method
      *
      * @return void
@@ -41,11 +66,11 @@ class MigrationHelperTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->Connection = ConnectionManager::get('test');
-        $this->Collection = new Collection($this->Connection);
-        $this->View = new View();
-        $this->Helper = new MigrationHelper($this->View, [
-            'collection' => $this->Collection,
+        $this->connection = ConnectionManager::get('test');
+        $this->collection = new Collection($this->connection);
+        $this->view = new View();
+        $this->helper = new MigrationHelper($this->view, [
+            'collection' => $this->collection,
         ]);
         Cache::clear('_cake_model_');
         Cache::enable();
@@ -86,7 +111,7 @@ class MigrationHelperTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        unset($this->Helper, $this->View, $this->Collection, $this->Connection);
+        unset($this->helper, $this->view, $this->collection, $this->connection);
     }
 
     /**
@@ -94,9 +119,9 @@ class MigrationHelperTest extends TestCase
      */
     public function testTableMethod()
     {
-        $this->assertEquals('drop', $this->Helper->tableMethod('drop_table'));
-        $this->assertEquals('create', $this->Helper->tableMethod('create_table'));
-        $this->assertEquals('update', $this->Helper->tableMethod('other_method'));
+        $this->assertEquals('drop', $this->helper->tableMethod('drop_table'));
+        $this->assertEquals('create', $this->helper->tableMethod('create_table'));
+        $this->assertEquals('update', $this->helper->tableMethod('other_method'));
     }
 
     /**
@@ -104,9 +129,9 @@ class MigrationHelperTest extends TestCase
      */
     public function testIndexMethod()
     {
-        $this->assertEquals('removeIndex', $this->Helper->indexMethod('drop_field'));
-        $this->assertEquals('addIndex', $this->Helper->indexMethod('add_field'));
-        $this->assertEquals('addIndex', $this->Helper->indexMethod('alter_field'));
+        $this->assertEquals('removeIndex', $this->helper->indexMethod('drop_field'));
+        $this->assertEquals('addIndex', $this->helper->indexMethod('add_field'));
+        $this->assertEquals('addIndex', $this->helper->indexMethod('alter_field'));
     }
 
     /**
@@ -114,9 +139,9 @@ class MigrationHelperTest extends TestCase
      */
     public function testColumnMethod()
     {
-        $this->assertEquals('removeColumn', $this->Helper->columnMethod('drop_field'));
-        $this->assertEquals('addColumn', $this->Helper->columnMethod('add_field'));
-        $this->assertEquals('changeColumn', $this->Helper->columnMethod('alter_field'));
+        $this->assertEquals('removeColumn', $this->helper->columnMethod('drop_field'));
+        $this->assertEquals('addColumn', $this->helper->columnMethod('add_field'));
+        $this->assertEquals('changeColumn', $this->helper->columnMethod('alter_field'));
     }
 
     /**
@@ -165,7 +190,7 @@ class MigrationHelperTest extends TestCase
                     'comment' => $this->values['comment'],
                 ],
             ],
-        ], $this->Helper->columns('users'));
+        ], $this->helper->columns('users'));
     }
 
     /**
@@ -185,7 +210,7 @@ class MigrationHelperTest extends TestCase
                 'signed' => true,
                 'autoIncrement' => true,
             ],
-        ], $this->Helper->column($tableSchema, 'id'));
+        ], $this->helper->column($tableSchema, 'id'));
 
         $this->assertEquals([
             'columnType' => 'string',
@@ -196,7 +221,7 @@ class MigrationHelperTest extends TestCase
                 'precision' => null,
                 'comment' => $this->values['comment'],
             ],
-        ], $this->Helper->column($tableSchema, 'username'));
+        ], $this->helper->column($tableSchema, 'username'));
 
         $this->assertEquals([
             'columnType' => 'string',
@@ -207,7 +232,7 @@ class MigrationHelperTest extends TestCase
                 'precision' => null,
                 'comment' => $this->values['comment'],
             ],
-        ], $this->Helper->column($tableSchema, 'password'));
+        ], $this->helper->column($tableSchema, 'password'));
 
         $this->assertEquals([
             'columnType' => 'timestamp',
@@ -218,7 +243,7 @@ class MigrationHelperTest extends TestCase
                 'precision' => null,
                 'comment' => $this->values['comment'],
             ],
-        ], $this->Helper->column($tableSchema, 'created'));
+        ], $this->helper->column($tableSchema, 'created'));
 
         $this->assertEquals([
             'columnType' => 'timestamp',
@@ -229,7 +254,7 @@ class MigrationHelperTest extends TestCase
                 'precision' => null,
                 'comment' => $this->values['comment'],
             ],
-        ], $this->Helper->column($tableSchema, 'updated'));
+        ], $this->helper->column($tableSchema, 'updated'));
     }
 
     /**
@@ -237,22 +262,22 @@ class MigrationHelperTest extends TestCase
      */
     public function testValue()
     {
-        $this->assertEquals('null', $this->Helper->value(null));
-        $this->assertEquals('null', $this->Helper->value('null'));
-        $this->assertEquals('true', $this->Helper->value(true));
-        $this->assertEquals('false', $this->Helper->value(false));
-        $this->assertEquals(1, $this->Helper->value(1));
-        $this->assertEquals(-1, $this->Helper->value(-1));
-        $this->assertEquals(1.5, $this->Helper->value(1.5));
-        $this->assertEquals(1.5, $this->Helper->value('1.5'));
-        $this->assertEquals(1, $this->Helper->value('1'));
-        $this->assertIsFloat($this->Helper->value('1'));
-        $this->assertIsString($this->Helper->value('1', true));
-        $this->assertIsString($this->Helper->value('1.5', true));
-        $this->assertIsString($this->Helper->value(1, true));
-        $this->assertIsString($this->Helper->value(1.5, true));
-        $this->assertEquals("'one'", $this->Helper->value('one'));
-        $this->assertEquals("'o\\\"ne'", $this->Helper->value('o"ne'));
+        $this->assertEquals('null', $this->helper->value(null));
+        $this->assertEquals('null', $this->helper->value('null'));
+        $this->assertEquals('true', $this->helper->value(true));
+        $this->assertEquals('false', $this->helper->value(false));
+        $this->assertEquals(1, $this->helper->value(1));
+        $this->assertEquals(-1, $this->helper->value(-1));
+        $this->assertEquals(1.5, $this->helper->value(1.5));
+        $this->assertEquals(1.5, $this->helper->value('1.5'));
+        $this->assertEquals(1, $this->helper->value('1'));
+        $this->assertIsFloat($this->helper->value('1'));
+        $this->assertIsString($this->helper->value('1', true));
+        $this->assertIsString($this->helper->value('1.5', true));
+        $this->assertIsString($this->helper->value(1, true));
+        $this->assertIsString($this->helper->value(1.5, true));
+        $this->assertEquals("'one'", $this->helper->value('one'));
+        $this->assertEquals("'o\\\"ne'", $this->helper->value('o"ne'));
     }
 
     /**
@@ -268,7 +293,7 @@ class MigrationHelperTest extends TestCase
             'comment' => $this->values['comment'],
             'signed' => true,
             'autoIncrement' => true,
-        ], $this->Helper->attributes('users', 'id'));
+        ], $this->helper->attributes('users', 'id'));
 
         $this->assertEquals([
             'limit' => 256,
@@ -276,7 +301,7 @@ class MigrationHelperTest extends TestCase
             'default' => $this->values['null'],
             'precision' => null,
             'comment' => $this->values['comment'],
-        ], $this->Helper->attributes('users', 'username'));
+        ], $this->helper->attributes('users', 'username'));
 
         $this->assertEquals([
             'limit' => 256,
@@ -284,7 +309,7 @@ class MigrationHelperTest extends TestCase
             'default' => $this->values['null'],
             'precision' => null,
             'comment' => $this->values['comment'],
-        ], $this->Helper->attributes('users', 'password'));
+        ], $this->helper->attributes('users', 'password'));
 
         $this->assertEquals([
             'limit' => null,
@@ -292,7 +317,7 @@ class MigrationHelperTest extends TestCase
             'default' => $this->values['null'],
             'precision' => null,
             'comment' => $this->values['comment'],
-        ], $this->Helper->attributes('users', 'created'));
+        ], $this->helper->attributes('users', 'created'));
 
         $this->assertEquals([
             'limit' => null,
@@ -300,7 +325,7 @@ class MigrationHelperTest extends TestCase
             'default' => $this->values['null'],
             'precision' => null,
             'comment' => null,
-        ], $this->Helper->attributes('users', 'updated'));
+        ], $this->helper->attributes('users', 'updated'));
 
         $this->assertEquals([
             'limit' => 11,
@@ -310,7 +335,7 @@ class MigrationHelperTest extends TestCase
             'comment' => $this->values['comment'],
             'signed' => true,
             'autoIncrement' => null,
-        ], $this->Helper->attributes('special_tags', 'article_id'));
+        ], $this->helper->attributes('special_tags', 'article_id'));
     }
 
     /**
@@ -318,16 +343,16 @@ class MigrationHelperTest extends TestCase
      */
     public function testStringifyList()
     {
-        $this->assertEquals("", $this->Helper->stringifyList([]));
+        $this->assertEquals("", $this->helper->stringifyList([]));
         $this->assertEquals("
         'key' => 'value',
-    ", $this->Helper->stringifyList([
+    ", $this->helper->stringifyList([
             'key' => 'value',
         ]));
         $this->assertEquals("
         'key' => 'value',
         'other_key' => 'other_value',
-    ", $this->Helper->stringifyList([
+    ", $this->helper->stringifyList([
             'key' => 'value',
             'other_key' => 'other_value',
         ]));
@@ -337,7 +362,7 @@ class MigrationHelperTest extends TestCase
             'key' => 'value',
             'other_key' => 'other_value',
         ],
-    ", $this->Helper->stringifyList([
+    ", $this->helper->stringifyList([
             'key' => 'value',
             'other_key' => [
                 'key' => 'value',


### PR DESCRIPTION
Psalm

> ERROR: DeprecatedClass - src/Table.php:153:9 - Cake\ORM\TableRegistry is marked deprecated (see https://psalm.dev/098)
        TableRegistry::getTableLocator()->clear();
ERROR: DeprecatedClass - src/TableFinderTrait.php:175:18 - Cake\ORM\TableRegistry is marked deprecated (see https://psalm.dev/098)
        $table = TableRegistry::getTableLocator()->get($className);

And invalid namespaces will break in Composer v2