### PR TITLE
4.x - Make diff tests run again

### DIFF
--- a/templates/bake/config/diff.twig
+++ b/templates/bake/config/diff.twig
@@ -158,7 +158,7 @@ not empty %}
         }) |  raw -}}
 {%  endif -%}
 {%  for tableName, tableDiff in data -%}
-{%  Migration.resetTableStatementGenerationFor(tableName) %}
+{%  do Migration.resetTableStatementGenerationFor(tableName) %}
 {%      if tableDiff['indexes']['add'] is not empty %}
 
         $this->table('{{ tableName }}')

--- a/templates/bake/element/add-foreign-keys.twig
+++ b/templates/bake/element/add-foreign-keys.twig
@@ -1,6 +1,6 @@
 {% set statement = Migration.tableStatement(table, true) %}
 {% set hasProcessedConstraint = false %}
-{% for constraintName, constraint in constraints[table] %}
+{% for constraintName, constraint in constraints %}
 {%     set constraintColumns = constraint['columns']|sort %}
 {%     if constraint['type'] != 'unique' %}
 {%         set hasProcessedConstraint = true %}

--- a/templates/bake/element/create-tables.twig
+++ b/templates/bake/element/create-tables.twig
@@ -66,7 +66,7 @@
 {% if createData.constraints %}
 {%   for table, tableConstraints in createData.constraints %}
 {{-     element('Migrations.add-foreign-keys', {
-         constraints: createData.constraints,
+         constraints: tableConstraints,
          table: table,
        })
 -}}

--- a/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
@@ -103,7 +103,7 @@ class BakeMigrationDiffCommandTest extends TestCase
      */
     public function testBakingDiff()
     {
-        $this->skipIf(env('DB_URL_COMPARE') !== false);
+        $this->skipIf(!env('DB_URL_COMPARE'));
 
         $diffConfigFolder = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Diff' . DS;
         $diffMigrationsPath = $diffConfigFolder . 'the_diff_' . env('DB') . '.php';
@@ -125,8 +125,9 @@ class BakeMigrationDiffCommandTest extends TestCase
         unlink($destination);
         copy($diffDumpPath, $destinationDumpPath);
 
+        /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('test_comparisons');
-        $connection->newQuery()
+        $connection->deleteQuery()
             ->delete('phinxlog')
             ->where(['version' => 20160415220805])
             ->execute();
@@ -137,7 +138,7 @@ class BakeMigrationDiffCommandTest extends TestCase
             'length' => 255,
         ]);
         foreach ($table->createSql($connection) as $stmt) {
-            $connection->query($stmt);
+            $connection->execute($stmt);
         }
 
         $this->_compareBasePath = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Diff' . DS;
@@ -155,7 +156,7 @@ class BakeMigrationDiffCommandTest extends TestCase
         rename($destinationConfigDir . $generatedMigration, $destination);
         $versionParts = explode('_', $generatedMigration);
 
-        $connection->newQuery()
+        $connection->insertQuery()
             ->insert(['version', 'migration_name', 'start_time', 'end_time'])
             ->into('phinxlog')
             ->values([
@@ -165,10 +166,11 @@ class BakeMigrationDiffCommandTest extends TestCase
                 'end_time' => '2016-05-22 16:51:46',
             ])
             ->execute();
+
         $this->getMigrations()->rollback(['target' => 'all']);
 
         foreach ($table->dropSql($connection) as $stmt) {
-            $connection->query($stmt);
+            $connection->execute($stmt);
         }
     }
 
@@ -180,7 +182,7 @@ class BakeMigrationDiffCommandTest extends TestCase
      */
     public function testBakingDiffSimple()
     {
-        $this->skipIf(env('DB_URL_COMPARE') !== false);
+        $this->skipIf(!env('DB_URL_COMPARE'));
 
         $diffConfigFolder = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Diff' . DS . 'simple' . DS;
         $diffMigrationsPath = $diffConfigFolder . 'the_diff_simple_' . env('DB') . '.php';
@@ -201,8 +203,9 @@ class BakeMigrationDiffCommandTest extends TestCase
         unlink($destination);
         copy($diffDumpPath, $destinationDumpPath);
 
+        /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('test_comparisons');
-        $connection->newQuery()
+        $connection->deleteQuery()
             ->delete('phinxlog')
             ->where(['version' => 20160415220805])
             ->execute();
@@ -223,7 +226,7 @@ class BakeMigrationDiffCommandTest extends TestCase
         rename($destinationConfigDir . $generatedMigration, $destination);
         $versionParts = explode('_', $generatedMigration);
 
-        $connection->newQuery()
+        $connection->insertQuery()
             ->insert(['version', 'migration_name', 'start_time', 'end_time'])
             ->into('phinxlog')
             ->values([
@@ -244,7 +247,7 @@ class BakeMigrationDiffCommandTest extends TestCase
      */
     public function testBakingDiffAddRemove()
     {
-        $this->skipIf(env('DB_URL_COMPARE') !== false);
+        $this->skipIf(!env('DB_URL_COMPARE'));
 
         $diffConfigFolder = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Diff' . DS . 'addremove' . DS;
         $diffMigrationsPath = $diffConfigFolder . 'the_diff_add_remove_' . env('DB') . '.php';
@@ -265,8 +268,9 @@ class BakeMigrationDiffCommandTest extends TestCase
         unlink($destination);
         copy($diffDumpPath, $destinationDumpPath);
 
+        /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('test_comparisons');
-        $connection->newQuery()
+        $connection->deleteQuery()
             ->delete('phinxlog')
             ->where(['version' => 20160415220805])
             ->execute();
@@ -288,7 +292,7 @@ class BakeMigrationDiffCommandTest extends TestCase
         rename($destinationConfigDir . $generatedMigration, $destination);
         $versionParts = explode('_', $generatedMigration);
 
-        $connection->newQuery()
+        $connection->insertQuery()
             ->insert(['version', 'migration_name', 'start_time', 'end_time'])
             ->into('phinxlog')
             ->values([

--- a/tests/comparisons/Diff/addremove/the_diff_add_remove_mysql.php
+++ b/tests/comparisons/Diff/addremove/the_diff_add_remove_mysql.php
@@ -14,6 +14,7 @@ class TheDiffAddRemoveMysql extends AbstractMigration
      */
     public function up(): void
     {
+
         $this->table('articles')
             ->removeColumn('excerpt')
             ->changeColumn('id', 'integer', [
@@ -43,6 +44,7 @@ class TheDiffAddRemoveMysql extends AbstractMigration
      */
     public function down(): void
     {
+
         $this->table('articles')
             ->addColumn('excerpt', 'text', [
                 'after' => 'title',

--- a/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
@@ -67,6 +67,7 @@ class TheDiffSimpleMysql extends AbstractMigration
                 [
                     'update' => 'RESTRICT',
                     'delete' => 'RESTRICT',
+                    'constraint' => 'articles_ibfk_1'
                 ]
             )
             ->update();

--- a/tests/comparisons/Diff/the_diff_mysql.php
+++ b/tests/comparisons/Diff/the_diff_mysql.php
@@ -76,11 +76,17 @@ class TheDiffMysql extends AbstractMigration
             ->addIndex(
                 [
                     'user_id',
+                ],
+                [
+                    'name' => 'categories_ibfk_1',
                 ]
             )
             ->addIndex(
                 [
                     'name',
+                ],
+                [
+                    'name' => 'name',
                 ]
             )
             ->create();
@@ -93,6 +99,7 @@ class TheDiffMysql extends AbstractMigration
                 [
                     'update' => 'RESTRICT',
                     'delete' => 'RESTRICT',
+                    'constraint' => 'categories_ibfk_1'
                 ]
             )
             ->update();
@@ -145,6 +152,7 @@ class TheDiffMysql extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
+                    'constraint' => 'articles_ibfk_1'
                 ]
             )
             ->update();
@@ -263,6 +271,7 @@ class TheDiffMysql extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
+                    'constraint' => 'articles_ibfk_1'
                 ]
             )
             ->update();

--- a/tests/test_app/App/Command/CustomBakeMigrationDiffCommand.php
+++ b/tests/test_app/App/Command/CustomBakeMigrationDiffCommand.php
@@ -6,6 +6,7 @@ namespace TestApp\Command;
 use Cake\Console\Arguments;
 use Cake\Core\Plugin;
 use Migrations\Command\BakeMigrationDiffCommand;
+use function Cake\Core\env;
 
 class CustomBakeMigrationDiffCommand extends BakeMigrationDiffCommand
 {

--- a/tests/test_app/App/Command/CustomRemoveBakeMigrationDiffCommand.php
+++ b/tests/test_app/App/Command/CustomRemoveBakeMigrationDiffCommand.php
@@ -6,6 +6,7 @@ namespace TestApp\Command;
 use Cake\Console\Arguments;
 use Cake\Core\Plugin;
 use Migrations\Command\BakeMigrationDiffCommand;
+use function Cake\Core\env;
 
 class CustomRemoveBakeMigrationDiffCommand extends BakeMigrationDiffCommand
 {

--- a/tests/test_app/App/Command/CustomSimpleBakeMigrationDiffCommand.php
+++ b/tests/test_app/App/Command/CustomSimpleBakeMigrationDiffCommand.php
@@ -6,6 +6,7 @@ namespace TestApp\Command;
 use Cake\Console\Arguments;
 use Cake\Core\Plugin;
 use Migrations\Command\BakeMigrationDiffCommand;
+use function Cake\Core\env;
 
 class CustomSimpleBakeMigrationDiffCommand extends BakeMigrationDiffCommand
 {


### PR DESCRIPTION
Partially reverts #615, as it didn't account for other usages of the `add-foreign-keys` element, where `constraints` is not indexed by table name.