### PR TITLE
4.x - Fix snapshot migration tests and index generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@ jobs:
           sudo service mysql start
           mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_test DEFAULT COLLATE=utf8mb4_general_ci;'
           mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_comparisons;'
+          mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_snapshot;'
+
+      - name: Setup Postgres
+        if: matrix.db-type == 'pgsql'
+        run: |
+          export PGPASSWORD='pg-password'
+          psql -h 127.0.0.1 -U postgres -c 'CREATE DATABASE "cakephp_snapshot";'
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -86,10 +93,12 @@ jobs:
             export DB='mysql'
             export DB_URL='mysql://root:root@127.0.0.1/cakephp_test'
             export DB_URL_COMPARE='mysql://root:root@127.0.0.1/cakephp_comparisons'
+            export DB_URL_SNAPSHOT='mysql://root:root@127.0.0.1/cakephp_snapshot'
           fi
           if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then
             export DB='pgsql'
             export DB_URL='postgres://postgres:pg-password@127.0.0.1/cakephp_test'
+            export DB_URL_SNAPSHOT='postgres://postgres:pg-password@127.0.0.1/cakephp_snapshot'
           fi
           if [[ ${{ matrix.php-version }} == '8.1' && ${{ matrix.db-type }} == 'mysql' ]]; then
             vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ Icon?
 ehthumbs.db
 Thumbs.db
 /cakephp_test
+/cakephp_snapshot

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -668,13 +668,8 @@ class MigrationHelper extends Helper
                 $foreignKeys[] = $constraint['columns'];
             }
         }
-        $indexes = array_filter($indexes, function ($index) use ($foreignKeys) {
-            /** @psalm-suppress PossiblyNullArrayAccess */
-            return !in_array($index['columns'], $foreignKeys, true);
-        });
-        $result = compact('constraints', 'indexes', 'foreignKeys');
 
-        return $result;
+        return compact('constraints', 'indexes', 'foreignKeys');
     }
 
     /**

--- a/templates/bake/element/create-tables.twig
+++ b/templates/bake/element/create-tables.twig
@@ -38,13 +38,10 @@
 {%     endfor %}
 {%     if createData.tables[table].constraints is not empty %}
 {%         for name, constraint in createData.tables[table].constraints %}
-{%             if constraint['columns'] != primaryKeysColumns %}
+{%             if constraint['type'] == 'unique' %}
             ->addIndex(
                 [{{ Migration.stringifyList(constraint['columns'], {'indent': 5}) | raw }}],
-{%                 set params = {'name': name} %}
-{%                 if constraint['type'] == 'unique' %}
-{%                     set params = params|merge({'unique': true}) %}
-{%                 endif %}
+{%                 set params = {'name': name, 'unique': true} %}
                 [{{ Migration.stringifyList(params, {'indent': 5}) | raw }}]
             )
 {%             endif %}

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -969,7 +969,12 @@ class MigrationsTest extends TestCase
      */
     public function testMigrateSnapshots($basePath, $files)
     {
-        $this->markTestSkipped('This test is failing and seems low value.');
+        $params = [
+            'connection' => 'test_snapshot',
+            'source' => 'SnapshotTests',
+        ];
+        $migrations = new Migrations($params);
+
         $destination = ROOT . DS . 'config' . DS . 'SnapshotTests' . DS;
 
         if (!file_exists($destination)) {
@@ -995,10 +1000,10 @@ class MigrationsTest extends TestCase
                 file_put_contents($destination . $copiedFileName, $content);
             }
 
-            $result = $this->migrations->migrate(['source' => 'SnapshotTests']);
+            $result = $migrations->migrate();
             $this->assertTrue($result);
 
-            $this->migrations->rollback(['target' => 'all', 'source' => 'SnapshotTests']);
+            $migrations->rollback(['target' => 'all', 'source' => 'SnapshotTests']);
         }
     }
 
@@ -1041,20 +1046,22 @@ class MigrationsTest extends TestCase
     {
         $db = getenv('DB');
 
+        $version = 20150912015600;
+
         if ($db === 'mysql') {
-            $return = [
+            return [
                 [
                     Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS,
                     [
-                        ['test_not_empty_snapshot', 20150912015601],
-                        ['test_auto_id_disabled_snapshot', 20150912015602],
-                        ['testCreatePrimaryKey', 20150912015603],
-                        ['testCreatePrimaryKeyUuid', 20150912015604],
+                        ['test_snapshot_not_empty', $version++],
+                        ['test_snapshot_auto_id_disabled', $version++],
+                        ['test_snapshot_plugin_blog', $version++],
+                        ['test_snapshot_with_auto_id_compatible_signed_primary_keys', $version++],
+                        ['test_snapshot_with_auto_id_incompatible_signed_primary_keys', $version++],
+                        ['test_snapshot_with_auto_id_incompatible_unsigned_primary_keys', $version++],
                     ],
                 ],
             ];
-
-            return $return;
         }
 
         if ($db === 'pgsql') {
@@ -1062,8 +1069,9 @@ class MigrationsTest extends TestCase
                 [
                     Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS . 'pgsql' . DS,
                     [
-                        ['test_not_empty_snapshot_pgsql', 20150912015606],
-                        ['test_auto_id_disabled_snapshot_pgsql', 20150912015607],
+                        ['test_snapshot_not_empty_pgsql', $version++],
+                        ['test_snapshot_auto_id_disabled_pgsql', $version++],
+                        ['test_snapshot_plugin_blog_pgsql', $version++],
                     ],
                 ],
             ];
@@ -1073,8 +1081,9 @@ class MigrationsTest extends TestCase
             [
                 Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS . 'sqlite' . DS,
                 [
-                    ['test_not_empty_snapshot_sqlite', 20150912015609],
-                    ['test_auto_id_disabled_snapshot_sqlite', 20150912015610],
+                    ['test_snapshot_not_empty_sqlite', $version++],
+                    ['test_snapshot_auto_id_disabled_sqlite', $version++],
+                    ['test_snapshot_plugin_blog_sqlite', $version++],
                 ],
             ],
         ];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -86,6 +86,7 @@ Router::reload();
 
 if (!getenv('DB_URL')) {
     putenv('DB_URL=sqlite://127.0.0.1/cakephp_test');
+    putenv('DB_URL_SNAPSHOT=sqlite://127.0.0.1/cakephp_snapshot');
 }
 if (!getenv('DB')) {
     $dsn = getenv('DB_URL');
@@ -101,6 +102,10 @@ if (!getenv('DB')) {
 ConnectionManager::setConfig('test', [
     'cacheMetadata' => false,
     'url' => getenv('DB_URL'),
+]);
+ConnectionManager::setConfig('test_snapshot', [
+    'cacheMetadata' => false,
+    'url' => getenv('DB_URL_SNAPSHOT'),
 ]);
 
 if (getenv('DB_URL_COMPARE') !== false) {

--- a/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
@@ -74,7 +74,7 @@ class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx',
+                    'name' => 'articles_title_idx',
                 ]
             )
             ->create();
@@ -121,7 +121,7 @@ class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_unique_slug',
+                    'name' => 'categories_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -190,7 +190,7 @@ class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category',
+                    'name' => 'orders_product_category_idx',
                 ]
             )
             ->create();
@@ -267,7 +267,7 @@ class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'products_unique_slug',
+                    'name' => 'products_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -276,7 +276,7 @@ class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx_ft',
+                    'name' => 'products_title_idx',
                 ]
             )
             ->create();
@@ -335,7 +335,7 @@ class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
                     'article_id',
                 ],
                 [
-                    'name' => 'UNIQUE_TAG2',
+                    'name' => 'special_tags_article_unique',
                     'unique' => true,
                 ]
             )
@@ -396,7 +396,7 @@ class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
-                    'constraint' => 'category_article_idx'
+                    'constraint' => 'articles_category_fk'
                 ]
             )
             ->update();
@@ -415,7 +415,7 @@ class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'product_id_fk'
+                    'constraint' => 'orders_product_fk'
                 ]
             )
             ->update();
@@ -428,7 +428,7 @@ class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'category_idx'
+                    'constraint' => 'products_category_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
@@ -71,14 +71,6 @@ class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
             ])
             ->addIndex(
                 [
-                    'category_id',
-                ],
-                [
-                    'name' => 'category_article_idx',
-                ]
-            )
-            ->addIndex(
-                [
                     'title',
                 ],
                 [
@@ -198,7 +190,7 @@ class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_id_fk',
+                    'name' => 'product_category',
                 ]
             )
             ->create();
@@ -277,14 +269,6 @@ class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
                 [
                     'name' => 'products_unique_slug',
                     'unique' => true,
-                ]
-            )
-            ->addIndex(
-                [
-                    'category_id',
-                ],
-                [
-                    'name' => 'category_idx',
                 ]
             )
             ->addIndex(

--- a/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
@@ -190,7 +190,7 @@ class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'orders_product_category_idx',
+                    'name' => 'product_category',
                 ]
             )
             ->create();

--- a/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
@@ -190,7 +190,7 @@ class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category',
+                    'name' => 'orders_product_category_idx',
                 ]
             )
             ->create();

--- a/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
@@ -62,14 +62,6 @@ class TestSnapshotNotEmptyPgsql extends AbstractMigration
             ])
             ->addIndex(
                 [
-                    'category_id',
-                ],
-                [
-                    'name' => 'category_article_idx',
-                ]
-            )
-            ->addIndex(
-                [
                     'title',
                 ],
                 [
@@ -167,7 +159,7 @@ class TestSnapshotNotEmptyPgsql extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_id_fk',
+                    'name' => 'product_category',
                 ]
             )
             ->create();
@@ -232,14 +224,6 @@ class TestSnapshotNotEmptyPgsql extends AbstractMigration
                 [
                     'name' => 'products_unique_slug',
                     'unique' => true,
-                ]
-            )
-            ->addIndex(
-                [
-                    'category_id',
-                ],
-                [
-                    'name' => 'category_idx',
                 ]
             )
             ->addIndex(

--- a/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
@@ -65,7 +65,7 @@ class TestSnapshotNotEmptyPgsql extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx',
+                    'name' => 'articles_title_idx',
                 ]
             )
             ->create();
@@ -105,7 +105,7 @@ class TestSnapshotNotEmptyPgsql extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_unique_slug',
+                    'name' => 'categories_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -159,7 +159,7 @@ class TestSnapshotNotEmptyPgsql extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category',
+                    'name' => 'orders_product_category_idx',
                 ]
             )
             ->create();
@@ -222,7 +222,7 @@ class TestSnapshotNotEmptyPgsql extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'products_unique_slug',
+                    'name' => 'products_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -231,7 +231,7 @@ class TestSnapshotNotEmptyPgsql extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx_ft',
+                    'name' => 'products_title_idx',
                 ]
             )
             ->create();
@@ -282,7 +282,7 @@ class TestSnapshotNotEmptyPgsql extends AbstractMigration
                     'article_id',
                 ],
                 [
-                    'name' => 'UNIQUE_TAG2',
+                    'name' => 'special_tags_article_unique',
                     'unique' => true,
                 ]
             )
@@ -336,7 +336,7 @@ class TestSnapshotNotEmptyPgsql extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
-                    'constraint' => 'category_article_idx'
+                    'constraint' => 'articles_category_fk'
                 ]
             )
             ->update();
@@ -355,7 +355,7 @@ class TestSnapshotNotEmptyPgsql extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'product_id_fk'
+                    'constraint' => 'orders_product_fk'
                 ]
             )
             ->update();
@@ -368,7 +368,7 @@ class TestSnapshotNotEmptyPgsql extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'category_idx'
+                    'constraint' => 'products_category_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
@@ -159,7 +159,7 @@ class TestSnapshotNotEmptyPgsql extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'orders_product_category_idx',
+                    'name' => 'product_category',
                 ]
             )
             ->create();

--- a/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
@@ -159,7 +159,7 @@ class TestSnapshotNotEmptyPgsql extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category',
+                    'name' => 'orders_product_category_idx',
                 ]
             )
             ->create();

--- a/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
@@ -65,7 +65,7 @@ class TestSnapshotPluginBlogPgsql extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx',
+                    'name' => 'articles_title_idx',
                 ]
             )
             ->create();
@@ -105,7 +105,7 @@ class TestSnapshotPluginBlogPgsql extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_unique_slug',
+                    'name' => 'categories_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -132,7 +132,7 @@ class TestSnapshotPluginBlogPgsql extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
-                    'constraint' => 'category_article_idx'
+                    'constraint' => 'articles_category_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
@@ -62,14 +62,6 @@ class TestSnapshotPluginBlogPgsql extends AbstractMigration
             ])
             ->addIndex(
                 [
-                    'category_id',
-                ],
-                [
-                    'name' => 'category_article_idx',
-                ]
-            )
-            ->addIndex(
-                [
                     'title',
                 ],
                 [

--- a/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
@@ -69,7 +69,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx',
+                    'name' => 'articles_title_idx',
                 ]
             )
             ->create();
@@ -112,7 +112,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_unique_slug',
+                    'name' => 'categories_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -181,7 +181,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category',
+                    'name' => 'orders_product_category_idx',
                 ]
             )
             ->create();
@@ -254,7 +254,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'products_unique_slug',
+                    'name' => 'products_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -263,7 +263,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx_ft',
+                    'name' => 'products_title_idx',
                 ]
             )
             ->create();
@@ -320,7 +320,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'article_id',
                 ],
                 [
-                    'name' => 'UNIQUE_TAG2',
+                    'name' => 'special_tags_article_unique',
                     'unique' => true,
                 ]
             )

--- a/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
@@ -112,7 +112,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_slug_unique',
+                    'name' => 'categories_unique_slug',
                     'unique' => true,
                 ]
             )
@@ -181,7 +181,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'orders_product_category_idx',
+                    'name' => 'product_category',
                 ]
             )
             ->create();
@@ -254,7 +254,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'products_slug_unique',
+                    'name' => 'products_unique_slug',
                     'unique' => true,
                 ]
             )
@@ -320,7 +320,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'article_id',
                 ],
                 [
-                    'name' => 'special_tags_article_unique',
+                    'name' => 'UNIQUE_TAG2',
                     'unique' => true,
                 ]
             )

--- a/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
@@ -112,7 +112,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_unique_slug',
+                    'name' => 'categories_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -181,7 +181,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category',
+                    'name' => 'orders_product_category_idx',
                 ]
             )
             ->create();
@@ -254,7 +254,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'products_unique_slug',
+                    'name' => 'products_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -320,7 +320,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'article_id',
                 ],
                 [
-                    'name' => 'UNIQUE_TAG2',
+                    'name' => 'special_tags_article_unique',
                     'unique' => true,
                 ]
             )

--- a/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
@@ -66,14 +66,6 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
             ])
             ->addIndex(
                 [
-                    'category_id',
-                ],
-                [
-                    'name' => 'category_id_0_fk',
-                ]
-            )
-            ->addIndex(
-                [
                     'title',
                 ],
                 [
@@ -189,7 +181,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category_product_id_0_fk',
+                    'name' => 'product_category',
                 ]
             )
             ->create();
@@ -264,14 +256,6 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                 [
                     'name' => 'products_unique_slug',
                     'unique' => true,
-                ]
-            )
-            ->addIndex(
-                [
-                    'category_id',
-                ],
-                [
-                    'name' => 'category_id_0_fk',
                 ]
             )
             ->addIndex(

--- a/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
@@ -60,7 +60,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx',
+                    'name' => 'articles_title_idx',
                 ]
             )
             ->create();
@@ -96,7 +96,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_unique_slug',
+                    'name' => 'categories_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -150,7 +150,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category',
+                    'name' => 'orders_product_category_idx',
                 ]
             )
             ->create();
@@ -209,7 +209,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'products_unique_slug',
+                    'name' => 'products_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -218,7 +218,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx_ft',
+                    'name' => 'products_title_idx',
                 ]
             )
             ->create();
@@ -267,7 +267,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'article_id',
                 ],
                 [
-                    'name' => 'UNIQUE_TAG2',
+                    'name' => 'special_tags_article_unique',
                     'unique' => true,
                 ]
             )

--- a/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
@@ -96,7 +96,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_unique_slug',
+                    'name' => 'categories_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -150,7 +150,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category',
+                    'name' => 'orders_product_category_idx',
                 ]
             )
             ->create();
@@ -209,7 +209,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'products_unique_slug',
+                    'name' => 'products_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -267,7 +267,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'article_id',
                 ],
                 [
-                    'name' => 'UNIQUE_TAG2',
+                    'name' => 'special_tags_article_unique',
                     'unique' => true,
                 ]
             )

--- a/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
@@ -57,14 +57,6 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
             ])
             ->addIndex(
                 [
-                    'category_id',
-                ],
-                [
-                    'name' => 'category_id_0_fk',
-                ]
-            )
-            ->addIndex(
-                [
                     'title',
                 ],
                 [
@@ -158,7 +150,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category_product_id_0_fk',
+                    'name' => 'product_category',
                 ]
             )
             ->create();
@@ -219,14 +211,6 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                 [
                     'name' => 'products_unique_slug',
                     'unique' => true,
-                ]
-            )
-            ->addIndex(
-                [
-                    'category_id',
-                ],
-                [
-                    'name' => 'category_id_0_fk',
                 ]
             )
             ->addIndex(

--- a/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
@@ -96,7 +96,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_slug_unique',
+                    'name' => 'categories_unique_slug',
                     'unique' => true,
                 ]
             )
@@ -150,7 +150,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'orders_product_category_idx',
+                    'name' => 'product_category',
                 ]
             )
             ->create();
@@ -209,7 +209,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'products_slug_unique',
+                    'name' => 'products_unique_slug',
                     'unique' => true,
                 ]
             )
@@ -267,7 +267,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'article_id',
                 ],
                 [
-                    'name' => 'special_tags_article_unique',
+                    'name' => 'UNIQUE_TAG2',
                     'unique' => true,
                 ]
             )

--- a/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
@@ -60,7 +60,7 @@ class TestSnapshotPluginBlogSqlite extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx',
+                    'name' => 'articles_title_idx',
                 ]
             )
             ->create();
@@ -96,7 +96,7 @@ class TestSnapshotPluginBlogSqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_unique_slug',
+                    'name' => 'categories_slug_unique',
                     'unique' => true,
                 ]
             )

--- a/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
@@ -96,7 +96,7 @@ class TestSnapshotPluginBlogSqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_slug_unique',
+                    'name' => 'categories_unique_slug',
                     'unique' => true,
                 ]
             )

--- a/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
@@ -57,14 +57,6 @@ class TestSnapshotPluginBlogSqlite extends AbstractMigration
             ])
             ->addIndex(
                 [
-                    'category_id',
-                ],
-                [
-                    'name' => 'category_id_0_fk',
-                ]
-            )
-            ->addIndex(
-                [
                     'title',
                 ],
                 [

--- a/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
@@ -96,7 +96,7 @@ class TestSnapshotPluginBlogSqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_unique_slug',
+                    'name' => 'categories_slug_unique',
                     'unique' => true,
                 ]
             )

--- a/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
+++ b/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
@@ -200,7 +200,7 @@ class TestSnapshotAutoIdDisabled extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_id_fk',
+                    'name' => 'product_category',
                 ]
             )
             ->create();
@@ -279,14 +279,6 @@ class TestSnapshotAutoIdDisabled extends AbstractMigration
                 [
                     'name' => 'products_category_unique',
                     'unique' => true,
-                ]
-            )
-            ->addIndex(
-                [
-                    'category_id',
-                ],
-                [
-                    'name' => 'category_idx',
                 ]
             )
             ->addIndex(

--- a/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
+++ b/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
@@ -74,7 +74,7 @@ class TestSnapshotAutoIdDisabled extends AbstractMigration
                     'category_id',
                 ],
                 [
-                    'name' => 'category_article_idx',
+                    'name' => 'articles_category_fk',
                 ]
             )
             ->addIndex(
@@ -82,7 +82,7 @@ class TestSnapshotAutoIdDisabled extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx',
+                    'name' => 'articles_title_idx',
                 ]
             )
             ->create();
@@ -127,7 +127,7 @@ class TestSnapshotAutoIdDisabled extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_unique_slug',
+                    'name' => 'categories_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -200,7 +200,7 @@ class TestSnapshotAutoIdDisabled extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category',
+                    'name' => 'orders_product_category_idx',
                 ]
             )
             ->create();
@@ -267,7 +267,7 @@ class TestSnapshotAutoIdDisabled extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'products_unique_slug',
+                    'name' => 'products_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -286,7 +286,7 @@ class TestSnapshotAutoIdDisabled extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx_ft',
+                    'name' => 'products_title_idx',
                 ]
             )
             ->create();
@@ -347,7 +347,7 @@ class TestSnapshotAutoIdDisabled extends AbstractMigration
                     'article_id',
                 ],
                 [
-                    'name' => 'UNIQUE_TAG2',
+                    'name' => 'special_tags_article_unique',
                     'unique' => true,
                 ]
             )
@@ -405,7 +405,7 @@ class TestSnapshotAutoIdDisabled extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
-                    'constraint' => 'category_article_idx'
+                    'constraint' => 'articles_category_fk'
                 ]
             )
             ->update();
@@ -424,7 +424,7 @@ class TestSnapshotAutoIdDisabled extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'product_id_fk'
+                    'constraint' => 'orders_product_fk'
                 ]
             )
             ->update();
@@ -437,7 +437,7 @@ class TestSnapshotAutoIdDisabled extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'category_idx'
+                    'constraint' => 'products_category_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
+++ b/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
@@ -200,7 +200,7 @@ class TestSnapshotAutoIdDisabled extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category',
+                    'name' => 'orders_product_category_idx',
                 ]
             )
             ->create();

--- a/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
+++ b/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
@@ -200,7 +200,7 @@ class TestSnapshotAutoIdDisabled extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'orders_product_category_idx',
+                    'name' => 'product_category',
                 ]
             )
             ->create();

--- a/tests/comparisons/Migration/test_snapshot_not_empty.php
+++ b/tests/comparisons/Migration/test_snapshot_not_empty.php
@@ -64,7 +64,7 @@ class TestSnapshotNotEmpty extends AbstractMigration
                     'category_id',
                 ],
                 [
-                    'name' => 'category_article_idx',
+                    'name' => 'articles_category_fk',
                 ]
             )
             ->addIndex(
@@ -72,7 +72,7 @@ class TestSnapshotNotEmpty extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx',
+                    'name' => 'articles_title_idx',
                 ]
             )
             ->create();
@@ -109,7 +109,7 @@ class TestSnapshotNotEmpty extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_unique_slug',
+                    'name' => 'categories_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -165,7 +165,7 @@ class TestSnapshotNotEmpty extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category',
+                    'name' => 'orders_product_category_idx',
                 ]
             )
             ->create();
@@ -216,7 +216,7 @@ class TestSnapshotNotEmpty extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'products_unique_slug',
+                    'name' => 'products_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -235,7 +235,7 @@ class TestSnapshotNotEmpty extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx_ft',
+                    'name' => 'products_title_idx',
                 ]
             )
             ->create();
@@ -287,7 +287,7 @@ class TestSnapshotNotEmpty extends AbstractMigration
                     'article_id',
                 ],
                 [
-                    'name' => 'UNIQUE_TAG2',
+                    'name' => 'special_tags_article_unique',
                     'unique' => true,
                 ]
             )
@@ -337,7 +337,7 @@ class TestSnapshotNotEmpty extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
-                    'constraint' => 'category_article_idx'
+                    'constraint' => 'articles_category_fk'
                 ]
             )
             ->update();
@@ -356,7 +356,7 @@ class TestSnapshotNotEmpty extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'product_id_fk'
+                    'constraint' => 'orders_product_fk'
                 ]
             )
             ->update();
@@ -369,7 +369,7 @@ class TestSnapshotNotEmpty extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'category_idx'
+                    'constraint' => 'products_category_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/test_snapshot_not_empty.php
+++ b/tests/comparisons/Migration/test_snapshot_not_empty.php
@@ -165,7 +165,7 @@ class TestSnapshotNotEmpty extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_id_fk',
+                    'name' => 'product_category',
                 ]
             )
             ->create();
@@ -228,14 +228,6 @@ class TestSnapshotNotEmpty extends AbstractMigration
                 [
                     'name' => 'products_category_unique',
                     'unique' => true,
-                ]
-            )
-            ->addIndex(
-                [
-                    'category_id',
-                ],
-                [
-                    'name' => 'category_idx',
                 ]
             )
             ->addIndex(

--- a/tests/comparisons/Migration/test_snapshot_not_empty.php
+++ b/tests/comparisons/Migration/test_snapshot_not_empty.php
@@ -165,7 +165,7 @@ class TestSnapshotNotEmpty extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category',
+                    'name' => 'orders_product_category_idx',
                 ]
             )
             ->create();

--- a/tests/comparisons/Migration/test_snapshot_not_empty.php
+++ b/tests/comparisons/Migration/test_snapshot_not_empty.php
@@ -165,7 +165,7 @@ class TestSnapshotNotEmpty extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'orders_product_category_idx',
+                    'name' => 'product_category',
                 ]
             )
             ->create();

--- a/tests/comparisons/Migration/test_snapshot_plugin_blog.php
+++ b/tests/comparisons/Migration/test_snapshot_plugin_blog.php
@@ -64,7 +64,7 @@ class TestSnapshotPluginBlog extends AbstractMigration
                     'category_id',
                 ],
                 [
-                    'name' => 'category_article_idx',
+                    'name' => 'articles_category_fk',
                 ]
             )
             ->addIndex(
@@ -72,7 +72,7 @@ class TestSnapshotPluginBlog extends AbstractMigration
                     'title',
                 ],
                 [
-                    'name' => 'title_idx',
+                    'name' => 'articles_title_idx',
                 ]
             )
             ->create();
@@ -109,7 +109,7 @@ class TestSnapshotPluginBlog extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'categories_unique_slug',
+                    'name' => 'categories_slug_unique',
                     'unique' => true,
                 ]
             )
@@ -137,7 +137,7 @@ class TestSnapshotPluginBlog extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
-                    'constraint' => 'category_article_idx'
+                    'constraint' => 'articles_category_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_compatible_signed_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_compatible_signed_primary_keys.php
@@ -64,7 +64,7 @@ class TestSnapshotWithAutoIdCompatibleSignedPrimaryKeys extends AbstractMigratio
                     'category_id',
                 ],
                 [
-                    'name' => 'category_article_idx',
+                    'name' => 'articles_category_fk',
                 ]
             )
             ->addIndex(
@@ -72,7 +72,7 @@ class TestSnapshotWithAutoIdCompatibleSignedPrimaryKeys extends AbstractMigratio
                     'title',
                 ],
                 [
-                    'name' => 'title_idx',
+                    'name' => 'articles_title_idx',
                 ]
             )
             ->create();
@@ -85,7 +85,7 @@ class TestSnapshotWithAutoIdCompatibleSignedPrimaryKeys extends AbstractMigratio
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
-                    'constraint' => 'category_article_idx'
+                    'constraint' => 'articles_category_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_signed_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_signed_primary_keys.php
@@ -74,7 +74,7 @@ class TestSnapshotWithAutoIdIncompatibleSignedPrimaryKeys extends AbstractMigrat
                     'category_id',
                 ],
                 [
-                    'name' => 'category_article_idx',
+                    'name' => 'articles_category_fk',
                 ]
             )
             ->addIndex(
@@ -82,7 +82,7 @@ class TestSnapshotWithAutoIdIncompatibleSignedPrimaryKeys extends AbstractMigrat
                     'title',
                 ],
                 [
-                    'name' => 'title_idx',
+                    'name' => 'articles_title_idx',
                 ]
             )
             ->create();
@@ -95,7 +95,7 @@ class TestSnapshotWithAutoIdIncompatibleSignedPrimaryKeys extends AbstractMigrat
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
-                    'constraint' => 'category_article_idx'
+                    'constraint' => 'articles_category_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_unsigned_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_unsigned_primary_keys.php
@@ -74,7 +74,7 @@ class TestSnapshotWithAutoIdIncompatibleUnsignedPrimaryKeys extends AbstractMigr
                     'category_id',
                 ],
                 [
-                    'name' => 'category_article_idx',
+                    'name' => 'articles_category_fk',
                 ]
             )
             ->addIndex(
@@ -82,7 +82,7 @@ class TestSnapshotWithAutoIdIncompatibleUnsignedPrimaryKeys extends AbstractMigr
                     'title',
                 ],
                 [
-                    'name' => 'title_idx',
+                    'name' => 'articles_title_idx',
                 ]
             )
             ->create();
@@ -95,7 +95,7 @@ class TestSnapshotWithAutoIdIncompatibleUnsignedPrimaryKeys extends AbstractMigr
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
-                    'constraint' => 'category_article_idx'
+                    'constraint' => 'articles_category_fk'
                 ]
             )
             ->update();

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -18,7 +18,7 @@ return [
         ],
         'constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
-            'categories_unique_slug' => ['type' => 'unique', 'columns' => ['slug']],
+            'categories_slug_unique' => ['type' => 'unique', 'columns' => ['slug']],
         ],
     ],
     [
@@ -32,16 +32,16 @@ return [
             'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         ],
         'indexes' => [
-            'title_idx_ft' => [
+            'products_title_idx' => [
                 'type' => 'index',
                 'columns' => ['title'],
             ],
         ],
         'constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
-            'products_unique_slug' => ['type' => 'unique', 'columns' => ['slug']],
+            'products_slug_unique' => ['type' => 'unique', 'columns' => ['slug']],
             'products_category_unique' => ['type' => 'unique', 'columns' => ['category_id', 'id']],
-            'category_idx' => [
+            'products_category_fk' => [
                 'type' => 'foreign',
                 'columns' => ['category_id'],
                 'references' => ['categories', 'id'],
@@ -58,7 +58,7 @@ return [
             'product_id' => ['type' => 'integer', 'unsigned' => true, 'null' => false, 'length' => 11],
         ],
         'indexes' => [
-            'product_category' => [
+            'orders_product_category_idx' => [
                 'type' => 'index',
                 'columns' => ['product_category', 'product_id'],
             ],
@@ -67,7 +67,7 @@ return [
             'primary' => [
                 'type' => 'primary', 'columns' => ['id'],
             ],
-            'product_id_fk' => [
+            'orders_product_fk' => [
                 'type' => 'foreign',
                 'columns' => ['product_category', 'product_id'],
                 'references' => ['products', ['category_id', 'id']],
@@ -90,14 +90,14 @@ return [
             'modified' => ['type' => 'timestamp', 'null' => true, 'default' => null],
         ],
         'indexes' => [
-            'title_idx' => [
+            'articles_title_idx' => [
                 'type' => 'index',
                 'columns' => ['title'],
             ],
         ],
         'constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
-            'category_article_idx' => [
+            'articles_category_fk' => [
                 'type' => 'foreign',
                 'columns' => ['category_id'],
                 'references' => ['categories', 'id'],
@@ -112,7 +112,7 @@ return [
             'id' => ['type' => 'uuid', 'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7', 'null' => false ],
             'name' => ['type' => 'string', 'length' => 10, 'default' => '', 'null' => false],
         ],
-        'constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'name']]],
+        'constraints' => ['primary' => ['type' => 'primary', 'columns' => ['name', 'id']]],
     ],
     [
         'table' => 'events',
@@ -157,7 +157,7 @@ return [
         ],
         'constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
-            'UNIQUE_TAG2' => ['type' => 'unique', 'columns' => ['article_id']],
+            'special_tags_article_unique' => ['type' => 'unique', 'columns' => ['article_id']],
         ],
     ],
     [


### PR DESCRIPTION
This depends on / is blocked by ~cakephp/cakephp#17256 and~ cakephp/phinx#2212.

Without the test that this PR re-enables it has gone unnoticed at the time, but #617 uncovered some weird behavior, where Migrations will filter out all indexes that are created over the same columns as any foreign key, and then it uses the foreign keys in the templates to generate `addIndex()` calls for them, which results in the original index names getting lost, and indexes being created that do not necessarily exist.

I'm not quite sure whether that is a bug, or if it was intended in order to emulate how MySQL (the DBMS, not Migrations) would automatically created indexes in the source table when creating foreign keys (should no index already exist that covers it). The original code stems from a huge pile of changes that were part of the initial CakePHP 3 compatibility revamp, and there's no explanation or anything.

Personally I don't like it, I'd neither want to loose the index names, nor would I want a snapshot to create indexes that do not actually exist in my schema. So alongside of making the snapshot migration test work again, I would like to suggest making the index handling more strict, and only create `addIndex()` calls for indexes that actually exist.