### PR TITLE
Override phinx hasConfig method

### DIFF
--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -61,6 +61,18 @@ trait ConfigurationTrait
 
         return $this->input;
     }
+    
+    /**
+     * Overrides the original method from phinx to just always return true to
+     * avoid calling loadConfig method which will throw an exception as we rely on
+     * the overridden getConfig method.
+     *
+     * @return bool
+     */
+    public function hasConfig(): bool
+    {
+        return true;
+    }
 
     /**
      * Overrides the original method from phinx in order to return a tailored


### PR DESCRIPTION
As discussed in other channels, this adds a new `hasConfig` phinx override here to avoid calling `AbstractCommand::loadConfig` method which is causing new exceptions to be thrown in the test suite.

This is to be merged on-top of #517