### PR TITLE
Allow also short forms lat/lng as they are commonly used.

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -264,7 +264,7 @@ an invalid value. Default field type is ``string``:
 
 * id: integer
 * created, modified, updated: datetime
-* latitude, longitude: decimal
+* latitude, longitude (or short forms lat, lng): decimal
 
 Creating a table
 ----------------

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -230,7 +230,7 @@ class ColumnParser
                 $fieldType = 'integer';
             } elseif (in_array($field, ['created', 'modified', 'updated'], true) || substr($field, -3) === '_at') {
                 $fieldType = 'datetime';
-            } elseif (in_array($field, ['latitude', 'longitude'], true)) {
+            } elseif (in_array($field, ['latitude', 'longitude', 'lat', 'lng'], true)) {
                 $fieldType = 'decimal';
             } else {
                 $fieldType = 'string';


### PR DESCRIPTION
Refs https://github.com/dereuromark/cakephp-geo/issues/55

I actually used float here usually. Is there any reason to favor decimal here? Since this isn't about this kind of precision as with money or alike.