### PR TITLE
Remove single quotes from default value if present

### DIFF
--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -477,6 +477,10 @@ class MigrationHelper extends Helper
                 continue;
             }
 
+            if ($option === 'default' && is_string($value)) {
+                $value = trim($value, "'");
+            }
+
             $attributes[$option] = $value;
         }
 


### PR DESCRIPTION
Fixes #552. The double quotes are coming from Schema inspector so maybe it may be causing issues somewhere else. However the fix was applied into MigrationHelper and if a similar fix is applied directly to schema it should not affect this one.
