### PR TITLE
overwrite `addTimestamps()` to set created and modified column names as default

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -227,4 +227,15 @@ class Table extends BaseTable
 
         $this->getTable()->setOptions($options);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function addTimestamps($createdAt = '', $updatedAt = '', bool $withTimezone = false)
+    {
+        $createdAt = $createdAt ?: 'created';
+        $updatedAt = $updatedAt ?: 'modified';
+
+        return parent::addTimestamps($createdAt, $updatedAt, $withTimezone);
+    }
 }

--- a/tests/TestCase/Command/Phinx/MarkMigratedTest.php
+++ b/tests/TestCase/Command/Phinx/MarkMigratedTest.php
@@ -140,7 +140,7 @@ class MarkMigratedTest extends TestCase
         );
 
         $result = $this->connection->selectQuery()->select(['COUNT(*)'])->from('phinxlog')->execute();
-        $this->assertSame(3, $result->fetchColumn(0));
+        $this->assertSame(4, $result->fetchColumn(0));
 
         $config = $this->command->getConfig();
         $env = $this->command->getManager()->getEnvironment('default');

--- a/tests/TestCase/Command/Phinx/StatusTest.php
+++ b/tests/TestCase/Command/Phinx/StatusTest.php
@@ -134,7 +134,7 @@ class StatusTest extends TestCase
         $commandTester->execute(['command' => $this->command->getName()] + $params);
         $display = $this->getDisplayFromOutput();
 
-        $expected = '[{"status":"down","id":20150704160200,"name":"CreateNumbersTable"},{"status":"down","id":20150724233100,"name":"UpdateNumbersTable"},{"status":"down","id":20150826191400,"name":"CreateLettersTable"}]';
+        $expected = '[{"status":"down","id":20150704160200,"name":"CreateNumbersTable"},{"status":"down","id":20150724233100,"name":"UpdateNumbersTable"},{"status":"down","id":20150826191400,"name":"CreateLettersTable"},{"status":"down","id":20230628181900,"name":"CreateStoresTable"}]';
 
         $this->assertTextContains($expected, $display);
     }

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -139,6 +139,11 @@ class MigrationsTest extends TestCase
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
             ],
+            [
+                'status' => 'down',
+                'id' => '20230628181900',
+                'name' => 'CreateStoresTable',
+            ],
         ];
         $this->assertEquals($expected, $result);
 
@@ -178,6 +183,11 @@ class MigrationsTest extends TestCase
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
             ],
+            [
+                'status' => 'up',
+                'id' => '20230628181900',
+                'name' => 'CreateStoresTable',
+            ],
         ];
         $this->assertEquals($expectedStatus, $status);
 
@@ -197,10 +207,17 @@ class MigrationsTest extends TestCase
         $primaryKey = $lettersTable->getSchema()->getPrimaryKey();
         $this->assertEquals($primaryKey, ['id']);
 
+        $storesTable = $this->getTableLocator()->get('Stores', ['connection' => $this->Connection]);
+        $columns = $storesTable->getSchema()->columns();
+        $expected = ['id', 'name', 'created', 'modified'];
+        $this->assertEquals($expected, $columns);
+        $createdColumn = $storesTable->getSchema()->getColumn('created');
+        $this->assertEquals('CURRENT_TIMESTAMP', $createdColumn['default']);
+
         // Rollback last
         $rollback = $this->migrations->rollback();
         $this->assertTrue($rollback);
-        $expectedStatus[2]['status'] = 'down';
+        $expectedStatus[3]['status'] = 'down';
         $status = $this->migrations->status();
         $this->assertEquals($expectedStatus, $status);
 
@@ -208,7 +225,7 @@ class MigrationsTest extends TestCase
         $this->migrations->migrate();
         $rollback = $this->migrations->rollback(['target' => 'all']);
         $this->assertTrue($rollback);
-        $expectedStatus[0]['status'] = $expectedStatus[1]['status'] = 'down';
+        $expectedStatus[0]['status'] = $expectedStatus[1]['status'] = $expectedStatus[2]['status'] = 'down';
         $status = $this->migrations->status();
         $this->assertEquals($expectedStatus, $status);
     }
@@ -265,6 +282,11 @@ class MigrationsTest extends TestCase
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
             ],
+            [
+                'status' => 'up',
+                'id' => '20230628181900',
+                'name' => 'CreateStoresTable',
+            ],
         ];
         $this->assertEquals($expected, $status);
     }
@@ -297,6 +319,11 @@ class MigrationsTest extends TestCase
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
             ],
+            [
+                'status' => 'up',
+                'id' => '20230628181900',
+                'name' => 'CreateStoresTable',
+            ],
         ];
         $this->assertEquals($expected, $status);
     }
@@ -327,6 +354,11 @@ class MigrationsTest extends TestCase
                 'status' => 'down',
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
+            ],
+            [
+                'status' => 'down',
+                'id' => 20230628181900,
+                'name' => 'CreateStoresTable',
             ],
         ];
         $this->assertEquals($expected, $status);
@@ -378,6 +410,11 @@ class MigrationsTest extends TestCase
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
             ],
+            [
+                'status' => 'down',
+                'id' => '20230628181900',
+                'name' => 'CreateStoresTable',
+            ],
         ];
         $this->assertEquals($expected, $status);
 
@@ -414,6 +451,11 @@ class MigrationsTest extends TestCase
                 'status' => 'down',
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
+            ],
+            [
+                'status' => 'down',
+                'id' => '20230628181900',
+                'name' => 'CreateStoresTable',
             ],
         ];
         $this->assertEquals($expected, $status);
@@ -465,6 +507,11 @@ class MigrationsTest extends TestCase
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
             ],
+            [
+                'status' => 'down',
+                'id' => '20230628181900',
+                'name' => 'CreateStoresTable',
+            ],
         ];
         $this->assertEquals($expected, $status);
 
@@ -499,6 +546,11 @@ class MigrationsTest extends TestCase
                 'status' => 'down',
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
+            ],
+            [
+                'status' => 'down',
+                'id' => '20230628181900',
+                'name' => 'CreateStoresTable',
             ],
         ];
         $this->assertEquals($expectedStatus, $result);
@@ -559,6 +611,11 @@ class MigrationsTest extends TestCase
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
             ],
+            [
+                'status' => 'down',
+                'id' => '20230628181900',
+                'name' => 'CreateStoresTable',
+            ],
         ];
         $this->assertEquals($expectedStatus, $this->migrations->status());
 
@@ -580,6 +637,11 @@ class MigrationsTest extends TestCase
                 'status' => 'down',
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
+            ],
+            [
+                'status' => 'down',
+                'id' => '20230628181900',
+                'name' => 'CreateStoresTable',
             ],
         ];
         $this->assertEquals($expectedStatus, $this->migrations->status());
@@ -603,6 +665,11 @@ class MigrationsTest extends TestCase
                 'status' => 'down',
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
+            ],
+            [
+                'status' => 'down',
+                'id' => '20230628181900',
+                'name' => 'CreateStoresTable',
             ],
         ];
         $this->assertEquals($expectedStatus, $this->migrations->status());
@@ -628,6 +695,11 @@ class MigrationsTest extends TestCase
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
             ],
+            [
+                'status' => 'down',
+                'id' => '20230628181900',
+                'name' => 'CreateStoresTable',
+            ],
         ];
         $this->assertEquals($expectedStatus, $this->migrations->status());
 
@@ -649,6 +721,11 @@ class MigrationsTest extends TestCase
                 'status' => 'down',
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
+            ],
+            [
+                'status' => 'down',
+                'id' => '20230628181900',
+                'name' => 'CreateStoresTable',
             ],
         ];
         $this->assertEquals($expectedStatus, $this->migrations->status());
@@ -674,6 +751,11 @@ class MigrationsTest extends TestCase
                 'status' => 'down',
                 'id' => '20150826191400',
                 'name' => 'CreateLettersTable',
+            ],
+            [
+                'status' => 'down',
+                'id' => '20230628181900',
+                'name' => 'CreateStoresTable',
             ],
         ];
         $this->assertEquals($expectedStatus, $this->migrations->status());

--- a/tests/test_app/config/TestsMigrations/20230628181900_create_stores_table.php
+++ b/tests/test_app/config/TestsMigrations/20230628181900_create_stores_table.php
@@ -1,0 +1,15 @@
+<?php
+
+use Migrations\AbstractMigration;
+
+class CreateStoresTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('stores', ['collation' => 'utf8_bin']);
+        $table
+            ->addColumn('name', 'string')
+            ->addTimestamps()
+            ->create();
+    }
+}


### PR DESCRIPTION
It's quite annoying, that the `->addTimestamps()` method from phinx doesn't use `created` and `modified` as default column names.

https://github.com/cakephp/phinx/blob/0.x/src/Phinx/Db/Table.php#L535C49-L536

Therefore this PR overwrites this method and sets the "correct" column names so that CakePHP's TimestampBehavior behaves as expected.