### PR TITLE
Map Date/Time types to string to avoid issues importing seeds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: '7.2'
         extensions: mbstring, intl
         coverage: none
         tools: cs2pr

--- a/src/Command/BakeSeedCommand.php
+++ b/src/Command/BakeSeedCommand.php
@@ -20,6 +20,8 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
+use Cake\Database\Type\StringType;
+use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Inflector;
 
@@ -41,6 +43,22 @@ class BakeSeedCommand extends SimpleBakeCommand
      * @var string
      */
     protected $_name;
+
+    /**
+     * @inheritDoc
+     */
+    public function initialize(): void
+    {
+        parent::initialize();
+        // Mapping date/time types to String to avoid creating seeds
+        // with FrozenDate/FrozenTime objects. refs #558
+        TypeFactory::map('datetime', StringType::class);
+        TypeFactory::map('date', StringType::class);
+        TypeFactory::map('datetimefractional', StringType::class);
+        TypeFactory::map('timestamp', StringType::class);
+        TypeFactory::map('timestampfractional', StringType::class);
+        TypeFactory::map('timestamptimezone', StringType::class);
+    }
 
     /**
      * @inheritDoc
@@ -134,6 +152,7 @@ class BakeSeedCommand extends SimpleBakeCommand
 
             /** @var array $records */
             $records = $query->toArray();
+
             $records = $this->prettifyArray($records);
         }
 

--- a/src/Command/BakeSeedCommand.php
+++ b/src/Command/BakeSeedCommand.php
@@ -20,8 +20,6 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
-use Cake\Database\Type\StringType;
-use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Inflector;
 
@@ -43,22 +41,6 @@ class BakeSeedCommand extends SimpleBakeCommand
      * @var string
      */
     protected $_name;
-
-    /**
-     * @inheritDoc
-     */
-    public function initialize(): void
-    {
-        parent::initialize();
-        // Mapping date/time types to String to avoid creating seeds
-        // with FrozenDate/FrozenTime objects. refs #558
-        TypeFactory::map('datetime', StringType::class);
-        TypeFactory::map('date', StringType::class);
-        TypeFactory::map('datetimefractional', StringType::class);
-        TypeFactory::map('timestamp', StringType::class);
-        TypeFactory::map('timestampfractional', StringType::class);
-        TypeFactory::map('timestamptimezone', StringType::class);
-    }
 
     /**
      * @inheritDoc
@@ -90,7 +72,7 @@ class BakeSeedCommand extends SimpleBakeCommand
     public function getPath(Arguments $args): string
     {
         $path = ROOT . DS . $this->pathFragment;
-        if (isset($this->plugin)) {
+        if ($this->plugin) {
             $path = $this->_pluginPath($this->plugin) . $this->pathFragment;
         }
 
@@ -151,7 +133,7 @@ class BakeSeedCommand extends SimpleBakeCommand
             }
 
             /** @var array $records */
-            $records = $query->toArray();
+            $records = $query->disableResultsCasting()->toArray();
 
             $records = $this->prettifyArray($records);
         }

--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -66,7 +66,7 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
     public function getPath(Arguments $args): string
     {
         $path = ROOT . DS . $this->pathFragment;
-        if (isset($this->plugin)) {
+        if ($this->plugin) {
             $path = $this->_pluginPath($this->plugin) . $this->pathFragment;
         }
 

--- a/tests/TestCase/Command/BakeSeedCommandTest.php
+++ b/tests/TestCase/Command/BakeSeedCommandTest.php
@@ -80,6 +80,8 @@ class BakeSeedCommandTest extends TestCase
         $path = __FUNCTION__ . '.php';
         if (getenv('DB') === 'pgsql') {
             $path = getenv('DB') . DS . $path;
+        } elseif (PHP_VERSION_ID >= 80100) {
+            $path = 'php81' . DS . $path;
         }
 
         $this->assertExitCode(BaseCommand::CODE_SUCCESS);
@@ -115,6 +117,8 @@ class BakeSeedCommandTest extends TestCase
         $path = __FUNCTION__ . '.php';
         if (getenv('DB') === 'pgsql') {
             $path = getenv('DB') . DS . $path;
+        } elseif (PHP_VERSION_ID >= 80100) {
+            $path = 'php81' . DS . $path;
         }
 
         $this->assertExitCode(BaseCommand::CODE_SUCCESS);

--- a/tests/comparisons/Seeds/php81/testWithData.php
+++ b/tests/comparisons/Seeds/php81/testWithData.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractSeed;
+
+/**
+ * Events seed.
+ */
+class EventsSeed extends AbstractSeed
+{
+    /**
+     * Run Method.
+     *
+     * Write your database seeder using this method.
+     *
+     * More information on writing seeds is available here:
+     * https://book.cakephp.org/phinx/0/en/seeding.html
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $data = [
+            [
+                'id' => 1,
+                'title' => 'Lorem ipsum dolor sit amet',
+                'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat.',
+                'published' => 'Y',
+            ],
+            [
+                'id' => 2,
+                'title' => 'Second event',
+                'description' => 'Second event description.',
+                'published' => 'Y',
+            ],
+            [
+                'id' => 3,
+                'title' => 'Lorem ipsum dolor sit amet',
+                'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat.
+Convallis morbi fringilla gravida, phasellus feugiat dapibus velit nunc, pulvinar eget \'sollicitudin\' venenatis cum
+nullam, vivamus ut a sed, mollitia lectus.
+Nulla vestibulum massa neque ut et, id hendrerit sit, feugiat in taciti enim proin nibh, tempor dignissim, rhoncus
+duis vestibulum nunc mattis convallis.',
+                'published' => 'Y',
+            ],
+        ];
+
+        $table = $this->table('events');
+        $table->insert($data)->save();
+    }
+}

--- a/tests/comparisons/Seeds/php81/testWithDataAndLimit.php
+++ b/tests/comparisons/Seeds/php81/testWithDataAndLimit.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractSeed;
+
+/**
+ * Events seed.
+ */
+class EventsSeed extends AbstractSeed
+{
+    /**
+     * Run Method.
+     *
+     * Write your database seeder using this method.
+     *
+     * More information on writing seeds is available here:
+     * https://book.cakephp.org/phinx/0/en/seeding.html
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $data = [
+            [
+                'id' => 1,
+                'title' => 'Lorem ipsum dolor sit amet',
+                'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat.',
+                'published' => 'Y',
+            ],
+            [
+                'id' => 2,
+                'title' => 'Second event',
+                'description' => 'Second event description.',
+                'published' => 'Y',
+            ],
+        ];
+
+        $table = $this->table('events');
+        $table->insert($data)->save();
+    }
+}

--- a/tests/comparisons/Seeds/testWithData.php
+++ b/tests/comparisons/Seeds/testWithData.php
@@ -22,19 +22,19 @@ class EventsSeed extends AbstractSeed
     {
         $data = [
             [
-                'id' => 1,
+                'id' => '1',
                 'title' => 'Lorem ipsum dolor sit amet',
                 'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat.',
                 'published' => 'Y',
             ],
             [
-                'id' => 2,
+                'id' => '2',
                 'title' => 'Second event',
                 'description' => 'Second event description.',
                 'published' => 'Y',
             ],
             [
-                'id' => 3,
+                'id' => '3',
                 'title' => 'Lorem ipsum dolor sit amet',
                 'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat.
 Convallis morbi fringilla gravida, phasellus feugiat dapibus velit nunc, pulvinar eget \'sollicitudin\' venenatis cum

--- a/tests/comparisons/Seeds/testWithDataAndLimit.php
+++ b/tests/comparisons/Seeds/testWithDataAndLimit.php
@@ -22,13 +22,13 @@ class EventsSeed extends AbstractSeed
     {
         $data = [
             [
-                'id' => 1,
+                'id' => '1',
                 'title' => 'Lorem ipsum dolor sit amet',
                 'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat.',
                 'published' => 'Y',
             ],
             [
-                'id' => 2,
+                'id' => '2',
                 'title' => 'Second event',
                 'description' => 'Second event description.',
                 'published' => 'Y',


### PR DESCRIPTION
I think the easier way to fix #558 is mapping date/time types to string so the data is generated as it comes from db. Please let me know if you see any issue with this approach.

I will work on fixing unit tests / adding new ones if needed so I will keep the pull request as draft until then.

Thank you
