### PR TITLE
Update deprecated default_database to default_environment

### DIFF
--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -110,7 +110,7 @@ trait ConfigurationTrait
             'migration_base_class' => 'Migrations\AbstractMigration',
             'environments' => [
                 'default_migration_table' => $phinxTable,
-                'default_database' => 'default',
+                'default_environment' => 'default',
                 'default' => [
                     'adapter' => $adapterName,
                     'host' => $connectionConfig['host'] ?? null,


### PR DESCRIPTION
`default_database` was deprecated and renamed to `default_environment` in the 0.12.0 release to better describe what it is that it actually does/mean.

Related upstream PR: https://github.com/cakephp/phinx/pull/1689