### PR TITLE
Patch constraintnames

### DIFF
--- a/templates/bake/element/add-foreign-keys.twig
+++ b/templates/bake/element/add-foreign-keys.twig
@@ -1,6 +1,6 @@
 {% set statement = Migration.tableStatement(table, true) %}
 {% set hasProcessedConstraint = false %}
-{% for constraint in constraints %}
+{% for constraintName, constraint in constraints[table] %}
 {%     set constraintColumns = constraint['columns']|sort %}
 {%     if constraint['type'] != 'unique' %}
 {%         set hasProcessedConstraint = true %}
@@ -29,6 +29,7 @@
                 [
                     'update' => '{{ Migration.formatConstraintAction(constraint['update']) | raw }}',
                     'delete' => '{{ Migration.formatConstraintAction(constraint['delete']) | raw }}',
+                    'constraint' => '{{ constraintName }}'
                 ]
             )
 {%     endif %}

--- a/templates/bake/element/create-tables.twig
+++ b/templates/bake/element/create-tables.twig
@@ -62,8 +62,8 @@
 {% if createData.constraints %}
 {%   for table, tableConstraints in createData.constraints %}
 {{-     element('Migrations.add-foreign-keys', {
-         constraints: tableConstraints,
-         table: table
+         constraints: createData.constraints,
+         table: table,
        })
 -}}
 {%   endfor -%}

--- a/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_auto_id_disabled_snapshot_pgsql.php
@@ -385,6 +385,7 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
+                    'constraint' => 'category_article_idx'
                 ]
             )
             ->update();
@@ -403,6 +404,7 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                    'constraint' => 'product_id_fk'
                 ]
             )
             ->update();
@@ -415,6 +417,7 @@ class TestAutoIdDisabledSnapshotPgsql extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                    'constraint' => 'category_idx'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_not_empty_snapshot_pgsql.php
@@ -325,6 +325,7 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
+                    'constraint' => 'category_article_idx'
                 ]
             )
             ->update();
@@ -343,6 +344,7 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                    'constraint' => 'product_id_fk'
                 ]
             )
             ->update();
@@ -355,6 +357,7 @@ class TestNotEmptySnapshotPgsql extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                    'constraint' => 'category_idx'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_plugin_blog_pgsql.php
@@ -131,6 +131,7 @@ class TestPluginBlogPgsql extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
+                    'constraint' => 'category_article_idx'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_auto_id_disabled_snapshot_sqlite.php
@@ -368,6 +368,7 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
+                    'constraint' => 'category_id_fk'
                 ]
             )
             ->update();
@@ -386,6 +387,7 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                    'constraint' => 'product_category_fk'
                 ]
             )
             ->update();
@@ -398,6 +400,7 @@ class TestAutoIdDisabledSnapshotSqlite extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                    'constraint' => 'category_id_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_not_empty_snapshot_sqlite.php
@@ -308,6 +308,7 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
+                    'constraint' => 'category_id_fk'
                 ]
             )
             ->update();
@@ -326,6 +327,7 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                    'constraint' => 'product_category_fk'
                 ]
             )
             ->update();
@@ -338,6 +340,7 @@ class TestNotEmptySnapshotSqlite extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                    'constraint' => 'category_id_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_plugin_blog_sqlite.php
@@ -124,6 +124,7 @@ class TestPluginBlogSqlite extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
+                    'constraint' => 'category_id_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -369,7 +369,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
-                    'constraint' => 'category_id_fk'
+                    'constraint' => 'category_article_idx'
                 ]
             )
             ->update();
@@ -388,7 +388,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'product_category_fk'
+                    'constraint' => 'product_id_fk'
                 ]
             )
             ->update();
@@ -401,7 +401,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'category_id_fk'
+                    'constraint' => 'category_idx'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
+++ b/tests/comparisons/Migration/test_auto_id_disabled_snapshot.php
@@ -369,6 +369,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
+                    'constraint' => 'category_id_fk'
                 ]
             )
             ->update();
@@ -387,6 +388,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                    'constraint' => 'product_category_fk'
                 ]
             )
             ->update();
@@ -399,6 +401,7 @@ class TestAutoIdDisabledSnapshot extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                    'constraint' => 'category_id_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -308,7 +308,8 @@ class TestNotEmptySnapshot extends AbstractMigration
                 'id',
                 [
                     'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
+                    'delete' => 'NO_ACTION',                    
+                    'constraint' => 'category_id_fk'
                 ]
             )
             ->update();
@@ -327,6 +328,7 @@ class TestNotEmptySnapshot extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                    'constraint' => 'product_category_fk'
                 ]
             )
             ->update();
@@ -339,6 +341,7 @@ class TestNotEmptySnapshot extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                    'constraint' => 'category_id_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/test_not_empty_snapshot.php
+++ b/tests/comparisons/Migration/test_not_empty_snapshot.php
@@ -308,8 +308,8 @@ class TestNotEmptySnapshot extends AbstractMigration
                 'id',
                 [
                     'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',                    
-                    'constraint' => 'category_id_fk'
+                    'delete' => 'NO_ACTION',
+                    'constraint' => 'category_article_idx'
                 ]
             )
             ->update();
@@ -328,7 +328,7 @@ class TestNotEmptySnapshot extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'product_category_fk'
+                    'constraint' => 'product_id_fk'
                 ]
             )
             ->update();
@@ -341,7 +341,7 @@ class TestNotEmptySnapshot extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'category_id_fk'
+                    'constraint' => 'category_idx'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -125,7 +125,7 @@ class TestPluginBlog extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
-                    'constraint' => 'category_id_fk'
+                    'constraint' => 'category_article_idx'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/test_plugin_blog.php
+++ b/tests/comparisons/Migration/test_plugin_blog.php
@@ -125,6 +125,7 @@ class TestPluginBlog extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
+                    'constraint' => 'category_id_fk'
                 ]
             )
             ->update();


### PR DESCRIPTION
Fixes #614 

When baking migration_diff/snapshot, the names defined in the constraints are used in the migration file now.

Sorry, but this is my first pull request ever. Please tell me if I'm doing anything wrong, so I can try to do it better ;)