### PR TITLE
Add `skip` option to Migrator::run()

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -869,6 +869,15 @@ If you need to run multiple sets of migrations, those can be run as follows::
         ['plugin' => 'Documents', 'connection' => 'test_docs']
     ]);
 
+If your database also contains tables that are not managed by your application
+like those created by PostGIS, then you can exclude those tables from the drop
+& truncate behavior using the ``skip`` option::
+
+    $migrator->run(['connection' => 'test', 'skip' => 'postgis*']);
+
+The ``skip`` option accepts a ``fnmatch()`` compatible pattern to exclude tables
+from drop & truncate operations.
+
 If you need to see additional debugging output from migrations are being run,
 you can enable a ``debug`` level logger.
 

--- a/tests/TestCase/TestSuite/MigratorTest.php
+++ b/tests/TestCase/TestSuite/MigratorTest.php
@@ -67,6 +67,25 @@ class MigratorTest extends TestCase
         $this->assertCount(1, $connection->query('SELECT * FROM migrator')->fetchAll());
     }
 
+    public function testMigrateSkipTables(): void
+    {
+        $connection = ConnectionManager::get('test');
+
+        // Create a table
+        $connection->execute('CREATE TABLE skipme (name TEXT)');
+
+        // Insert a record so that we can ensure the table was skipped.
+        $connection->execute('INSERT INTO skipme (name) VALUES (:name)', ['name' => 'Ron']);
+
+        $migrator = new Migrator();
+        $migrator->run(['plugin' => 'Migrator', 'skip' => ['skip*']]);
+
+        $tables = $connection->getSchemaCollection()->listTables();
+        $this->assertContains('migrator', $tables);
+        $this->assertContains('skipme', $tables);
+        $this->assertCount(1, $connection->query('SELECT * FROM skipme')->fetchAll());
+    }
+
     public function testRunManyDropTruncate(): void
     {
         $migrator = new Migrator();


### PR DESCRIPTION
This option can be used to partially skip dropping and truncating
a subset of tables. This gives more fine grained control than trying
to exclude views from the list of tables.

Fixes #526