### PR TITLE
Support phinx 0.15 requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "robmorgan/phinx": "^0.15",
+        "robmorgan/phinx": "^0.15.1",
         "cakephp/orm": "^5.0",
         "cakephp/cache": "^5.0"
     },
@@ -30,7 +30,7 @@
         "phpunit/phpunit": "^10.1.0",
         "cakephp/cakephp": "^5.0",
         "cakephp/bake": "^3.0",
-        "cakephp/cakephp-codesniffer": "^4.1"
+        "cakephp/cakephp-codesniffer": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -1051,7 +1051,7 @@ it to the table declaration::
     class CreateProductsTable extends AbstractMigration
     {
 
-        public $autoId = false;
+        public bool $autoId = false;
 
         public function up()
         {

--- a/docs/fr/index.rst
+++ b/docs/fr/index.rst
@@ -1051,7 +1051,7 @@ primaire et devrez l'ajouter à la déclaration de la table::
     class CreateProductsTable extends AbstractMigration
     {
 
-        public $autoId = false;
+        public bool $autoId = false;
 
         public function up()
         {

--- a/docs/ja/index.rst
+++ b/docs/ja/index.rst
@@ -934,7 +934,7 @@ migrations プラグインのバージョン 1.2 から、非シェル環境で�
     class CreateProductsTable extends AbstractMigration
     {
 
-        public $autoId = false;
+        public bool $autoId = false;
 
         public function up()
         {

--- a/docs/pt/index.rst
+++ b/docs/pt/index.rst
@@ -854,7 +854,7 @@ adicioná-la à declaração da tabela::
     class CreateProductsTable extends AbstractMigration
     {
 
-        public $autoId = false;
+        public bool $autoId = false;
 
         public function up()
         {

--- a/docs/ru/index.rst
+++ b/docs/ru/index.rst
@@ -899,7 +899,7 @@
     class CreateProductsTable extends AbstractMigration
     {
 
-        public $autoId = false;
+        public bool $autoId = false;
 
         public function up()
         {

--- a/src/AbstractMigration.php
+++ b/src/AbstractMigration.php
@@ -27,7 +27,7 @@ class AbstractMigration extends BaseAbstractMigration
      *
      * @var bool
      */
-    public $autoId = true;
+    public bool $autoId = true;
 
     /**
      * Returns an instance of the Table class.

--- a/src/CakeManager.php
+++ b/src/CakeManager.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace Migrations;
 
 use DateTime;
+use Exception;
+use InvalidArgumentException;
 use Phinx\Migration\Manager;
+use RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -153,7 +156,7 @@ class CakeManager extends Manager
     /**
      * @inheritDoc
      */
-    public function rollbackToDateTime(string $environment, \DateTime $dateTime, bool $force = false): void
+    public function rollbackToDateTime(string $environment, DateTime $dateTime, bool $force = false): void
     {
         $env = $this->getEnvironment($environment);
         $versions = $env->getVersions();
@@ -216,7 +219,7 @@ class CakeManager extends Manager
         $migrationFile = glob($path . DS . $version . '*');
 
         if (empty($migrationFile)) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 sprintf('A migration file matching version number `%s` could not be found', $version)
             );
         }
@@ -259,7 +262,7 @@ class CakeManager extends Manager
 
         if ($input->getOption('only') || !empty($versionArg)) {
             if (!in_array($version, $versions)) {
-                throw new \InvalidArgumentException("Migration `$version` was not found !");
+                throw new InvalidArgumentException("Migration `$version` was not found !");
             }
 
             return [$version];
@@ -269,7 +272,7 @@ class CakeManager extends Manager
         $index = array_search($version, $versions);
 
         if ($index === false) {
-            throw new \InvalidArgumentException("Migration `$version` was not found !");
+            throw new InvalidArgumentException("Migration `$version` was not found !");
         }
 
         return array_slice($versions, 0, $index + $lengthIncrease);
@@ -308,7 +311,7 @@ class CakeManager extends Manager
                 $output->writeln(
                     sprintf('<info>Migration `%s` successfully marked migrated !</info>', $version)
                 );
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $adapter->rollbackTransaction();
                 $output->writeln(
                     sprintf(
@@ -376,7 +379,7 @@ class CakeManager extends Manager
             return [];
         }
 
-        foreach ($this->seeds as $class => $instance) {
+        foreach ($this->seeds as $instance) {
             if ($instance instanceof AbstractSeed) {
                 $instance->setInput($this->input);
             }

--- a/src/Command/BakeMigrationCommand.php
+++ b/src/Command/BakeMigrationCommand.php
@@ -47,7 +47,7 @@ class BakeMigrationCommand extends BakeSimpleMigrationCommand
      */
     public function bake(string $name, Arguments $args, ConsoleIo $io): void
     {
-        EventManager::instance()->on('Bake.initialize', function (Event $event) {
+        EventManager::instance()->on('Bake.initialize', function (Event $event): void {
             $event->getSubject()->loadHelper('Migrations.Migration');
         });
         $this->_name = $name;

--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -129,7 +129,7 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
         $connection = ConnectionManager::get($this->connection);
         assert($connection instanceof Connection);
 
-        EventManager::instance()->on('Bake.initialize', function (Event $event) use ($collection, $connection) {
+        EventManager::instance()->on('Bake.initialize', function (Event $event) use ($collection, $connection): void {
             $event->getSubject()->loadHelper('Migrations.Migration', [
                 'collection' => $collection,
                 'connection' => $connection,

--- a/src/Command/BakeMigrationSnapshotCommand.php
+++ b/src/Command/BakeMigrationSnapshotCommand.php
@@ -59,7 +59,7 @@ class BakeMigrationSnapshotCommand extends BakeSimpleMigrationCommand
         $connection = ConnectionManager::get($this->connection);
         assert($connection instanceof Connection);
 
-        EventManager::instance()->on('Bake.initialize', function (Event $event) use ($collection, $connection) {
+        EventManager::instance()->on('Bake.initialize', function (Event $event) use ($collection, $connection): void {
             $event->getSubject()->loadHelper('Migrations.Migration', [
                 'collection' => $collection,
                 'connection' => $connection,

--- a/src/Command/MigrationsCacheBuildCommand.php
+++ b/src/Command/MigrationsCacheBuildCommand.php
@@ -25,5 +25,5 @@ class MigrationsCacheBuildCommand extends MigrationsCommand
      *
      * @var string
      */
-    protected static $commandName = 'CacheBuild';
+    protected static string $commandName = 'CacheBuild';
 }

--- a/src/Command/MigrationsCacheClearCommand.php
+++ b/src/Command/MigrationsCacheClearCommand.php
@@ -25,5 +25,5 @@ class MigrationsCacheClearCommand extends MigrationsCommand
      *
      * @var string
      */
-    protected static $commandName = 'CacheClear';
+    protected static string $commandName = 'CacheClear';
 }

--- a/src/Command/MigrationsCommand.php
+++ b/src/Command/MigrationsCommand.php
@@ -41,7 +41,7 @@ class MigrationsCommand extends Command
      *
      * @var string
      */
-    protected static $commandName = '';
+    protected static string $commandName = '';
 
     /**
      * @inheritDoc
@@ -80,7 +80,7 @@ class MigrationsCommand extends Command
         $command = new MigrationsDispatcher::$phinxCommands[static::$commandName]();
         $parser->setDescription($command->getDescription());
         $definition = $command->getDefinition();
-        foreach ($definition->getOptions() as $key => $option) {
+        foreach ($definition->getOptions() as $option) {
             if (!empty($option->getShortcut())) {
                 $parser->addOption($option->getName(), [
                     'short' => $option->getShortcut(),

--- a/src/Command/MigrationsCreateCommand.php
+++ b/src/Command/MigrationsCreateCommand.php
@@ -25,5 +25,5 @@ class MigrationsCreateCommand extends MigrationsCommand
      *
      * @var string
      */
-    protected static $commandName = 'Create';
+    protected static string $commandName = 'Create';
 }

--- a/src/Command/MigrationsDumpCommand.php
+++ b/src/Command/MigrationsDumpCommand.php
@@ -25,5 +25,5 @@ class MigrationsDumpCommand extends MigrationsCommand
      *
      * @var string
      */
-    protected static $commandName = 'Dump';
+    protected static string $commandName = 'Dump';
 }

--- a/src/Command/MigrationsMarkMigratedCommand.php
+++ b/src/Command/MigrationsMarkMigratedCommand.php
@@ -25,5 +25,5 @@ class MigrationsMarkMigratedCommand extends MigrationsCommand
      *
      * @var string
      */
-    protected static $commandName = 'MarkMigrated';
+    protected static string $commandName = 'MarkMigrated';
 }

--- a/src/Command/MigrationsMigrateCommand.php
+++ b/src/Command/MigrationsMigrateCommand.php
@@ -25,5 +25,5 @@ class MigrationsMigrateCommand extends MigrationsCommand
      *
      * @var string
      */
-    protected static $commandName = 'Migrate';
+    protected static string $commandName = 'Migrate';
 }

--- a/src/Command/MigrationsRollbackCommand.php
+++ b/src/Command/MigrationsRollbackCommand.php
@@ -25,5 +25,5 @@ class MigrationsRollbackCommand extends MigrationsCommand
      *
      * @var string
      */
-    protected static $commandName = 'Rollback';
+    protected static string $commandName = 'Rollback';
 }

--- a/src/Command/MigrationsSeedCommand.php
+++ b/src/Command/MigrationsSeedCommand.php
@@ -25,5 +25,5 @@ class MigrationsSeedCommand extends MigrationsCommand
      *
      * @var string
      */
-    protected static $commandName = 'Seed';
+    protected static string $commandName = 'Seed';
 }

--- a/src/Command/MigrationsStatusCommand.php
+++ b/src/Command/MigrationsStatusCommand.php
@@ -25,5 +25,5 @@ class MigrationsStatusCommand extends MigrationsCommand
      *
      * @var string
      */
-    protected static $commandName = 'Status';
+    protected static string $commandName = 'Status';
 }

--- a/src/Command/Phinx/Create.php
+++ b/src/Command/Phinx/Create.php
@@ -71,7 +71,7 @@ class Create extends CreateCommand
      * @param \Symfony\Component\Console\Output\OutputInterface $output the output object
      * @return void
      */
-    protected function beforeExecute(InputInterface $input, OutputInterface $output)
+    protected function beforeExecute(InputInterface $input, OutputInterface $output): void
     {
         // Set up as a dummy, its value is not going to be used, as a custom
         // template will always be set.
@@ -98,6 +98,7 @@ class Create extends CreateCommand
         $migrationPath = array_pop($migrationPaths) . DS;
         /** @var string $name */
         $name = $input->getArgument('name');
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
         [$phinxTimestamp, $phinxName] = explode('_', Util::mapClassNameToFileName($name), 2);
         $migrationFilename = glob($migrationPath . '*' . $phinxName);
 

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -14,10 +14,13 @@ declare(strict_types=1);
 namespace Migrations;
 
 use Cake\Datasource\ConnectionManager;
+use DateTime;
+use InvalidArgumentException;
 use Phinx\Config\Config;
 use Phinx\Config\ConfigInterface;
 use Phinx\Db\Adapter\WrapperInterface;
 use Phinx\Migration\Manager;
+use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
@@ -168,7 +171,7 @@ class Migrations
 
         if ($input->getOption('date')) {
             $method = 'migrateToDateTime';
-            $params[1] = new \DateTime($input->getOption('date'));
+            $params[1] = new DateTime($input->getOption('date'));
         }
 
         $this->run($method, $params, $input);
@@ -199,7 +202,7 @@ class Migrations
 
         if ($input->getOption('date')) {
             $method = 'rollbackToDateTime';
-            $params[1] = new \DateTime($input->getOption('date'));
+            $params[1] = new DateTime($input->getOption('date'));
         }
 
         $this->run($method, $params, $input);
@@ -229,7 +232,7 @@ class Migrations
             isset($options['only'])
         ) {
             $exceptionMessage = 'You should use `exclude` OR `only` (not both) along with a `target` argument';
-            throw new \InvalidArgumentException($exceptionMessage);
+            throw new InvalidArgumentException($exceptionMessage);
         }
 
         $input = $this->getInput('MarkMigrated', ['version' => $version], $options);
@@ -342,7 +345,7 @@ class Migrations
     {
         if (!($this->manager instanceof CakeManager)) {
             if (!($config instanceof ConfigInterface)) {
-                throw new \RuntimeException(
+                throw new RuntimeException(
                     'You need to pass a ConfigInterface object for your first getManager() call'
                 );
             }
@@ -360,7 +363,7 @@ class Migrations
                         ->getAdapter()
                         ->getConnection();
                 }
-            } catch (\InvalidArgumentException $e) {
+            } catch (InvalidArgumentException $e) {
             }
             $config['environments'] = ['default' => $defaultEnvironment];
             $this->manager->setEnvironments([]);

--- a/src/MigrationsPlugin.php
+++ b/src/MigrationsPlugin.php
@@ -16,6 +16,16 @@ namespace Migrations;
 use Bake\Command\SimpleBakeCommand;
 use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
+use Migrations\Command\MigrationsCacheBuildCommand;
+use Migrations\Command\MigrationsCacheClearCommand;
+use Migrations\Command\MigrationsCommand;
+use Migrations\Command\MigrationsCreateCommand;
+use Migrations\Command\MigrationsDumpCommand;
+use Migrations\Command\MigrationsMarkMigratedCommand;
+use Migrations\Command\MigrationsMigrateCommand;
+use Migrations\Command\MigrationsRollbackCommand;
+use Migrations\Command\MigrationsSeedCommand;
+use Migrations\Command\MigrationsStatusCommand;
 
 /**
  * Plugin class for migrations
@@ -37,16 +47,16 @@ class MigrationsPlugin extends BasePlugin
      * @psalm-var array<class-string<\Cake\Console\BaseCommand>>
      */
     protected array $migrationCommandsList = [
-        \Migrations\Command\MigrationsCommand::class,
-        \Migrations\Command\MigrationsCreateCommand::class,
-        \Migrations\Command\MigrationsDumpCommand::class,
-        \Migrations\Command\MigrationsMarkMigratedCommand::class,
-        \Migrations\Command\MigrationsMigrateCommand::class,
-        \Migrations\Command\MigrationsCacheBuildCommand::class,
-        \Migrations\Command\MigrationsCacheClearCommand::class,
-        \Migrations\Command\MigrationsRollbackCommand::class,
-        \Migrations\Command\MigrationsSeedCommand::class,
-        \Migrations\Command\MigrationsStatusCommand::class,
+        MigrationsCommand::class,
+        MigrationsCreateCommand::class,
+        MigrationsDumpCommand::class,
+        MigrationsMarkMigratedCommand::class,
+        MigrationsMigrateCommand::class,
+        MigrationsCacheBuildCommand::class,
+        MigrationsCacheClearCommand::class,
+        MigrationsRollbackCommand::class,
+        MigrationsSeedCommand::class,
+        MigrationsStatusCommand::class,
     ];
 
     /**

--- a/src/Table.php
+++ b/src/Table.php
@@ -15,6 +15,7 @@ namespace Migrations;
 
 use Cake\Collection\Collection;
 use Cake\ORM\Locator\LocatorAwareTrait;
+use Phinx\Db\Action\AddColumn;
 use Phinx\Db\Table as BaseTable;
 use Phinx\Db\Table\Column;
 
@@ -32,7 +33,7 @@ class Table extends BaseTable
      *
      * @var string|string[]
      */
-    protected $primaryKey;
+    protected string|array $primaryKey;
 
     /**
      * Add a primary key to a database table.
@@ -55,12 +56,12 @@ class Table extends BaseTable
      * auto increment attribute
      *
      * @param string|\Phinx\Db\Table\Column $columnName Column Name
-     * @param string|\Phinx\Util\Literal|null $type Column Type
+     * @param string|\Phinx\Util\Literal $type Column Type
      * @param array $options Column Options
      * @throws \InvalidArgumentException
      * @return $this
      */
-    public function addColumn($columnName, $type = null, $options = [])
+    public function addColumn(Column|string $columnName, $type, $options = [])
     {
         $options = $this->convertedAutoIncrement($options);
 
@@ -197,7 +198,7 @@ class Table extends BaseTable
 
         $columnsCollection = (new Collection($this->actions->getActions()))
             ->filter(function ($action) {
-                return $action instanceof \Phinx\Db\Action\AddColumn;
+                return $action instanceof AddColumn;
             })
             ->map(function ($action) {
                 /** @var \Phinx\Db\Action\ChangeColumn|\Phinx\Db\Action\RenameColumn|\Phinx\Db\Action\RemoveColumn|\Phinx\Db\Action\AddColumn $action */

--- a/src/TableFinderTrait.php
+++ b/src/TableFinderTrait.php
@@ -110,7 +110,7 @@ trait TableFinderTrait
             return [];
         }
 
-        foreach ($tables as $num => $table) {
+        foreach ($tables as $table) {
             $list = array_merge($list, $this->fetchTableName($table, $pluginName));
         }
 

--- a/src/TestSuite/Migrator.php
+++ b/src/TestSuite/Migrator.php
@@ -17,6 +17,7 @@ use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
 use Cake\TestSuite\ConnectionHelper;
+use Exception;
 use Migrations\Migrations;
 use RuntimeException;
 
@@ -118,7 +119,7 @@ class Migrator
                         "Unable to migrate fixtures for `{$migrationSet['connection']}`."
                     );
                 }
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 throw new RuntimeException(
                     'Could not apply migrations for ' . json_encode($migrationSet) . "\n\n" .
                     "Migrations failed to apply with message:\n\n" .

--- a/templates/bake/config/diff.twig
+++ b/templates/bake/config/diff.twig
@@ -25,7 +25,7 @@ use Migrations\AbstractMigration;
 class {{ name }} extends AbstractMigration
 {
 {% if not autoId %}
-    public $autoId = false;
+    public bool $autoId = false;
 
 {% endif %}
     /**

--- a/templates/bake/config/skeleton.twig
+++ b/templates/bake/config/skeleton.twig
@@ -25,7 +25,7 @@ use Migrations\AbstractMigration;
 class {{ name }} extends AbstractMigration
 {
 {% if tableMethod == 'create' and columns['primaryKey'] %}
-    public $autoId = false;
+    public bool $autoId = false;
 
 {% endif %}
     /**

--- a/templates/bake/config/snapshot.twig
+++ b/templates/bake/config/snapshot.twig
@@ -27,7 +27,7 @@ use Migrations\AbstractMigration;
 class {{ name }} extends AbstractMigration
 {
 {% if not autoId  %}
-    public $autoId = false;
+    public bool $autoId = false;
 
 {% endif %}
     /**

--- a/tests/TestCase/Command/Phinx/CacheBuildTest.php
+++ b/tests/TestCase/Command/Phinx/CacheBuildTest.php
@@ -8,7 +8,6 @@ use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Migrations\MigrationsDispatcher;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -111,7 +110,7 @@ class CacheBuildTest extends TestCase
             $this->connection->getDriver()->connect();
         }
 
-        $input = new ArrayInput($params, $this->command->getDefinition());
+        //$input = new ArrayInput($params, $this->command->getDefinition());
         $commandTester = new CommandTester($this->command);
 
         return $commandTester;

--- a/tests/TestCase/Command/Phinx/CacheClearTest.php
+++ b/tests/TestCase/Command/Phinx/CacheClearTest.php
@@ -7,7 +7,6 @@ use Cake\Cache\Cache;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Migrations\MigrationsDispatcher;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -104,7 +103,7 @@ class CacheClearTest extends TestCase
             $this->connection->getDriver()->connect();
         }
 
-        $input = new ArrayInput($params, $this->command->getDefinition());
+        //$input = new ArrayInput($params, $this->command->getDefinition());
         $commandTester = new CommandTester($this->command);
 
         return $commandTester;

--- a/tests/TestCase/Command/Phinx/CreateTest.php
+++ b/tests/TestCase/Command/Phinx/CreateTest.php
@@ -9,6 +9,7 @@ use Cake\TestSuite\StringCompareTrait;
 use Cake\TestSuite\TestCase;
 use Migrations\CakeManager;
 use Migrations\MigrationsDispatcher;
+use Migrations\Test\CommandTester;
 use Migrations\Test\TestCase\DriverConnectionTrait;
 use Phinx\Db\Adapter\WrapperInterface;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -131,7 +132,7 @@ class CreateTest extends TestCase
         }
         $adapter->setConnection($this->getDriverConnection($this->connection->getDriver()));
         $this->command->setManager($manager);
-        $commandTester = new \Migrations\Test\CommandTester($this->command);
+        $commandTester = new CommandTester($this->command);
 
         return $commandTester;
     }

--- a/tests/TestCase/Command/Phinx/DumpTest.php
+++ b/tests/TestCase/Command/Phinx/DumpTest.php
@@ -22,6 +22,7 @@ use Cake\TestSuite\TestCase;
 use Migrations\CakeManager;
 use Migrations\Migrations;
 use Migrations\MigrationsDispatcher;
+use Migrations\Test\CommandTester;
 use Migrations\Test\TestCase\DriverConnectionTrait;
 use PDO;
 use Phinx\Db\Adapter\WrapperInterface;
@@ -166,7 +167,7 @@ class DumpTest extends TestCase
         $adapter->setConnection($this->pdo);
 
         $this->command->setManager($manager);
-        $commandTester = new \Migrations\Test\CommandTester($this->command);
+        $commandTester = new CommandTester($this->command);
 
         return $commandTester;
     }

--- a/tests/TestCase/Command/Phinx/MarkMigratedTest.php
+++ b/tests/TestCase/Command/Phinx/MarkMigratedTest.php
@@ -15,8 +15,10 @@ namespace Migrations\Test\TestCase\Command\Phinx;
 
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use Exception;
 use Migrations\CakeManager;
 use Migrations\MigrationsDispatcher;
+use Migrations\Test\CommandTester as TestCommandTester;
 use Migrations\Test\TestCase\DriverConnectionTrait;
 use PDO;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -156,14 +158,14 @@ class MarkMigratedTest extends TestCase
         $manager->expects($this->any())
             ->method('getMigrations')->will($this->returnValue($migrations));
         $manager
-            ->method('markMigrated')->will($this->throwException(new \Exception('Error during marking process')));
+            ->method('markMigrated')->will($this->throwException(new Exception('Error during marking process')));
 
         $this->connection->execute('DELETE FROM phinxlog');
 
         $application = new MigrationsDispatcher('testing');
         $buggyCommand = $application->find('mark_migrated');
         $buggyCommand->setManager($manager);
-        $buggyCommandTester = new \Migrations\Test\CommandTester($buggyCommand);
+        $buggyCommandTester = new TestCommandTester($buggyCommand);
         $buggyCommandTester->execute([
             'command' => $this->command->getName(),
             '--connection' => 'test',

--- a/tests/TestCase/Command/Phinx/SeedTest.php
+++ b/tests/TestCase/Command/Phinx/SeedTest.php
@@ -18,6 +18,7 @@ use Cake\TestSuite\TestCase;
 use Migrations\CakeManager;
 use Migrations\Migrations;
 use Migrations\MigrationsDispatcher;
+use Migrations\Test\CommandTester;
 use Migrations\Test\TestCase\DriverConnectionTrait;
 use PDO;
 use Phinx\Db\Adapter\WrapperInterface;
@@ -247,7 +248,7 @@ class SeedTest extends TestCase
         }
         $adapter->setConnection($this->pdo);
         $this->command->setManager($manager);
-        $commandTester = new \Migrations\Test\CommandTester($this->command);
+        $commandTester = new CommandTester($this->command);
 
         return $commandTester;
     }

--- a/tests/TestCase/Command/Phinx/StatusTest.php
+++ b/tests/TestCase/Command/Phinx/StatusTest.php
@@ -18,6 +18,7 @@ use Cake\TestSuite\TestCase;
 use Migrations\CakeManager;
 use Migrations\Migrations;
 use Migrations\MigrationsDispatcher;
+use Migrations\Test\CommandTester;
 use Migrations\Test\TestCase\DriverConnectionTrait;
 use PDO;
 use Phinx\Db\Adapter\WrapperInterface;
@@ -230,7 +231,7 @@ class StatusTest extends TestCase
         }
         $adapter->setConnection($this->pdo);
         $this->command->setManager($manager);
-        $commandTester = new \Migrations\Test\CommandTester($this->command);
+        $commandTester = new CommandTester($this->command);
 
         return $commandTester;
     }

--- a/tests/TestCase/ConfigurationTraitTest.php
+++ b/tests/TestCase/ConfigurationTraitTest.php
@@ -19,6 +19,8 @@ use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Migrations\Test\ExampleCommand;
+use PDO;
+use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -59,13 +61,9 @@ class ConfigurationTraitTest extends TestCase
      */
     public function testGetAdapterName()
     {
-        $mysql = $this->getMockBuilder('\Cake\Database\Driver\Mysql')->getMock();
-        $pgsql = $this->getMockBuilder('\Cake\Database\Driver\Postgres')->getMock();
-        $sqlite = $this->getMockBuilder('\Cake\Database\Driver\Sqlite')->getMock();
-
-        $this->assertEquals('mysql', $this->command->getAdapterName($mysql));
-        $this->assertEquals('pgsql', $this->command->getAdapterName($pgsql));
-        $this->assertEquals('sqlite', $this->command->getAdapterName($sqlite));
+        $this->assertEquals('mysql', $this->command->getAdapterName('\Cake\Database\Driver\Mysql'));
+        $this->assertEquals('pgsql', $this->command->getAdapterName('\Cake\Database\Driver\Postgres'));
+        $this->assertEquals('sqlite', $this->command->getAdapterName('\Cake\Database\Driver\Sqlite'));
     }
 
     /**
@@ -88,9 +86,9 @@ class ConfigurationTraitTest extends TestCase
             'ssl_key' => 'ssl_key_value',
             'ssl_cert' => 'ssl_cert_value',
             'flags' => [
-                \PDO::ATTR_EMULATE_PREPARES => true,
-                \PDO::MYSQL_ATTR_SSL_CA => 'flags do not overwrite config',
-                \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
+                PDO::ATTR_EMULATE_PREPARES => true,
+                PDO::MYSQL_ATTR_SSL_CA => 'flags do not overwrite config',
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
             ],
         ]);
 
@@ -307,12 +305,12 @@ class ConfigurationTraitTest extends TestCase
         $seedsPath = ROOT . DS . 'config' . DS . 'TestGetConfigSeeds';
 
         $command = $this->_getCommandMock($migrationsPath, $seedsPath);
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf(
             'Migrations path `%s` does not exist and cannot be created because `debug` is disabled.',
             $migrationsPath
         ));
-        $config = $command->getConfig();
+        $command->getConfig();
     }
 
     /**
@@ -340,7 +338,7 @@ class ConfigurationTraitTest extends TestCase
         $command = $this->_getCommandMock($migrationsPath, $seedsPath);
         $this->assertFalse(is_dir($seedsPath));
         try {
-            $config = $command->getConfig();
+            $command->getConfig();
         } finally {
             rmdir($migrationsPath);
         }
@@ -369,7 +367,7 @@ class ConfigurationTraitTest extends TestCase
 
         $command = $this->_getCommandMock($migrationsPath, $seedsPath);
 
-        $config = $command->getConfig();
+        $command->getConfig();
 
         $this->assertTrue(is_dir($migrationsPath));
         $this->assertTrue(is_dir($seedsPath));

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -16,6 +16,8 @@ namespace Migrations\Test\TestCase;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use Exception;
+use InvalidArgumentException;
 use Migrations\CakeAdapter;
 use Migrations\Migrations;
 use Phinx\Db\Adapter\WrapperInterface;
@@ -378,7 +380,7 @@ class MigrationsTest extends TestCase
      */
     public function testMarkMigratedTargetError()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Migration `20150704160610` was not found !');
         $this->migrations->markMigrated(null, ['target' => '20150704160610']);
     }
@@ -475,7 +477,7 @@ class MigrationsTest extends TestCase
      */
     public function testMarkMigratedTargetExcludeOnly()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('You should use `exclude` OR `only` (not both) along with a `target` argument');
         $this->migrations->markMigrated(null, ['target' => '20150724233100', 'only' => true, 'exclude' => true]);
     }
@@ -954,7 +956,7 @@ class MigrationsTest extends TestCase
      */
     public function testSeedWrongSeed()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The seed class "DerpSeed" does not exist');
         $this->migrations->seed(['source' => 'AltSeeds', 'seed' => 'DerpSeed']);
     }
@@ -1005,7 +1007,7 @@ class MigrationsTest extends TestCase
      */
     public function testMigrateErrors()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->migrations->markMigrated(20150704160200);
         $this->migrations->migrate();
     }
@@ -1015,7 +1017,7 @@ class MigrationsTest extends TestCase
      */
     public function testRollbackErrors()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->migrations->markMigrated('all');
         $this->migrations->rollback();
     }
@@ -1026,7 +1028,7 @@ class MigrationsTest extends TestCase
      */
     public function testMarkMigratedErrors()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->migrations->markMigrated(20150704000000);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,11 +12,16 @@ declare(strict_types=1);
  * @license       https://www.opensource.org/licenses/mit-license.php MIT License
  */
 
+use Bake\BakePlugin;
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\Routing\Router;
 use Cake\TestSuite\Fixture\SchemaLoader;
+use Migrations\MigrationsPlugin;
+use Snapshot\Plugin as SnapshotPlugin;
+use TestBlog\Plugin as TestBlogPlugin;
 use function Cake\Core\env;
 
 $findRoot = function ($root) {
@@ -62,7 +67,7 @@ Configure::write('App', [
     ],
 ]);
 
-Cake\Cache\Cache::setConfig([
+Cache::setConfig([
     '_cake_core_' => [
         'engine' => 'File',
         'prefix' => 'cake_core_',
@@ -105,10 +110,10 @@ if (getenv('DB_URL_COMPARE') !== false) {
     ]);
 }
 
-Plugin::getCollection()->add(new \Migrations\MigrationsPlugin());
-Plugin::getCollection()->add(new \Bake\BakePlugin());
-Plugin::getCollection()->add(new \Snapshot\Plugin());
-Plugin::getCollection()->add(new \TestBlog\Plugin());
+Plugin::getCollection()->add(new MigrationsPlugin());
+Plugin::getCollection()->add(new BakePlugin());
+Plugin::getCollection()->add(new SnapshotPlugin());
+Plugin::getCollection()->add(new TestBlogPlugin());
 
 if (!defined('PHINX_VERSION')) {
     define('PHINX_VERSION', strpos('@PHINX_VERSION@', '@PHINX_VERSION') === 0 ? 'UNKNOWN' : '@PHINX_VERSION@');

--- a/tests/comparisons/Diff/withAutoIdIncompatibleSignedPrimaryKeys/the_diff_with_auto_id_incompatible_signed_primary_keys_mysql.php
+++ b/tests/comparisons/Diff/withAutoIdIncompatibleSignedPrimaryKeys/the_diff_with_auto_id_incompatible_signed_primary_keys_mysql.php
@@ -5,7 +5,7 @@ use Migrations\AbstractMigration;
 
 class TheDiffWithAutoIdIncompatibleSignedPrimaryKeysMysql extends AbstractMigration
 {
-    public $autoId = false;
+    public bool $autoId = false;
 
     /**
      * Up Method.

--- a/tests/comparisons/Diff/withAutoIdIncompatibleUnsignedPrimaryKeys/the_diff_with_auto_id_incompatible_unsigned_primary_keys_mysql.php
+++ b/tests/comparisons/Diff/withAutoIdIncompatibleUnsignedPrimaryKeys/the_diff_with_auto_id_incompatible_unsigned_primary_keys_mysql.php
@@ -5,7 +5,7 @@ use Migrations\AbstractMigration;
 
 class TheDiffWithAutoIdIncompatibleUnsignedPrimaryKeysMysql extends AbstractMigration
 {
-    public $autoId = false;
+    public bool $autoId = false;
 
     /**
      * Up Method.

--- a/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
@@ -5,7 +5,7 @@ use Migrations\AbstractMigration;
 
 class TestSnapshotAutoIdDisabledPgsql extends AbstractMigration
 {
-    public $autoId = false;
+    public bool $autoId = false;
 
     /**
      * Up Method.

--- a/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
@@ -5,7 +5,7 @@ use Migrations\AbstractMigration;
 
 class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
 {
-    public $autoId = false;
+    public bool $autoId = false;
 
     /**
      * Up Method.

--- a/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
@@ -69,7 +69,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'category_id',
                 ],
                 [
-                    'name' => 'category_id_fk',
+                    'name' => 'category_id_0_fk',
                 ]
             )
             ->addIndex(
@@ -120,7 +120,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'sqlite_autoindex_categories_1',
+                    'name' => 'categories_unique_slug',
                     'unique' => true,
                 ]
             )
@@ -189,7 +189,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category_fk',
+                    'name' => 'product_category_product_id_0_fk',
                 ]
             )
             ->create();
@@ -253,7 +253,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'id',
                 ],
                 [
-                    'name' => 'sqlite_autoindex_products_2',
+                    'name' => 'products_category_unique',
                     'unique' => true,
                 ]
             )
@@ -262,7 +262,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'sqlite_autoindex_products_1',
+                    'name' => 'products_unique_slug',
                     'unique' => true,
                 ]
             )
@@ -271,7 +271,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'category_id',
                 ],
                 [
-                    'name' => 'category_id_fk',
+                    'name' => 'category_id_0_fk',
                 ]
             )
             ->addIndex(
@@ -336,7 +336,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                     'article_id',
                 ],
                 [
-                    'name' => 'sqlite_autoindex_special_tags_1',
+                    'name' => 'UNIQUE_TAG2',
                     'unique' => true,
                 ]
             )
@@ -393,7 +393,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
-                    'constraint' => 'category_id_fk'
+                    'constraint' => 'category_id_0_fk'
                 ]
             )
             ->update();
@@ -412,7 +412,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'product_category_fk'
+                    'constraint' => 'product_category_product_id_0_fk'
                 ]
             )
             ->update();
@@ -425,7 +425,7 @@ class TestSnapshotAutoIdDisabledSqlite extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'category_id_fk'
+                    'constraint' => 'category_id_0_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
@@ -60,7 +60,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'category_id',
                 ],
                 [
-                    'name' => 'category_id_fk',
+                    'name' => 'category_id_0_fk',
                 ]
             )
             ->addIndex(
@@ -104,7 +104,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'sqlite_autoindex_categories_1',
+                    'name' => 'categories_unique_slug',
                     'unique' => true,
                 ]
             )
@@ -158,7 +158,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'product_id',
                 ],
                 [
-                    'name' => 'product_category_fk',
+                    'name' => 'product_category_product_id_0_fk',
                 ]
             )
             ->create();
@@ -208,7 +208,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'id',
                 ],
                 [
-                    'name' => 'sqlite_autoindex_products_2',
+                    'name' => 'products_category_unique',
                     'unique' => true,
                 ]
             )
@@ -217,7 +217,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'sqlite_autoindex_products_1',
+                    'name' => 'products_unique_slug',
                     'unique' => true,
                 ]
             )
@@ -226,7 +226,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'category_id',
                 ],
                 [
-                    'name' => 'category_id_fk',
+                    'name' => 'category_id_0_fk',
                 ]
             )
             ->addIndex(
@@ -283,7 +283,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                     'article_id',
                 ],
                 [
-                    'name' => 'sqlite_autoindex_special_tags_1',
+                    'name' => 'UNIQUE_TAG2',
                     'unique' => true,
                 ]
             )
@@ -333,7 +333,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
-                    'constraint' => 'category_id_fk'
+                    'constraint' => 'category_id_0_fk'
                 ]
             )
             ->update();
@@ -352,7 +352,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'product_category_fk'
+                    'constraint' => 'product_category_product_id_0_fk'
                 ]
             )
             ->update();
@@ -365,7 +365,7 @@ class TestSnapshotNotEmptySqlite extends AbstractMigration
                 [
                     'update' => 'CASCADE',
                     'delete' => 'CASCADE',
-                    'constraint' => 'category_id_fk'
+                    'constraint' => 'category_id_0_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
@@ -60,7 +60,7 @@ class TestSnapshotPluginBlogSqlite extends AbstractMigration
                     'category_id',
                 ],
                 [
-                    'name' => 'category_id_fk',
+                    'name' => 'category_id_0_fk',
                 ]
             )
             ->addIndex(
@@ -104,7 +104,7 @@ class TestSnapshotPluginBlogSqlite extends AbstractMigration
                     'slug',
                 ],
                 [
-                    'name' => 'sqlite_autoindex_categories_1',
+                    'name' => 'categories_unique_slug',
                     'unique' => true,
                 ]
             )
@@ -131,7 +131,7 @@ class TestSnapshotPluginBlogSqlite extends AbstractMigration
                 [
                     'update' => 'NO_ACTION',
                     'delete' => 'NO_ACTION',
-                    'constraint' => 'category_id_fk'
+                    'constraint' => 'category_id_0_fk'
                 ]
             )
             ->update();

--- a/tests/comparisons/Migration/testCreatePrimaryKey.php
+++ b/tests/comparisons/Migration/testCreatePrimaryKey.php
@@ -5,7 +5,7 @@ use Migrations\AbstractMigration;
 
 class CreateUsers extends AbstractMigration
 {
-    public $autoId = false;
+    public bool $autoId = false;
 
     /**
      * Change Method.

--- a/tests/comparisons/Migration/testCreatePrimaryKeyUuid.php
+++ b/tests/comparisons/Migration/testCreatePrimaryKeyUuid.php
@@ -5,7 +5,7 @@ use Migrations\AbstractMigration;
 
 class CreateUsers extends AbstractMigration
 {
-    public $autoId = false;
+    public bool $autoId = false;
 
     /**
      * Change Method.

--- a/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
+++ b/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
@@ -5,7 +5,7 @@ use Migrations\AbstractMigration;
 
 class TestSnapshotAutoIdDisabled extends AbstractMigration
 {
-    public $autoId = false;
+    public bool $autoId = false;
 
     /**
      * Up Method.

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_signed_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_signed_primary_keys.php
@@ -5,7 +5,7 @@ use Migrations\AbstractMigration;
 
 class TestSnapshotWithAutoIdIncompatibleSignedPrimaryKeys extends AbstractMigration
 {
-    public $autoId = false;
+    public bool $autoId = false;
 
     /**
      * Up Method.

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_unsigned_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_unsigned_primary_keys.php
@@ -5,7 +5,7 @@ use Migrations\AbstractMigration;
 
 class TestSnapshotWithAutoIdIncompatibleUnsignedPrimaryKeys extends AbstractMigration
 {
-    public $autoId = false;
+    public bool $autoId = false;
 
     /**
      * Up Method.

--- a/tests/test_app/config/MigrationsDiffWithAutoIdIncompatibleSignedPrimaryKeys/20151218183450_CreateArticlesWithAutoIdIncompatibleSignedPrimaryKeys.php
+++ b/tests/test_app/config/MigrationsDiffWithAutoIdIncompatibleSignedPrimaryKeys/20151218183450_CreateArticlesWithAutoIdIncompatibleSignedPrimaryKeys.php
@@ -4,7 +4,7 @@ use Migrations\AbstractMigration;
 
 class CreateArticlesWithAutoIdIncompatibleSignedPrimaryKeys extends AbstractMigration
 {
-    public $autoId = false;
+    public bool $autoId = false;
 
     public function change(): void
     {

--- a/tests/test_app/config/MigrationsDiffWithAutoIdIncompatibleUnsignedPrimaryKeys/20151218183450_CreateArticlesWithAutoIdIncompatibleUnsignedPrimaryKeys.php
+++ b/tests/test_app/config/MigrationsDiffWithAutoIdIncompatibleUnsignedPrimaryKeys/20151218183450_CreateArticlesWithAutoIdIncompatibleUnsignedPrimaryKeys.php
@@ -4,7 +4,7 @@ use Migrations\AbstractMigration;
 
 class CreateArticlesWithAutoIdIncompatibleUnsignedPrimaryKeys extends AbstractMigration
 {
-    public $autoId = false;
+    public bool $autoId = false;
 
     public function change(): void
     {

--- a/tests/test_app/config/TestsMigrations/20150826191400_create_letters_table.php
+++ b/tests/test_app/config/TestsMigrations/20150826191400_create_letters_table.php
@@ -4,7 +4,7 @@ use Migrations\AbstractMigration;
 
 class CreateLettersTable extends AbstractMigration
 {
-    public $autoId = false;
+    public bool $autoId = false;
 
     public function change(): void
     {


### PR DESCRIPTION
There is a bug in PostgresAdapter::setConnection() where `useIdentity` isn't initialized. Testing with branch until fix is released.

https://github.com/cakephp/phinx/pull/2223