### PR TITLE
Fix Phinx Feature Flags Link Syntax

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -997,7 +997,7 @@ Set them via Configure to enable (e.g. in ``config/app.php``)::
         'column_null_default' => true,
     ],
 
-For details see `Phinx docs<https://book.cakephp.org/phinx/0/en/configuration.html#feature-flags>`__.
+For details see `Phinx documentation <https://book.cakephp.org/phinx/0/en/configuration.html#feature-flags>`_.
 
 Tips and tricks
 ===============


### PR DESCRIPTION
The current link is not being rendered correctly. This PR should fix it.
![image](https://github.com/cakephp/migrations/assets/3212673/87219f02-d71a-4d2e-8d7a-5de561ed4ad0)

I tried searching for other links that have this same issue with the following command. I didn't find any others.
```sh
grep '`.\+[^ ]<.\+>`' docs/**/*.rst
```

This issue also exists on the 3.x branch. Should I create a separate PR to fix that, or is there a different procedure to backport this change?