### PR TITLE
Fix failing mysql tests.

### DIFF
--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -88,7 +88,7 @@ class MigrationHelperTest extends TestCase
             $this->values = [
                 'null' => null,
                 'integerNull' => null,
-                'integerLimit' => 11,
+                'integerLimit' => null,
                 'comment' => '',
             ];
         }
@@ -328,7 +328,7 @@ class MigrationHelperTest extends TestCase
         ], $this->helper->attributes('users', 'updated'));
 
         $this->assertEquals([
-            'limit' => 11,
+            'limit' => $this->values['integerLimit'],
             'null' => false,
             'default' => $this->values['integerNull'],
             'precision' => null,

--- a/tests/comparisons/Diff/addremove/the_diff_add_remove_mysql.php
+++ b/tests/comparisons/Diff/addremove/the_diff_add_remove_mysql.php
@@ -17,6 +17,12 @@ class TheDiffAddRemoveMysql extends AbstractMigration
 
         $this->table('articles')
             ->removeColumn('excerpt')
+            ->changeColumn('id', 'integer', [
+                'default' => null,
+                'length' => null,
+                'limit' => null,
+                'null' => false,
+            ])
             ->update();
 
         $this->table('articles')
@@ -44,6 +50,12 @@ class TheDiffAddRemoveMysql extends AbstractMigration
                 'after' => 'title',
                 'default' => null,
                 'length' => null,
+                'null' => false,
+            ])
+            ->changeColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'length' => 11,
                 'null' => false,
             ])
             ->removeColumn('the_text')

--- a/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
@@ -14,6 +14,21 @@ class TheDiffSimpleMysql extends AbstractMigration
      */
     public function up()
     {
+
+        $this->table('articles')
+            ->changeColumn('id', 'integer', [
+                'default' => null,
+                'length' => null,
+                'limit' => null,
+                'null' => false,
+            ])
+            ->changeColumn('rating', 'integer', [
+                'default' => null,
+                'length' => null,
+                'limit' => null,
+                'null' => false,
+            ])
+            ->update();
         $this->table('users')
             ->addColumn('username', 'string', [
                 'default' => null,
@@ -31,7 +46,7 @@ class TheDiffSimpleMysql extends AbstractMigration
             ->addColumn('user_id', 'integer', [
                 'after' => 'name',
                 'default' => null,
-                'length' => 11,
+                'length' => null,
                 'null' => false,
             ])
             ->addIndex(
@@ -76,6 +91,17 @@ class TheDiffSimpleMysql extends AbstractMigration
             ->update();
 
         $this->table('articles')
+            ->changeColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'length' => 11,
+                'null' => false,
+            ])
+            ->changeColumn('rating', 'integer', [
+                'default' => null,
+                'length' => 11,
+                'null' => false,
+            ])
             ->removeColumn('user_id')
             ->update();
 

--- a/tests/comparisons/Diff/the_diff_mysql.php
+++ b/tests/comparisons/Diff/the_diff_mysql.php
@@ -23,7 +23,19 @@ class TheDiffMysql extends AbstractMigration
 
         $this->table('articles')
             ->removeColumn('content')
+            ->changeColumn('id', 'integer', [
+                'default' => null,
+                'length' => null,
+                'limit' => null,
+                'null' => false,
+            ])
             ->changeColumn('title', 'text', [
+                'default' => null,
+                'length' => null,
+                'limit' => null,
+                'null' => false,
+            ])
+            ->changeColumn('rating', 'integer', [
                 'default' => null,
                 'length' => null,
                 'limit' => null,
@@ -32,6 +44,21 @@ class TheDiffMysql extends AbstractMigration
             ->changeColumn('name', 'string', [
                 'default' => null,
                 'limit' => 10,
+                'null' => false,
+            ])
+            ->changeColumn('user_id', 'integer', [
+                'default' => null,
+                'length' => null,
+                'limit' => null,
+                'null' => false,
+            ])
+            ->update();
+
+        $this->table('users')
+            ->changeColumn('id', 'integer', [
+                'default' => null,
+                'length' => null,
+                'limit' => null,
                 'null' => false,
             ])
             ->update();
@@ -43,7 +70,7 @@ class TheDiffMysql extends AbstractMigration
             ])
             ->addColumn('user_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addIndex(
@@ -74,7 +101,7 @@ class TheDiffMysql extends AbstractMigration
             ->addColumn('category_id', 'integer', [
                 'after' => 'user_id',
                 'default' => null,
-                'length' => 11,
+                'length' => null,
                 'null' => false,
             ])
             ->addColumn('average_note', 'decimal', [
@@ -164,14 +191,30 @@ class TheDiffMysql extends AbstractMigration
                 'length' => null,
                 'null' => false,
             ])
+            ->changeColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'length' => 11,
+                'null' => false,
+            ])
             ->changeColumn('title', 'string', [
                 'default' => null,
                 'length' => 255,
                 'null' => false,
             ])
+            ->changeColumn('rating', 'integer', [
+                'default' => null,
+                'length' => 11,
+                'null' => false,
+            ])
             ->changeColumn('name', 'string', [
                 'default' => null,
                 'length' => 255,
+                'null' => false,
+            ])
+            ->changeColumn('user_id', 'integer', [
+                'default' => null,
+                'length' => 11,
                 'null' => false,
             ])
             ->removeColumn('category_id')
@@ -201,6 +244,15 @@ class TheDiffMysql extends AbstractMigration
                     'name' => 'BY_NAME',
                 ]
             )
+            ->update();
+
+        $this->table('users')
+            ->changeColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'length' => 11,
+                'null' => false,
+            ])
             ->update();
 
         $this->table('articles')

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -20,7 +20,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addPrimaryKey(['id'])
@@ -32,12 +32,12 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
             ])
             ->addColumn('note', 'string', [
@@ -47,7 +47,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
                 'signed' => false,
             ])
@@ -68,12 +68,12 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ])
             ->addIndex(
                 [
-                    'category_id',
+                    'product_id',
                 ]
             )
             ->addIndex(
                 [
-                    'product_id',
+                    'category_id',
                 ]
             )
             ->addIndex(
@@ -87,13 +87,13 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addPrimaryKey(['id'])
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
             ])
             ->addColumn('title', 'string', [
@@ -142,18 +142,18 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addPrimaryKey(['id'])
             ->addColumn('product_category', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addIndex(
@@ -168,7 +168,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addPrimaryKey(['id'])
@@ -179,7 +179,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ])
             ->addColumn('number', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => null,
                 'null' => true,
                 'signed' => false,
             ])
@@ -189,7 +189,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addPrimaryKey(['id'])
@@ -205,7 +205,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -261,23 +261,23 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addPrimaryKey(['id'])
             ->addColumn('article_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addColumn('author_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
             ])
             ->addColumn('tag_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addColumn('highlighted', 'boolean', [
@@ -315,7 +315,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addPrimaryKey(['id'])
@@ -343,21 +343,21 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                ]
-            )
-            ->addForeignKey(
                 'product_id',
                 'products',
                 'id',
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                ]
+            )
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION',
                 ]
             )
             ->update();
@@ -404,10 +404,10 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
     {
         $this->table('articles')
             ->dropForeignKey(
-                'category_id'
+                'product_id'
             )
             ->dropForeignKey(
-                'product_id'
+                'category_id'
             )->save();
 
         $this->table('orders')

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -23,12 +23,12 @@ class TestNotEmptySnapshot extends AbstractMigration
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
             ])
             ->addColumn('note', 'string', [
@@ -38,7 +38,7 @@ class TestNotEmptySnapshot extends AbstractMigration
             ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
                 'signed' => false,
             ])
@@ -59,12 +59,12 @@ class TestNotEmptySnapshot extends AbstractMigration
             ])
             ->addIndex(
                 [
-                    'category_id',
+                    'product_id',
                 ]
             )
             ->addIndex(
                 [
-                    'product_id',
+                    'category_id',
                 ]
             )
             ->addIndex(
@@ -77,7 +77,7 @@ class TestNotEmptySnapshot extends AbstractMigration
         $this->table('categories')
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
             ])
             ->addColumn('title', 'string', [
@@ -124,12 +124,12 @@ class TestNotEmptySnapshot extends AbstractMigration
         $this->table('orders')
             ->addColumn('product_category', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addIndex(
@@ -148,7 +148,7 @@ class TestNotEmptySnapshot extends AbstractMigration
             ])
             ->addColumn('number', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => null,
                 'null' => true,
                 'signed' => false,
             ])
@@ -167,7 +167,7 @@ class TestNotEmptySnapshot extends AbstractMigration
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
             ])
             ->addColumn('created', 'timestamp', [
@@ -221,17 +221,17 @@ class TestNotEmptySnapshot extends AbstractMigration
         $this->table('special_tags')
             ->addColumn('article_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addColumn('author_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
             ])
             ->addColumn('tag_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => false,
             ])
             ->addColumn('highlighted', 'boolean', [
@@ -290,21 +290,21 @@ class TestNotEmptySnapshot extends AbstractMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                ]
-            )
-            ->addForeignKey(
                 'product_id',
                 'products',
                 'id',
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                ]
+            )
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION',
                 ]
             )
             ->update();
@@ -351,10 +351,10 @@ class TestNotEmptySnapshot extends AbstractMigration
     {
         $this->table('articles')
             ->dropForeignKey(
-                'category_id'
+                'product_id'
             )
             ->dropForeignKey(
-                'product_id'
+                'category_id'
             )->save();
 
         $this->table('orders')

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -77,7 +77,7 @@ class TestPluginBlog extends AbstractMigration
         $this->table('categories')
             ->addColumn('parent_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
             ])
             ->addColumn('title', 'string', [

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -23,12 +23,12 @@ class TestPluginBlog extends AbstractMigration
             ])
             ->addColumn('category_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
             ])
             ->addColumn('product_id', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
             ])
             ->addColumn('note', 'string', [
@@ -38,7 +38,7 @@ class TestPluginBlog extends AbstractMigration
             ])
             ->addColumn('counter', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => null,
                 'null' => true,
                 'signed' => false,
             ])
@@ -59,52 +59,18 @@ class TestPluginBlog extends AbstractMigration
             ])
             ->addIndex(
                 [
-                    'category_id',
+                    'product_id',
                 ]
             )
             ->addIndex(
                 [
-                    'product_id',
+                    'category_id',
                 ]
             )
             ->addIndex(
                 [
                     'title',
                 ]
-            )
-            ->create();
-
-        $this->table('categories')
-            ->addColumn('parent_id', 'integer', [
-                'default' => null,
-                'limit' => 11,
-                'null' => true,
-            ])
-            ->addColumn('title', 'string', [
-                'default' => null,
-                'limit' => 255,
-                'null' => true,
-            ])
-            ->addColumn('slug', 'string', [
-                'default' => null,
-                'limit' => 100,
-                'null' => true,
-            ])
-            ->addColumn('created', 'timestamp', [
-                'default' => null,
-                'limit' => null,
-                'null' => true,
-            ])
-            ->addColumn('modified', 'timestamp', [
-                'default' => null,
-                'limit' => null,
-                'null' => true,
-            ])
-            ->addIndex(
-                [
-                    'slug',
-                ],
-                ['unique' => true]
             )
             ->create();
 
@@ -116,7 +82,7 @@ class TestPluginBlog extends AbstractMigration
             ])
             ->addColumn('number', 'integer', [
                 'default' => null,
-                'limit' => 10,
+                'limit' => null,
                 'null' => true,
                 'signed' => false,
             ])
@@ -124,21 +90,21 @@ class TestPluginBlog extends AbstractMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                ]
-            )
-            ->addForeignKey(
                 'product_id',
                 'products',
                 'id',
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                ]
+            )
+            ->addForeignKey(
+                'category_id',
+                'categories',
+                'id',
+                [
+                    'update' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION',
                 ]
             )
             ->update();
@@ -155,14 +121,13 @@ class TestPluginBlog extends AbstractMigration
     {
         $this->table('articles')
             ->dropForeignKey(
-                'category_id'
+                'product_id'
             )
             ->dropForeignKey(
-                'product_id'
+                'category_id'
             )->save();
 
         $this->table('articles')->drop()->save();
-        $this->table('categories')->drop()->save();
         $this->table('parts')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -74,6 +74,40 @@ class TestPluginBlog extends AbstractMigration
             )
             ->create();
 
+        $this->table('categories')
+            ->addColumn('parent_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'slug',
+                ],
+                ['unique' => true]
+            )
+            ->create();
+
         $this->table('parts')
             ->addColumn('name', 'string', [
                 'default' => null,
@@ -128,6 +162,7 @@ class TestPluginBlog extends AbstractMigration
             )->save();
 
         $this->table('articles')->drop()->save();
+        $this->table('categories')->drop()->save();
         $this->table('parts')->drop()->save();
     }
 }


### PR DESCRIPTION
The schema reflection changed in CakePHP to accomodate mysql8 not supporting lengths and lengths only being used for display in mysql5.6+.

Because the serialized snapshot data contains lengths all those values are updated in this diff.