### PR TITLE
Add force-autoid config.

### DIFF
--- a/src/Command/BakeMigrationSnapshotCommand.php
+++ b/src/Command/BakeMigrationSnapshotCommand.php
@@ -105,6 +105,10 @@ class BakeMigrationSnapshotCommand extends BakeSimpleMigrationCommand
         if ($arguments->hasOption('disable-autoid')) {
             $autoId = !$arguments->getOption('disable-autoid');
         }
+        $forceAutoId = false;
+        if ($arguments->hasOption('force-autoid')) {
+            $forceAutoId = !$arguments->getOption('force-autoid');
+        }
 
         return [
             'plugin' => $this->plugin,
@@ -115,6 +119,7 @@ class BakeMigrationSnapshotCommand extends BakeSimpleMigrationCommand
             'action' => 'create_table',
             'name' => $this->_name,
             'autoId' => $autoId,
+            'forceAutoId' => $forceAutoId,
         ];
     }
 
@@ -171,6 +176,10 @@ class BakeMigrationSnapshotCommand extends BakeSimpleMigrationCommand
             'boolean' => true,
             'default' => false,
             'help' => 'Disable phinx behavior of automatically adding an id field.',
+        ])->addOption('force-autoid', [
+            'boolean' => true,
+            'default' => false,
+            'help' => 'Force automatically adding an id field. This will overwrite the disable-autoid option and ignore signed integers.',
         ])
         ->addOption('no-lock', [
             'help' => 'If present, no lock file will be generated after baking',

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -308,7 +308,7 @@ class MigrationHelper extends Helper
             return false;
         }
 
-        $useUnsignedPrimaryKes = Configure::read(
+        $useUnsignedPrimaryKeys = Configure::read(
             'Migrations.unsigned_primary_keys',
             FeatureFlags::$unsignedPrimaryKeys
         );
@@ -321,7 +321,7 @@ class MigrationHelper extends Helper
 
             foreach ($schema->getPrimaryKey() as $column) {
                 $data = $schema->getColumn($column);
-                if (isset($data['unsigned']) && $data['unsigned'] === !$useUnsignedPrimaryKes) {
+                if (isset($data['unsigned']) && $data['unsigned'] === !$useUnsignedPrimaryKeys) {
                     return true;
                 }
             }

--- a/templates/bake/config/diff.twig
+++ b/templates/bake/config/diff.twig
@@ -15,7 +15,7 @@
 #}
 {% set tables = data['fullTables'] %}
 {% set constraints = [] %}
-{% set autoId = forceAutoId OR not Migration.hasAutoIdIncompatiblePrimaryKey(tables['add'] + tables['remove']) %}
+{% set autoId = not Migration.hasAutoIdIncompatiblePrimaryKey(tables['add'] + tables['remove']) %}
 <?php
 declare(strict_types=1);
 

--- a/templates/bake/config/diff.twig
+++ b/templates/bake/config/diff.twig
@@ -14,9 +14,8 @@
 */
 #}
 {% set tables = data['fullTables'] %}
-{# unset($data['fullTables']) #}
 {% set constraints = [] %}
-{% set autoId = not Migration.hasAutoIdIncompatiblePrimaryKey(tables['add'] + tables['remove']) %}
+{% set autoId = forceAutoId OR not Migration.hasAutoIdIncompatiblePrimaryKey(tables['add'] + tables['remove']) %}
 <?php
 declare(strict_types=1);
 

--- a/templates/bake/config/snapshot.twig
+++ b/templates/bake/config/snapshot.twig
@@ -26,7 +26,7 @@ use Migrations\AbstractMigration;
 
 class {{ name }} extends AbstractMigration
 {
-{% if not autoId  %}
+{% if not autoId and not forceAutoId %}
     public bool $autoId = false;
 
 {% endif %}

--- a/templates/bake/config/snapshot.twig
+++ b/templates/bake/config/snapshot.twig
@@ -16,7 +16,7 @@
 {% set constraints = [] %}
 {% set foreignKeys = [] %}
 {% set dropForeignKeys = [] %}
-{% if autoId and Migration.hasAutoIdIncompatiblePrimaryKey(tables) %}
+{% if not forceAutoId and autoId and Migration.hasAutoIdIncompatiblePrimaryKey(tables) %}
 {%     set autoId = false %}
 {% endif %}
 <?php


### PR DESCRIPTION
With the

    'Migrations.unsigned_primary_keys'

we introduced some issues around baking a fresh snapshot.
The autoid gets cancelled with the slightest issue for ALL tables, making it super hard to clean that up.

I would like to propose a force-autoid config that allows to overwrite the "detected" one for those that want/need it.

I didnt quite figure out the proper twig syntax
Apprently this doesnt do it:

    set autoId = forceAutoId OR not Migration.hasAutoIdIncompatiblePrimaryKey(tables['add'] + tables['remove'])

Any ideas?

Even setting it to

    {% set autoId = true %}
    
doesnt work, is there some weird extra cache involved?

---

Alternatively, we could see if hasAutoIdIncompatiblePrimaryKey() could be applied per table, instead of per file.


Refs https://github.com/cakephp/bake/issues/962