### PR TITLE
#464 Fix error strpos if $lastfile is null

### DIFF
--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -451,7 +451,7 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             $lastVersion = $this->migratedItems[0]['version'];
             $lastFile = end($this->migrationsFiles);
 
-            return (bool)strpos($lastFile, (string)$lastVersion);
+            return $lastFile && (bool)strpos($lastFile, (string)$lastVersion);
         }
 
         return false;


### PR DESCRIPTION
This fix is to resolve an error on a strpos fonction when $lastfile value is null. (it appears when the migrations files are deleted, but not the migrations in the database)