### PR TITLE
Fix missing migration

### DIFF
--- a/src/CakeManager.php
+++ b/src/CakeManager.php
@@ -69,7 +69,7 @@ class CakeManager extends Manager
             $env = $this->getEnvironment($environment);
             $versions = $env->getVersionLog();
             $this->maxNameLength = $versions ? max(array_map(function ($version) {
-                return strlen($version['migration_name']);
+                return strlen((string)$version['migration_name']);
             }, $versions)) : 0;
 
             foreach ($this->getMigrations('default') as $migration) {

--- a/src/Command/Phinx/Status.php
+++ b/src/Command/Phinx/Status.php
@@ -109,7 +109,7 @@ class Status extends StatusCommand
             foreach ($migrations as $migration) {
                 $status = $migration['status'] === 'up' ? '     <info>up</info> ' : '   <error>down</error> ';
                 $maxNameLength = $this->getManager()->maxNameLength;
-                $name = $migration['name'] !== false ?
+                $name = $migration['name'] ?
                     ' <comment>' . str_pad($migration['name'], $maxNameLength, ' ') . ' </comment>' :
                     ' <error>** MISSING **</error>';
 


### PR DESCRIPTION
Missing migrations end up as null instead of false

  (int) 1 => [
    'missing' => true,
    'status' => 'up',
    'id' => '20150913000236',
    'name' => null
  ],

Might be a recent change
Either way, any empty value should suffice as check to avoid

    Exception: str_pad() expects parameter 1 to be string, null given

errors