### PR TITLE
Dont allow historic app table to trip up

### DIFF
--- a/src/TableFinderTrait.php
+++ b/src/TableFinderTrait.php
@@ -156,6 +156,10 @@ trait TableFinderTrait
     {
         $tables = [];
         $className = str_replace('Table.php', '', $className);
+        if (!$className) {
+            return $tables;
+        }
+
         if ($pluginName !== null) {
             $className = $pluginName . '.' . $className;
         }


### PR DESCRIPTION
Caused by
```
error: [Cake\Core\Exception\CakeException] You must specify either the `alias` or the `table` option for the constructor. in /shared/httpd/sandbox/vendor/cakephp/cakephp/src/ORM/Table.php on line 393
Stack Trace:
- /shared/httpd/sandbox/vendor/cakephp/migrations/src/TableFinderTrait.php:188
- /shared/httpd/sandbox/vendor/cakephp/migrations/src/TableFinderTrait.php:116
- /shared/httpd/sandbox/vendor/cakephp/migrations/src/TableFinderTrait.php:63
```
and having a Table.php there that the other tables inherit from (app table).

By design, an empty table (empty string) cannot work, so bail early here then.

This fixes it as BC solution. Since we cannot just make it abstract now, given that there are already released versions of those plugins for many years.