### PR TITLE
Include cake3 branch name to composer require

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can install this plugin into your CakePHP application using [Composer](http:
 
 Run the following command
 ```sh
-composer require cakephp/migrations
+composer require cakephp/migrations:dev-cake3
  ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can install this plugin into your CakePHP application using [Composer](http:
 
 Run the following command
 ```sh
-composer require cakephp/migrations:dev-cake3
+composer require cakephp/migrations:2.x
  ```
 
 ## Configuration


### PR DESCRIPTION
Not specifying the branch name will revert to the default one, which is now for CakePHP 4. 

Command source: https://stackoverflow.com/questions/33525885/composer-require-branch-name/33526908#33526908