### PR TITLE
bake migration_diff now supports --source for multiple database configs

### DIFF
--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -473,20 +473,7 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
         $newArgs = [];
         $newArgs[] = $name;
 
-        if ($args->getOption('connection')) {
-            $newArgs[] = '-c';
-            $newArgs[] = $args->getOption('connection');
-        }
-
-        if ($args->getOption('plugin')) {
-            $newArgs[] = '-p';
-            $newArgs[] = $args->getOption('plugin');
-        }
-
-        if ($args->getOption('source')) {
-            $newArgs[] = '-s';
-            $newArgs[] = $args->getOption('source');
-        }
+        $newArgs = array_merge($newArgs, $this->parseOptions($args));
 
         $exitCode = $this->executeCommand(BakeMigrationSnapshotCommand::class, $newArgs, $io);
 

--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -483,6 +483,11 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             $newArgs[] = $args->getOption('plugin');
         }
 
+        if ($args->getOption('source')) {
+            $newArgs[] = '-s';
+            $newArgs[] = $args->getOption('source');
+        }
+
         $exitCode = $this->executeCommand(BakeMigrationSnapshotCommand::class, $newArgs, $io);
 
         if ($exitCode === 1) {

--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -191,7 +191,7 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
         ])->addOption('source', [
             'short' => 's',
             'default' => 'Migrations',
-            'help' => 'Name of the folder in which the migration should be saved',
+            'help' => 'Name of the folder in which the migration should be saved.',
         ]);
 
         return $parser;

--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -191,7 +191,7 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
         ])->addOption('source', [
             'short' => 's',
             'default' => 'Migrations',
-            'help' => 'Name of the Folder in which the migration should be saved',
+            'help' => 'Name of the folder in which the migration should be saved',
         ]);
 
         return $parser;

--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -40,7 +40,7 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
      *
      * @var string
      */
-    public $pathFragment = 'config/Migrations/';
+    public $pathFragment = 'config';
 
     /**
      * @inheritDoc
@@ -65,9 +65,9 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
      */
     public function getPath(Arguments $args): string
     {
-        $path = ROOT . DS . $this->pathFragment;
+        $path = ROOT . DS . $this->pathFragment . DS . $args->getOption('source') . DS;
         if ($this->plugin) {
-            $path = $this->_pluginPath($this->plugin) . $this->pathFragment;
+            $path = $this->_pluginPath($this->plugin) . $this->pathFragment . DS . $args->getOption('source') . DS;
         }
 
         return str_replace('/', DS, $path);
@@ -188,6 +188,10 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
             'short' => 'f',
             'boolean' => true,
             'help' => 'Force overwriting existing file if a migration already exists with the same name.',
+        ])->addOption('source', [
+            'short' => 's',
+            'default' => 'Migrations',
+            'help' => 'Name of the Folder in which the migration should be saved',
         ]);
 
         return $parser;

--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -67,9 +67,10 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
      */
     public function getPath(Arguments $args): string
     {
-        $path = ROOT . DS . $this->pathFragment . DS . $args->getOption('source') . DS;
+        $migrationFolder = $this->pathFragment . DS . $args->getOption('source') . DS;
+        $path = ROOT . DS . $migrationFolder;
         if ($this->plugin) {
-            $path = $this->_pluginPath($this->plugin) . $this->pathFragment . DS . $args->getOption('source') . DS;
+            $path = $this->_pluginPath($this->plugin) . $migrationFolder;
         }
 
         return str_replace('/', DS, $path);

--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -42,6 +42,8 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
      */
     public $pathFragment = 'config';
 
+    public const DEFAULT_MIGRATION_FOLDER = 'Migrations';
+
     /**
      * @inheritDoc
      */
@@ -190,7 +192,7 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
             'help' => 'Force overwriting existing file if a migration already exists with the same name.',
         ])->addOption('source', [
             'short' => 's',
-            'default' => 'Migrations',
+            'default' => self::DEFAULT_MIGRATION_FOLDER,
             'help' => 'Name of the folder in which the migration should be saved.',
         ]);
 

--- a/src/Command/SnapshotTrait.php
+++ b/src/Command/SnapshotTrait.php
@@ -81,14 +81,14 @@ trait SnapshotTrait
         $this->executeCommand(MigrationsDumpCommand::class, $newArgs, $io);
     }
 
-
     /**
      * Will parse 'connection', 'plugin' and 'source' options into a new Array
      *
-     * @param Arguments $args The command arguments.
+     * @param \Cake\Console\Arguments $args The command arguments.
      * @return array Array containing the short for the option followed by its value
      */
-    protected function parseOptions(Arguments $args): array {
+    protected function parseOptions(Arguments $args): array
+    {
         $newArgs = [];
         if ($args->getOption('connection')) {
             $newArgs[] = '-c';

--- a/src/Command/SnapshotTrait.php
+++ b/src/Command/SnapshotTrait.php
@@ -59,20 +59,7 @@ trait SnapshotTrait
         $newArgs[] = $version;
         $newArgs[] = '-o';
 
-        if ($args->getOption('connection')) {
-            $newArgs[] = '-c';
-            $newArgs[] = $args->getOption('connection');
-        }
-
-        if ($args->getOption('plugin')) {
-            $newArgs[] = '-p';
-            $newArgs[] = $args->getOption('plugin');
-        }
-
-        if ($args->getOption('source')) {
-            $newArgs[] = '-s';
-            $newArgs[] = $args->getOption('source');
-        }
+        $newArgs = array_merge($newArgs, $this->parseOptions($args));
 
         $io->out('Marking the migration ' . $fileName . ' as migrated...');
         $this->executeCommand(MigrationsMarkMigratedCommand::class, $newArgs, $io);
@@ -88,8 +75,21 @@ trait SnapshotTrait
      */
     protected function refreshDump(Arguments $args, ConsoleIo $io)
     {
-        $newArgs = [];
+        $newArgs = $this->parseOptions($args);
 
+        $io->out('Creating a dump of the new database state...');
+        $this->executeCommand(MigrationsDumpCommand::class, $newArgs, $io);
+    }
+
+
+    /**
+     * Will parse 'connection', 'plugin' and 'source' options into a new Array
+     *
+     * @param Arguments $args The command arguments.
+     * @return array Array containing the short for the option followed by its value
+     */
+    protected function parseOptions(Arguments $args): array {
+        $newArgs = [];
         if ($args->getOption('connection')) {
             $newArgs[] = '-c';
             $newArgs[] = $args->getOption('connection');
@@ -105,7 +105,6 @@ trait SnapshotTrait
             $newArgs[] = $args->getOption('source');
         }
 
-        $io->out('Creating a dump of the new database state...');
-        $this->executeCommand(MigrationsDumpCommand::class, $newArgs, $io);
+        return $newArgs;
     }
 }

--- a/src/Command/SnapshotTrait.php
+++ b/src/Command/SnapshotTrait.php
@@ -69,6 +69,11 @@ trait SnapshotTrait
             $newArgs[] = $args->getOption('plugin');
         }
 
+        if ($args->getOption('source')) {
+            $newArgs[] = '-s';
+            $newArgs[] = $args->getOption('source');
+        }
+
         $io->out('Marking the migration ' . $fileName . ' as migrated...');
         $this->executeCommand(MigrationsMarkMigratedCommand::class, $newArgs, $io);
     }
@@ -93,6 +98,11 @@ trait SnapshotTrait
         if ($args->getOption('plugin')) {
             $newArgs[] = '-p';
             $newArgs[] = $args->getOption('plugin');
+        }
+
+        if ($args->getOption('source')) {
+            $newArgs[] = '-s';
+            $newArgs[] = $args->getOption('source');
         }
 
         $io->out('Creating a dump of the new database state...');

--- a/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
@@ -109,7 +109,7 @@ class BakeMigrationDiffCommandTest extends TestCase
         $path = ROOT . DS . 'config' . DS . $customFolderName . DS;
         $this->generatedFiles = glob($path . '*_MigrationDiffForCustomFolder.php');
 
-        $this->assertEquals(1, count($this->generatedFiles));
+        $this->assertCount(1, $this->generatedFiles);
         $this->assertFileExists($path . 'schema-dump-test.lock', 'Cannot test contents, file does not exist.');
         $this->generatedFiles[] = $path . 'schema-dump-test.lock';
 

--- a/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
@@ -97,6 +97,28 @@ class BakeMigrationDiffCommandTest extends TestCase
     }
 
     /**
+     * Tests baking a diff in a custom folder source
+     *
+     * @return void
+     */
+    public function testBakeMigrationDiffInCustomFolder()
+    {
+        $customFolderName = 'CustomMigrationsFolder';
+        $this->exec('bake migration_diff MigrationDiffForCustomFolder -c test -s ' . $customFolderName);
+
+        $path = ROOT . DS . 'config' . DS . $customFolderName . DS;
+        $this->generatedFiles = glob($path . '*_MigrationDiffForCustomFolder.php');
+
+        $this->assertEquals(1, count($this->generatedFiles));
+        $this->assertFileExists($path . 'schema-dump-test.lock', 'Cannot test contents, file does not exist.');
+        $this->generatedFiles[] = $path . 'schema-dump-test.lock';
+
+        $fileName = pathinfo($this->generatedFiles[0], PATHINFO_FILENAME);
+        $this->assertOutputContains('Marking the migration ' . $fileName . ' as migrated...');
+        $this->assertOutputContains('Creating a dump of the new database state...');
+    }
+
+    /**
      * Tests baking a diff
      *
      * @return void


### PR DESCRIPTION
Implemented a souce option for bake migration_diff. migration_diff now supports multiple target folders for the generated migration.

This is especially what was requested in issue #608 and it also bothered our company.

This has now been built on top of the 3.x branch (because we need it theres) but should probably be merged to 4.x as well.

We added tests for the option and also executed CS before opening the PR, both are running without errors. 

We appreciate your feedback if there is more to change to be compliant with the contribution guidelines.