### PR TITLE
Fix phpunit deprecation warnings

### DIFF
--- a/tests/TestCase/ConfigurationTraitTest.php
+++ b/tests/TestCase/ConfigurationTraitTest.php
@@ -170,16 +170,6 @@ class ConfigurationTraitTest extends TestCase
         $input = $this->getMockBuilder(InputInterface::class)->getMock();
         $this->command->setInput($input);
 
-        $input->expects($this->at(1))
-            ->method('getOption')
-            ->with('plugin')
-            ->will($this->returnValue('MyPlugin'));
-
-        $input->expects($this->at(4))
-            ->method('getOption')
-            ->with('plugin')
-            ->will($this->returnValue('MyPlugin'));
-
         $config = $this->command->getConfig();
         $this->assertInstanceOf('Phinx\Config\Config', $config);
 


### PR DESCRIPTION
I don't think we need to check the methods called in order here.