### PR TITLE
3.x - Add support for MySQL and SQL Server PDO attributes via `flags` option.

### DIFF
--- a/tests/TestCase/ConfigurationTraitTest.php
+++ b/tests/TestCase/ConfigurationTraitTest.php
@@ -93,6 +93,10 @@ class ConfigurationTraitTest extends TestCase
                 'ssl_ca' => '/certs/my_cert',
                 'ssl_key' => 'ssl_key_value',
                 'ssl_cert' => 'ssl_cert_value',
+                'flags' => [
+                    \PDO::MYSQL_ATTR_SSL_CA => 'flags do not overwrite config',
+                    \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
+                ],
             ],
         ]);
 
@@ -122,6 +126,7 @@ class ConfigurationTraitTest extends TestCase
         $this->assertSame('/certs/my_cert', $environment['mysql_attr_ssl_ca']);
         $this->assertSame('ssl_key_value', $environment['mysql_attr_ssl_key']);
         $this->assertSame('ssl_cert_value', $environment['mysql_attr_ssl_cert']);
+        $this->assertFalse($environment['mysql_attr_ssl_verify_server_cert']);
     }
 
     /**


### PR DESCRIPTION
Phinx supports PDO attributes for MySQL and SQL Server via the `mysql_attr_*` and `sqlsrv_attr_*` options respectively. [**The docs state**](https://book.cakephp.org/phinx/0/en/configuration.html#supported-adapters) that non-driver-specific PDO attributes would be supported too, but looking at the different adapter's `connect()` methods, that doesn't actually seem to be the case.

For now this PR aims to introduce support to translate the supported attributes from the CakePHP datasource connection configuration's `flags` option into the special Phinx adapter options.

refs #374