### PR TITLE
Fix up CS to avoid having to exclude Migrations.

### DIFF
--- a/templates/bake/config/diff.twig
+++ b/templates/bake/config/diff.twig
@@ -26,6 +26,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class {{ name }} extends AbstractMigration
 {
 {% if not autoId %}

--- a/templates/bake/config/skeleton.twig
+++ b/templates/bake/config/skeleton.twig
@@ -22,6 +22,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class {{ name }} extends AbstractMigration
 {
 {% if tableMethod == 'create' and columns['primaryKey'] %}

--- a/templates/bake/config/snapshot.twig
+++ b/templates/bake/config/snapshot.twig
@@ -25,6 +25,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class {{ name }} extends AbstractMigration
 {
 {% if not autoId  %}

--- a/tests/TestCase/Command/Phinx/CreateTest.php
+++ b/tests/TestCase/Command/Phinx/CreateTest.php
@@ -101,7 +101,6 @@ class CreateTest extends TestCase
         $files = glob(ROOT . DS . 'config' . DS . 'Create' . DS . '*_TestCreate*.php');
         $this->generatedFiles = $files;
         $this->assertNotEmpty($files);
-
         $file = current($files);
         $this->assertSameAsFile('TestCreate.php', file_get_contents($file));
     }

--- a/tests/comparisons/Diff/addremove/the_diff_add_remove_mysql.php
+++ b/tests/comparisons/Diff/addremove/the_diff_add_remove_mysql.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TheDiffAddRemoveMysql extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Diff/addremove/the_diff_add_remove_pgsql.php
+++ b/tests/comparisons/Diff/addremove/the_diff_add_remove_pgsql.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TheDiffAddRemovePgsql extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TheDiffSimpleMysql extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Diff/simple/the_diff_simple_pgsql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_pgsql.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TheDiffSimplePgsql extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Diff/the_diff.php
+++ b/tests/comparisons/Diff/the_diff.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TheDiff extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Diff/the_diff_mysql.php
+++ b/tests/comparisons/Diff/the_diff_mysql.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TheDiffMysql extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Diff/the_diff_pgsql.php
+++ b/tests/comparisons/Diff/the_diff_pgsql.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TheDiffPgsql extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
 {
     public $autoId = false;

--- a/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TestNotEmptySnapshotPgsql extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TestPluginBlogPgsql extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
 {
     public $autoId = false;

--- a/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TestNotEmptySnapshotSqlite extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TestPluginBlogSqlite extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Migration/testCreate.php
+++ b/tests/comparisons/Migration/testCreate.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class CreateUsers extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Migration/testCreateDatetime.php
+++ b/tests/comparisons/Migration/testCreateDatetime.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class CreateUsers extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Migration/testCreateFieldLength.php
+++ b/tests/comparisons/Migration/testCreateFieldLength.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class CreateUsers extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Migration/testCreatePrimaryKey.php
+++ b/tests/comparisons/Migration/testCreatePrimaryKey.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class CreateUsers extends AbstractMigration
 {
     public $autoId = false;

--- a/tests/comparisons/Migration/testCreatePrimaryKeyUuid.php
+++ b/tests/comparisons/Migration/testCreatePrimaryKeyUuid.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class CreateUsers extends AbstractMigration
 {
     public $autoId = false;

--- a/tests/comparisons/Migration/testNoContents.php
+++ b/tests/comparisons/Migration/testNoContents.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class NoContents extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TestAutoIdDisabledSnapshot extends AbstractMigration
 {
     public $autoId = false;

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot56.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TestAutoIdDisabledSnapshot56 extends AbstractMigration
 {
     public $autoId = false;

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TestNotEmptySnapshot extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Migration/test_not_empty_snapshot56.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot56.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TestNotEmptySnapshot56 extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TestPluginBlog extends AbstractMigration
 {
     /**

--- a/tests/comparisons/Migration/test_plugin_blog56.php
+++ b/tests/comparisons/Migration/test_plugin_blog56.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class TestPluginBlog56 extends AbstractMigration
 {
     /**

--- a/tests/test_app/config/Migrations/20150416223600_mark_migrated_test.php
+++ b/tests/test_app/config/Migrations/20150416223600_mark_migrated_test.php
@@ -2,6 +2,8 @@
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class MarkMigratedTest extends AbstractMigration
 {
     public function up()

--- a/tests/test_app/config/MigrationsDiff/20151218183450_CreateArticles.php
+++ b/tests/test_app/config/MigrationsDiff/20151218183450_CreateArticles.php
@@ -2,6 +2,8 @@
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class CreateArticles extends AbstractMigration
 {
     public function change()

--- a/tests/test_app/config/MigrationsDiff/20160128183623_AlterArticles.php
+++ b/tests/test_app/config/MigrationsDiff/20160128183623_AlterArticles.php
@@ -2,6 +2,8 @@
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class AlterArticles extends AbstractMigration
 {
     /**

--- a/tests/test_app/config/MigrationsDiff/20160128183652_AlterArticlesSlug.php
+++ b/tests/test_app/config/MigrationsDiff/20160128183652_AlterArticlesSlug.php
@@ -2,6 +2,8 @@
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class AlterArticlesSlug extends AbstractMigration
 {
     /**

--- a/tests/test_app/config/MigrationsDiff/20160128183952_CreateUsers.php
+++ b/tests/test_app/config/MigrationsDiff/20160128183952_CreateUsers.php
@@ -2,6 +2,8 @@
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class CreateUsers extends AbstractMigration
 {
     /**

--- a/tests/test_app/config/MigrationsDiff/20160128184109_AlterArticlesFk.php
+++ b/tests/test_app/config/MigrationsDiff/20160128184109_AlterArticlesFk.php
@@ -2,6 +2,8 @@
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class AlterArticlesFk extends AbstractMigration
 {
     /**

--- a/tests/test_app/config/MigrationsDiff/20160414193900_CreateTags.php
+++ b/tests/test_app/config/MigrationsDiff/20160414193900_CreateTags.php
@@ -2,6 +2,8 @@
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class CreateTags extends AbstractMigration
 {
     /**

--- a/tests/test_app/config/MigrationsDiffAddRemove/20151218183450_CreateArticlesAddRemove.php
+++ b/tests/test_app/config/MigrationsDiffAddRemove/20151218183450_CreateArticlesAddRemove.php
@@ -2,6 +2,8 @@
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class CreateArticlesAddRemove extends AbstractMigration
 {
     public function change()

--- a/tests/test_app/config/MigrationsDiffSimple/20151218183450_CreateArticlesSimple.php
+++ b/tests/test_app/config/MigrationsDiffSimple/20151218183450_CreateArticlesSimple.php
@@ -2,6 +2,8 @@
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class CreateArticlesSimple extends AbstractMigration
 {
     public function change()

--- a/tests/test_app/config/MigrationsDiffSimple/20160128183623_AlterArticlesSimple.php
+++ b/tests/test_app/config/MigrationsDiffSimple/20160128183623_AlterArticlesSimple.php
@@ -2,6 +2,8 @@
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class AlterArticlesSimple extends AbstractMigration
 {
     /**

--- a/tests/test_app/config/TestsMigrations/20150704160200_create_numbers_table.php
+++ b/tests/test_app/config/TestsMigrations/20150704160200_create_numbers_table.php
@@ -2,6 +2,8 @@
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class CreateNumbersTable extends AbstractMigration
 {
     public function change()

--- a/tests/test_app/config/TestsMigrations/20150724233100_update_numbers_table.php
+++ b/tests/test_app/config/TestsMigrations/20150724233100_update_numbers_table.php
@@ -2,6 +2,8 @@
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class UpdateNumbersTable extends AbstractMigration
 {
     public function up()

--- a/tests/test_app/config/TestsMigrations/20150826191400_create_letters_table.php
+++ b/tests/test_app/config/TestsMigrations/20150826191400_create_letters_table.php
@@ -2,6 +2,8 @@
 
 use Migrations\AbstractMigration;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+// phpcs:disable PSR2R.Classes.ClassFileName.NoMatch
 class CreateLettersTable extends AbstractMigration
 {
     public $autoId = false;


### PR DESCRIPTION
In every project and plugin I have to skip /config/Migrations due to the CS issues.
`--ignore=/tests/test_files/,/config/Migrations/`

As long as we don't have the namespace and class name issue solved, we should add those above to avoid the overhead in config.
Now we can properly CS those as well.

Refs  https://github.com/cakephp/migrations/issues/475