### PR TITLE
#633 Quote schema for PostgreSQL in the CakeAdapter

### DIFF
--- a/src/CakeAdapter.php
+++ b/src/CakeAdapter.php
@@ -60,7 +60,7 @@ class CakeAdapter extends AdapterWrapper
         if ($connection->getDriver() instanceof Postgres) {
             $config = $connection->config();
             $schema = empty($config['schema']) ? 'public' : $config['schema'];
-            $pdo->exec('SET search_path TO ' . $schema);
+            $pdo->exec('SET search_path TO ' . $pdo->quote($schema));
         }
 
         $driver = $connection->getDriver();


### PR DESCRIPTION
On PostgreSQL, the schema should be quoted in order to allow schema names with dashes.