### PR TITLE
Make compatible with latest Phinx version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "robmorgan/phinx": "^0.15.2",
+        "robmorgan/phinx": "^0.15.3",
         "cakephp/orm": "^5.0",
         "cakephp/cache": "^5.0"
     },

--- a/src/Table.php
+++ b/src/Table.php
@@ -62,7 +62,7 @@ class Table extends BaseTable
      * @throws \InvalidArgumentException
      * @return $this
      */
-    public function addColumn(Column|string $columnName, string|Literal|null $type, $options = [])
+    public function addColumn(Column|string $columnName, string|Literal|null $type = null, $options = [])
     {
         $options = $this->convertedAutoIncrement($options);
 


### PR DESCRIPTION
A composer update, updated phinx which caused an error in unit testing:
```
HP Fatal error:  Declaration of Migrations\Table::addColumn(Phinx\Db\Table\Column|string $columnName, Phinx\Util\Literal|string|null $type, $options = []) must be compatible with Phinx\Db\Table::addColumn(Phinx\Db\Table\Column|string $columnName, Phinx\Util\Literal|string|null $type = null, array $options = []) in vendor/cakephp/migrations/src/Table.php on line 65
```
