### PR TITLE
initial snapshot does not define collation info

### DIFF
--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -390,6 +390,7 @@ class MigrationHelper extends Helper
             'autoIncrement',
             'precision',
             'after',
+            'collate',
         ]);
         $columnOptions = array_intersect_key($options, $wantedOptions);
         if (empty($columnOptions['comment'])) {
@@ -403,6 +404,12 @@ class MigrationHelper extends Helper
         $isMysql = $connection->getDriver() instanceof Mysql;
         if (!$isMysql) {
             unset($columnOptions['signed']);
+        }
+
+        if ($isMysql && !empty($columnOptions['collate'])) {
+            // due to Phinx using different naming for the collation
+            $columnOptions['collation'] = $columnOptions['collate'];
+            unset($columnOptions['collate']);
         }
 
         if ($columnOptions['precision'] === null) {
@@ -476,6 +483,7 @@ class MigrationHelper extends Helper
             'comment', 'unsigned',
             'signed', 'properties',
             'autoIncrement', 'unique',
+            'collate',
         ];
 
         $attributes = [];
@@ -514,6 +522,11 @@ class MigrationHelper extends Helper
         $isMysql = $connection->getDriver() instanceof Mysql;
         if (!$isMysql) {
             unset($attributes['signed']);
+        }
+
+        $defaultCollation = $tableSchema->getOptions()['collation'];
+        if (empty($attributes['collate']) || $attributes['collate'] == $defaultCollation) {
+            unset($attributes['collate']);
         }
 
         ksort($attributes);

--- a/tests/TestCase/Command/BakeMigrationSnapshotCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationSnapshotCommandTest.php
@@ -307,4 +307,21 @@ class BakeMigrationSnapshotCommandTest extends TestCase
             $this->assertSameAsFile($bakeName . '.php', $result);
         }
     }
+
+    /**
+     * Tests that non default collation is used in the initial snapshot.
+     */
+    public function testSnapshotWithNonDefaultCollation(): void
+    {
+        $this->skipIf(env('DB') !== 'mysql');
+
+        $this->migrationPath = ROOT . DS . 'Plugin' . DS . 'SimpleSnapshot' . DS . 'config' . DS . 'Migrations' . DS;
+
+        $connection = ConnectionManager::get('test');
+        assert($connection instanceof Connection);
+
+        $connection->execute('ALTER TABLE events MODIFY title VARCHAR(255) CHARACTER SET utf8 COLLATE utf8mb3_hungarian_ci');
+        $this->runSnapshotTest('WithNonDefaultCollation', '-p SimpleSnapshot');
+        $connection->execute('ALTER TABLE events MODIFY title VARCHAR(255)');
+    }
 }

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -1061,6 +1061,7 @@ class MigrationsTest extends TestCase
                 [$path, 'test_snapshot_with_auto_id_compatible_signed_primary_keys', ['unsigned_primary_keys' => false]],
                 [$path, 'test_snapshot_with_auto_id_incompatible_signed_primary_keys'],
                 [$path, 'test_snapshot_with_auto_id_incompatible_unsigned_primary_keys', ['unsigned_primary_keys' => false]],
+                [$path, 'test_snapshot_with_non_default_collation'],
             ];
         }
 

--- a/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
+++ b/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
@@ -29,6 +29,7 @@ class TheDiffAddRemoveMysql extends AbstractMigration
         $this->table('articles')
             ->addColumn('the_text', 'text', [
                 'after' => 'title',
+                'collation' => 'utf8mb4_0900_ai_ci',
                 'default' => null,
                 'length' => null,
                 'null' => false,

--- a/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
+++ b/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
@@ -50,6 +50,7 @@ class TheDiffAddRemoveMysql extends AbstractMigration
         $this->table('articles')
             ->addColumn('excerpt', 'text', [
                 'after' => 'title',
+                'collation' => 'utf8_general_ci',
                 'default' => null,
                 'length' => null,
                 'null' => false,

--- a/tests/comparisons/Diff/default/the_diff_default_mysql.php
+++ b/tests/comparisons/Diff/default/the_diff_default_mysql.php
@@ -201,6 +201,7 @@ class TheDiffDefaultMysql extends AbstractMigration
         $this->table('articles')
             ->addColumn('content', 'text', [
                 'after' => 'rating',
+                'collation' => 'utf8_general_ci',
                 'default' => null,
                 'length' => null,
                 'null' => false,
@@ -212,6 +213,7 @@ class TheDiffDefaultMysql extends AbstractMigration
                 'null' => false,
             ])
             ->changeColumn('title', 'string', [
+                'collation' => 'utf8_general_ci',
                 'default' => null,
                 'length' => 255,
                 'null' => false,
@@ -222,6 +224,7 @@ class TheDiffDefaultMysql extends AbstractMigration
                 'null' => false,
             ])
             ->changeColumn('name', 'string', [
+                'collation' => 'utf8_general_ci',
                 'default' => null,
                 'length' => 255,
                 'null' => false,

--- a/tests/comparisons/Migration/test_snapshot_with_non_default_collation.php
+++ b/tests/comparisons/Migration/test_snapshot_with_non_default_collation.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+
+class TestSnapshotWithNonDefaultCollation extends AbstractMigration
+{
+    /**
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * @return void
+     */
+    public function up(): void
+    {
+        $this->table('events')
+            ->addColumn('title', 'string', [
+                'collation' => 'utf8mb3_hungarian_ci',
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('published', 'string', [
+                'default' => 'N',
+                'limit' => 1,
+                'null' => true,
+            ])
+            ->create();
+    }
+
+    /**
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * @return void
+     */
+    public function down(): void
+    {
+        $this->table('events')->drop()->save();
+    }
+}


### PR DESCRIPTION
This PR is intended to fix https://github.com/cakephp/phinx/issues/2225

cleaned out for https://github.com/cakephp/migrations/pull/645