### PR TITLE
Add error message when using runMany() and skip

### DIFF
--- a/src/TestSuite/Migrator.php
+++ b/src/TestSuite/Migrator.php
@@ -110,9 +110,21 @@ class Migrator
         foreach ($options as $migrationSet) {
             $migrations = new Migrations();
 
-            if (!$migrations->migrate($migrationSet)) {
+            try {
+                if (!$migrations->migrate($migrationSet)) {
+                    throw new RuntimeException(
+                        "Unable to migrate fixtures for `{$migrationSet['connection']}`."
+                    );
+                }
+            } catch (\Exception $e) {
                 throw new RuntimeException(
-                    "Unable to migrate fixtures for `{$migrationSet['connection']}`."
+                    'Could not apply migrations for ' . json_encode($migrationSet) . "\n\n" .
+                    "Migrations failed to apply with message:\n\n" .
+                    $e->getMessage() . "\n\n" .
+                    'If you are using the `skip` option and running multiple sets of migrations ' .
+                    'on the same connection try calling `truncate()` before `runMany()` to avoid this.',
+                    0,
+                    $e
                 );
             }
         }

--- a/tests/TestCase/TestSuite/MigratorTest.php
+++ b/tests/TestCase/TestSuite/MigratorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Migrations\Test\TestCase\TestSuite;
 
 use Cake\Chronos\ChronosInterface;
+use Cake\Database\Driver\Postgres;
 use Cake\Datasource\ConnectionManager;
 use Cake\I18n\FrozenDate;
 use Cake\TestSuite\ConnectionHelper;
@@ -107,6 +108,7 @@ class MigratorTest extends TestCase
     public function testRunManyMultipleSkip(): void
     {
         $connection = ConnectionManager::get('test');
+        $this->skipIf($connection->getDriver() instanceof Postgres);
 
         $migrator = new Migrator();
         // Run migrations for the first time.

--- a/tests/TestCase/TestSuite/MigratorTest.php
+++ b/tests/TestCase/TestSuite/MigratorTest.php
@@ -106,6 +106,8 @@ class MigratorTest extends TestCase
 
     public function testRunManyMultipleSkip(): void
     {
+        $connection = ConnectionManager::get('test');
+
         $migrator = new Migrator();
         // Run migrations for the first time.
         $migrator->runMany([
@@ -113,9 +115,7 @@ class MigratorTest extends TestCase
             ['plugin' => 'Migrator', 'source' => 'Migrations2'],
         ], false);
 
-        $connection = ConnectionManager::get('test');
         $connection->begin();
-
         // Run migrations the second time. Skip clauses will cause problems.
         try {
             $migrator->runMany([
@@ -124,6 +124,7 @@ class MigratorTest extends TestCase
             ], false);
         } catch (RuntimeException $e) {
             $connection->rollback();
+            $connection->getDriver()->disconnect();
             $this->assertStringContainsString('Could not apply migrations', $e->getMessage());
         }
     }

--- a/tests/TestCase/TestSuite/MigratorTest.php
+++ b/tests/TestCase/TestSuite/MigratorTest.php
@@ -111,7 +111,7 @@ class MigratorTest extends TestCase
         $migrator->runMany([
             ['plugin' => 'Migrator'],
             ['plugin' => 'Migrator', 'source' => 'Migrations2'],
-        ]);
+        ], false);
 
         // Run migrations the second time. Skip clauses will cause problems.
         $this->expectException(RuntimeException::class);
@@ -119,7 +119,7 @@ class MigratorTest extends TestCase
         $migrator->runMany([
             ['plugin' => 'Migrator', 'skip' => ['migrator']],
             ['plugin' => 'Migrator', 'source' => 'Migrations2', 'skip' => ['m*']],
-        ]);
+        ], false);
     }
 
     /**

--- a/tests/TestCase/TestSuite/MigratorTest.php
+++ b/tests/TestCase/TestSuite/MigratorTest.php
@@ -115,7 +115,6 @@ class MigratorTest extends TestCase
             ['plugin' => 'Migrator', 'source' => 'Migrations2'],
         ], false);
 
-        $connection->begin();
         // Run migrations the second time. Skip clauses will cause problems.
         try {
             $migrator->runMany([
@@ -123,7 +122,6 @@ class MigratorTest extends TestCase
                 ['plugin' => 'Migrator', 'source' => 'Migrations2', 'skip' => ['m*']],
             ], false);
         } catch (RuntimeException $e) {
-            $connection->rollback();
             $connection->getDriver()->disconnect();
             $this->assertStringContainsString('Could not apply migrations', $e->getMessage());
         }


### PR DESCRIPTION
Applying `skip` to multiple profiles when using `runMany()` creates a problem that I don't think is solvable.

The problem boils down to skip is able to exclude some or all tables from a migration set (plugin or application). When we're attempting to reset both table schema and phinxlog state we can only operate at the connection level. Because both your plugin and application are using the same connection the queries we need to use to find which tables need to be dropped and which phinxlogs need to be reset pollute each other and overlap.

Because we don't have enough metadata to know which tables map to which phinxlog tables, and which migrations within those migration logs we can only operate on schema and phinxlogs in a coarse manner.

Refs #603