### PR TITLE
Fix MigrationHelper.php throwing Exception

### DIFF
--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -17,7 +17,7 @@ use ArrayAccess;
 use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
-use Cake\Database\Schema\Collection;
+use Cake\Database\Schema\CollectionInterface;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
@@ -156,7 +156,7 @@ class MigrationHelper extends Helper
         }
 
         $collection = $this->getConfig('collection');
-        assert($collection instanceof Collection);
+        assert($collection instanceof CollectionInterface);
         $schema = $collection->describe($table);
         $this->schemas[$table] = $schema;
 


### PR DESCRIPTION
I noticed sometimes it is using`Cake\Database\Schema\CachedCollection` and not `Cake\Database\Schema\Collection`.

This is what I tried.

```
bin/cake bake migration_snapshot Initial
```

Which was throwing exception as in screenshot given below .

<img width="817" alt="image" src="https://github.com/cakephp/migrations/assets/120454/23940710-1942-4782-9495-dde7253a99ec">
