### PR TITLE
Improve help text for migration commands.

### DIFF
--- a/src/Command/BakeMigrationCommand.php
+++ b/src/Command/BakeMigrationCommand.php
@@ -174,12 +174,7 @@ All sections other than name are optional.
   key with `unique` or a primary key with `primary`
 TEXT;
 
-        $parser
-            ->setDescription($text)
-            ->addArgument('name', [
-                'help' => 'Name of the migration to bake. Can use Plugin.name to bake migration files into plugins.',
-                'required' => true,
-            ]);
+        $parser->setDescription($text);
 
         return $parser;
     }

--- a/src/Command/BakeMigrationCommand.php
+++ b/src/Command/BakeMigrationCommand.php
@@ -17,6 +17,7 @@ namespace Migrations\Command;
 
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
@@ -117,11 +118,78 @@ class BakeMigrationCommand extends BakeSimpleMigrationCommand
     }
 
     /**
+     * Gets the option parser instance and configures it.
+     *
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function getOptionParser(): ConsoleOptionParser
+    {
+        $parser = parent::getOptionParser();
+        $text = <<<'TEXT'
+Create a blank or generated migration. Using the name of the migration 
+Operations and table names will be inferred.
+
+<info>Examples</info>
+
+<warning>bin/cake bake migration CreateUsers</warning>
+
+This command will generate a migration that creates
+a table named users.
+
+<warning>bin/cake bake migration DropGroups</warning>
+This command will generate a migration that drops
+the groups table.
+
+<warning>bin/cake bake migration AlterUsers</warning>
+This command will generate a migration that alters the users table.
+
+<warning>bin/cake bake migration AddFieldToUsers role:string</warning>
+This command will generate a migration that adds a 'role' field
+with a 'string' type to the users table. Migrations that operate
+on columns can use the <info>Column Grammar</info> to describe
+the column in detail.
+
+<warning>bin/cake bake migration AlterFieldOnUsers role avatar_img</warning>
+These commands will generate a migration that will alter the listed fields
+on the users table.
+
+<warning>bin/cake bake migration RemoveFieldsFromUsers role avatar_img</warning>
+<warning>bin/cake bake migration RemoveRoleFromUsers</warning>
+These commands will generate a migration that will remove the listed fields
+on the users table.
+
+<info>Column Grammar</info>
+
+When describing columns you can use the following syntax:
+
+<warning>{name}:{primary}{type}{nullable}[{length}]:{index}</warning>
+
+All sections other than name are optional.
+
+* The types are the abstract database column types in CakePHP.
+* The <warning>?</warning> value indicates if a column is nullable.
+  e.x. `role:string?`
+* Length option must be enclosed in `[]` e.x. `name:string[100]`
+* The `index` attribute can define the column as having a unique
+  key with `unique` or a primary key with `primary`
+TEXT;
+
+        $parser
+            ->setDescription($text)
+            ->addArgument('name', [
+                'help' => 'Name of the migration to bake. Can use Plugin.name to bake migration files into plugins.',
+                'required' => true,
+            ]);
+
+        return $parser;
+    }
+
+    /**
      * Detects the action and table from the name of a migration
      *
      * @param string $name Name of migration
      * @return array
-     **/
+     */
     public function detectAction($name)
     {
         if (preg_match('/^(Create|Drop)(.*)/', $name, $matches)) {

--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -574,7 +574,11 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
     {
         $parser = parent::getOptionParser();
 
-        $parser->addArgument('name', [
+        $parser->setDescription(
+            'Create a migration that captures the difference between ' .
+            'the migration state is expected to be and what the schema ' .
+            'reflection contains.'
+        )->addArgument('name', [
             'help' => 'Name of the migration to bake. Can use Plugin.name to bake migration files into plugins.',
             'required' => true,
         ]);

--- a/src/Command/BakeMigrationSnapshotCommand.php
+++ b/src/Command/BakeMigrationSnapshotCommand.php
@@ -147,7 +147,10 @@ class BakeMigrationSnapshotCommand extends BakeSimpleMigrationCommand
         $parser = parent::getOptionParser();
 
         $parser->setDescription(
-            'Bake migration snapshot class.'
+            "Bake migration snapshot class\n" .
+            "\n" .
+            'Migration snapshots capture the current schema of an application into a ' .
+            'migration that will reproduce the current state as accurately as possible.'
         )->addArgument('name', [
             'help' => 'Name of the migration to bake. Can use Plugin.name to bake migration files into plugins.',
             'required' => true,


### PR DESCRIPTION
I think this is all useful context to have available in the CLI context. The column grammar being in the CLI is especially useful as its close to where you'll be working and having to switch context to a browser for help is less ideal than having it all in your scrollback.