### PR TITLE
3.x - Fix decimal diff baking.

### DIFF
--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -83,8 +83,6 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
         if (empty($name)) {
             $io->err('You must provide a name to bake a ' . $this->name());
             $this->abort();
-
-            return null;
         }
         $name = $this->_getName($name);
         $name = Inflector::camelize($name);

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -382,20 +382,26 @@ class MigrationHelper extends Helper
         if (isset($columnOptions['signed']) && $columnOptions['signed'] === true) {
             unset($columnOptions['signed']);
         }
-        if (($options['type'] ?? null) === 'decimal') {
-            // due to Phinx using different naming for the precision and scale to CakePHP
-            $columnOptions['scale'] = $columnOptions['precision'];
-
-            if (isset($columnOptions['limit'])) {
-                $columnOptions['precision'] = $columnOptions['limit'];
-                unset($columnOptions['limit']);
-            }
-            if (isset($columnOptions['length'])) {
-                $columnOptions['precision'] = $columnOptions['length'];
-                unset($columnOptions['length']);
-            }
-        } else {
+        if (array_key_exists('precision', $columnOptions) && $columnOptions['precision'] === null) {
             unset($columnOptions['precision']);
+        } else {
+            // due to Phinx using different naming for the precision and scale to CakePHP
+            $type = $options['type'] ?? null;
+
+            if ($type === 'decimal') {
+                $columnOptions['scale'] = $columnOptions['precision'];
+            }
+
+            if (in_array($type, ['decimal', 'time', 'timestamp'], true)) {
+                if (isset($columnOptions['limit'])) {
+                    $columnOptions['precision'] = $columnOptions['limit'];
+                    unset($columnOptions['limit']);
+                }
+                if (isset($columnOptions['length'])) {
+                    $columnOptions['precision'] = $columnOptions['length'];
+                    unset($columnOptions['length']);
+                }
+            }
         }
 
         return $columnOptions;

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -382,9 +382,7 @@ class MigrationHelper extends Helper
         if (isset($columnOptions['signed']) && $columnOptions['signed'] === true) {
             unset($columnOptions['signed']);
         }
-        if ($columnOptions['precision'] === null) {
-            unset($columnOptions['precision']);
-        } else {
+        if (($options['type'] ?? null) === 'decimal') {
             // due to Phinx using different naming for the precision and scale to CakePHP
             $columnOptions['scale'] = $columnOptions['precision'];
 
@@ -396,6 +394,8 @@ class MigrationHelper extends Helper
                 $columnOptions['precision'] = $columnOptions['length'];
                 unset($columnOptions['length']);
             }
+        } else {
+            unset($columnOptions['precision']);
         }
 
         return $columnOptions;

--- a/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
@@ -103,7 +103,7 @@ class BakeMigrationDiffCommandTest extends TestCase
      */
     public function testBakingDiff()
     {
-        $this->skipIf(env('DB_URL_COMPARE') !== false);
+        $this->skipIf(getenv('DB_URL_COMPARE') === false);
 
         $diffConfigFolder = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Diff' . DS;
         $diffMigrationsPath = $diffConfigFolder . 'the_diff_' . env('DB') . '.php';
@@ -180,7 +180,7 @@ class BakeMigrationDiffCommandTest extends TestCase
      */
     public function testBakingDiffSimple()
     {
-        $this->skipIf(env('DB_URL_COMPARE') !== false);
+        $this->skipIf(getenv('DB_URL_COMPARE') === false);
 
         $diffConfigFolder = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Diff' . DS . 'simple' . DS;
         $diffMigrationsPath = $diffConfigFolder . 'the_diff_simple_' . env('DB') . '.php';
@@ -244,7 +244,7 @@ class BakeMigrationDiffCommandTest extends TestCase
      */
     public function testBakingDiffAddRemove()
     {
-        $this->skipIf(env('DB_URL_COMPARE') !== false);
+        $this->skipIf(getenv('DB_URL_COMPARE') === false);
 
         $diffConfigFolder = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Diff' . DS . 'addremove' . DS;
         $diffMigrationsPath = $diffConfigFolder . 'the_diff_add_remove_' . env('DB') . '.php';

--- a/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
@@ -60,14 +60,12 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addColumn('modified', 'timestamp', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addIndex(
                 [
@@ -109,14 +107,12 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addColumn('modified', 'timestamp', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addIndex(
                 [
@@ -239,14 +235,12 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addColumn('modified', 'timestamp', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addIndex(
                 [
@@ -320,7 +314,6 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addIndex(
                 [
@@ -366,14 +359,12 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addColumn('updated', 'timestamp', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->create();
 

--- a/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
@@ -51,14 +51,12 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addColumn('modified', 'timestamp', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addIndex(
                 [
@@ -93,14 +91,12 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addColumn('modified', 'timestamp', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addIndex(
                 [
@@ -194,14 +190,12 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addColumn('modified', 'timestamp', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addIndex(
                 [
@@ -267,7 +261,6 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addIndex(
                 [
@@ -306,14 +299,12 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addColumn('updated', 'timestamp', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->create();
 

--- a/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
@@ -51,14 +51,12 @@ class TestPluginBlogPgsql extends AbstractMigration
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addColumn('modified', 'timestamp', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addIndex(
                 [
@@ -93,14 +91,12 @@ class TestPluginBlogPgsql extends AbstractMigration
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addColumn('modified', 'timestamp', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
-                'scale' => 6,
             ])
             ->addIndex(
                 [


### PR DESCRIPTION
Apparently the tests stopped running at some point because of an incorrect skip condition, so the problem got unnoticed.

Somewhere along the way the `precision` option stopped being "always" available. I am _assuming_ that this is actually the expected behavior, but I can't tell for sure, so I'd appreciate if someone could confirm or deny!