### PR TITLE
cake5 - Re-enable connection pdo injection

### DIFF
--- a/src/CakeAdapter.php
+++ b/src/CakeAdapter.php
@@ -20,6 +20,7 @@ use InvalidArgumentException;
 use PDO;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Adapter\AdapterWrapper;
+use ReflectionProperty;
 
 /**
  * Decorates an AdapterInterface in order to proxy some method to the actual
@@ -61,6 +62,10 @@ class CakeAdapter extends AdapterWrapper
             $schema = empty($config['schema']) ? 'public' : $config['schema'];
             $pdo->exec('SET search_path TO ' . $schema);
         }
+
+        $driver = $connection->getDriver();
+        $prop = new ReflectionProperty($driver, 'pdo');
+        $prop->setValue($driver, $pdo);
     }
 
     /**

--- a/tests/TestCase/Command/Phinx/CreateTest.php
+++ b/tests/TestCase/Command/Phinx/CreateTest.php
@@ -9,12 +9,14 @@ use Cake\TestSuite\StringCompareTrait;
 use Cake\TestSuite\TestCase;
 use Migrations\CakeManager;
 use Migrations\MigrationsDispatcher;
+use Migrations\Test\TestCase\DriverConnectionTrait;
 use Phinx\Db\Adapter\WrapperInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\StreamOutput;
 
 class CreateTest extends TestCase
 {
+    use DriverConnectionTrait;
     use StringCompareTrait;
 
     /**
@@ -127,7 +129,7 @@ class CreateTest extends TestCase
         while ($adapter instanceof WrapperInterface) {
             $adapter = $adapter->getAdapter();
         }
-        //$adapter->setConnection($this->connection->getDriver()->getConnection());
+        $adapter->setConnection($this->getDriverConnection($this->connection->getDriver()));
         $this->command->setManager($manager);
         $commandTester = new \Migrations\Test\CommandTester($this->command);
 

--- a/tests/TestCase/Command/Phinx/MarkMigratedTest.php
+++ b/tests/TestCase/Command/Phinx/MarkMigratedTest.php
@@ -17,6 +17,8 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Migrations\CakeManager;
 use Migrations\MigrationsDispatcher;
+use Migrations\Test\TestCase\DriverConnectionTrait;
+use PDO;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -26,6 +28,8 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class MarkMigratedTest extends TestCase
 {
+    use DriverConnectionTrait;
+
     /**
      * Instance of a Symfony Command object
      *
@@ -48,6 +52,11 @@ class MarkMigratedTest extends TestCase
     protected $commandTester;
 
     /**
+     * @var \PDO|null
+     */
+    protected ?PDO $pdo = null;
+
+    /**
      * setup method
      *
      * @return void
@@ -57,6 +66,9 @@ class MarkMigratedTest extends TestCase
         parent::setUp();
 
         $this->connection = ConnectionManager::get('test');
+        $this->connection->getDriver()->connect();
+        $this->pdo = $this->getDriverConnection($this->connection->getDriver());
+
         $this->connection->execute('DROP TABLE IF EXISTS phinxlog');
         $this->connection->execute('DROP TABLE IF EXISTS numbers');
 

--- a/tests/TestCase/DriverConnectionTrait.php
+++ b/tests/TestCase/DriverConnectionTrait.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Migrations\Test\TestCase;
+
+use Cake\Database\Driver;
+use PDO;
+use ReflectionProperty;
+
+trait DriverConnectionTrait
+{
+    protected function getDriverConnection(Driver $driver): PDO
+    {
+        $prop = new ReflectionProperty($driver, 'pdo');
+
+        return $prop->getValue($driver);
+    }
+
+    protected function setDriverConnection(Driver $driver, PDO $connection): void
+    {
+        $prop = new ReflectionProperty($driver, 'pdo');
+        $prop->setValue($driver, $connection);
+    }
+}


### PR DESCRIPTION
This brings back the connection injection, making things behave just like in the current 3.x branch.