### PR TITLE
Remove connection aliasing from Migrator

### DIFF
--- a/src/TestSuite/Migrator.php
+++ b/src/TestSuite/Migrator.php
@@ -17,7 +17,6 @@ use Cake\Console\ConsoleIo;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\SchemaCleaner;
 use Cake\TestSuite\Fixture\SchemaLoader;
-use Cake\TestSuite\TestConnectionManager;
 use Migrations\Migrations;
 
 class Migrator extends SchemaLoader
@@ -39,10 +38,6 @@ class Migrator extends SchemaLoader
         if (isset($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
             return $migrator;
         }
-
-        // Ensures that the connections are aliased, in case
-        // the migrations invoke the table registry.
-        TestConnectionManager::aliasConnections();
 
         $configReader = new ConfigReader();
         $configReader->readMigrationsInDatasources();


### PR DESCRIPTION
This should be setup by including the `PHPUnitExtension` extension.

If a migration is referencing a test connection, it should be already be configured in the bootstrap.