### PR TITLE
Import sqlite adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         if: matrix.db-type == 'mysql'
         run: |
           sudo service mysql start
-          mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_test DEFAULT COLLATE=utf8mb4_general_ci;'
+          mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_test CHARACTER SET = utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;'
           mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_comparisons;'
           mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_snapshot;'
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,6 +36,11 @@ parameters:
 			path: src/Db/Adapter/PdoAdapter.php
 
 		-
+			message: "#^Offset 'id' on array\\<string, mixed\\> in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 2
+			path: src/Db/Adapter/SqliteAdapter.php
+
+		-
 			message: "#^Possibly invalid array key type Cake\\\\Database\\\\Schema\\\\TableSchemaInterface\\|string\\.$#"
 			count: 2
 			path: src/View/Helper/MigrationHelper.php

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1153,7 +1153,8 @@ PCRE_PATTERN;
 
         if ($columnName && !$found) {
             throw new InvalidArgumentException(sprintf(
-                'The specified column doesn\'t exist: %s', $columnName
+                'The specified column doesn\'t exist: %s',
+                $columnName
             ));
         }
 

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1,0 +1,1984 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Migrations\Db\Adapter;
+
+use BadMethodCallException;
+use Cake\Database\Connection;
+use Cake\Database\Driver\Sqlite as SqliteDriver;
+use InvalidArgumentException;
+use Migrations\Db\AlterInstructions;
+use Migrations\Db\Expression;
+use Migrations\Db\Literal;
+use Migrations\Db\Table\Column;
+use Migrations\Db\Table\ForeignKey;
+use Migrations\Db\Table\Index;
+use Migrations\Db\Table\Table;
+use PDO;
+use PDOException;
+use RuntimeException;
+use const FILTER_VALIDATE_BOOLEAN;
+
+/**
+ * Migrations SQLite Adapter.
+ */
+class SqliteAdapter extends PdoAdapter
+{
+    public const MEMORY = ':memory:';
+
+    /**
+     * List of supported Phinx column types with their SQL equivalents
+     * some types have an affinity appended to ensure they do not receive NUMERIC affinity
+     *
+     * @var string[]
+     */
+    protected static array $supportedColumnTypes = [
+        self::PHINX_TYPE_BIG_INTEGER => 'biginteger',
+        self::PHINX_TYPE_BINARY => 'binary_blob',
+        self::PHINX_TYPE_BINARYUUID => 'uuid_blob',
+        self::PHINX_TYPE_BLOB => 'blob',
+        self::PHINX_TYPE_BOOLEAN => 'boolean_integer',
+        self::PHINX_TYPE_CHAR => 'char',
+        self::PHINX_TYPE_DATE => 'date_text',
+        self::PHINX_TYPE_DATETIME => 'datetime_text',
+        self::PHINX_TYPE_DECIMAL => 'decimal',
+        self::PHINX_TYPE_DOUBLE => 'double',
+        self::PHINX_TYPE_FLOAT => 'float',
+        self::PHINX_TYPE_INTEGER => 'integer',
+        self::PHINX_TYPE_JSON => 'json_text',
+        self::PHINX_TYPE_JSONB => 'jsonb_text',
+        self::PHINX_TYPE_SMALL_INTEGER => 'smallinteger',
+        self::PHINX_TYPE_STRING => 'varchar',
+        self::PHINX_TYPE_TEXT => 'text',
+        self::PHINX_TYPE_TIME => 'time_text',
+        self::PHINX_TYPE_TIMESTAMP => 'timestamp_text',
+        self::PHINX_TYPE_TINY_INTEGER => 'tinyinteger',
+        self::PHINX_TYPE_UUID => 'uuid_text',
+        self::PHINX_TYPE_VARBINARY => 'varbinary_blob',
+    ];
+
+    /**
+     * List of aliases of supported column types
+     *
+     * @var string[]
+     */
+    protected static array $supportedColumnTypeAliases = [
+        'varchar' => self::PHINX_TYPE_STRING,
+        'tinyint' => self::PHINX_TYPE_TINY_INTEGER,
+        'tinyinteger' => self::PHINX_TYPE_TINY_INTEGER,
+        'smallint' => self::PHINX_TYPE_SMALL_INTEGER,
+        'int' => self::PHINX_TYPE_INTEGER,
+        'mediumint' => self::PHINX_TYPE_INTEGER,
+        'mediuminteger' => self::PHINX_TYPE_INTEGER,
+        'bigint' => self::PHINX_TYPE_BIG_INTEGER,
+        'tinytext' => self::PHINX_TYPE_TEXT,
+        'mediumtext' => self::PHINX_TYPE_TEXT,
+        'longtext' => self::PHINX_TYPE_TEXT,
+        'tinyblob' => self::PHINX_TYPE_BLOB,
+        'mediumblob' => self::PHINX_TYPE_BLOB,
+        'longblob' => self::PHINX_TYPE_BLOB,
+        'real' => self::PHINX_TYPE_FLOAT,
+    ];
+
+    /**
+     * List of known but unsupported Phinx column types
+     *
+     * @var string[]
+     */
+    protected static array $unsupportedColumnTypes = [
+        self::PHINX_TYPE_BIT,
+        self::PHINX_TYPE_CIDR,
+        self::PHINX_TYPE_ENUM,
+        self::PHINX_TYPE_FILESTREAM,
+        self::PHINX_TYPE_GEOMETRY,
+        self::PHINX_TYPE_INET,
+        self::PHINX_TYPE_INTERVAL,
+        self::PHINX_TYPE_LINESTRING,
+        self::PHINX_TYPE_MACADDR,
+        self::PHINX_TYPE_POINT,
+        self::PHINX_TYPE_POLYGON,
+        self::PHINX_TYPE_SET,
+    ];
+
+    /**
+     * @var string[]
+     */
+    protected array $definitionsWithLimits = [
+        'CHAR',
+        'CHARACTER',
+        'VARCHAR',
+        'VARYING CHARACTER',
+        'NCHAR',
+        'NATIVE CHARACTER',
+        'NVARCHAR',
+    ];
+
+    /**
+     * @var string
+     */
+    protected string $suffix = '.sqlite3';
+
+    /**
+     * Indicates whether the database library version is at least the specified version
+     *
+     * @param string $ver The version to check against e.g. '3.28.0'
+     * @return bool
+     */
+    public function databaseVersionAtLeast(string $ver): bool
+    {
+        $actual = $this->query('SELECT sqlite_version()')->fetchColumn();
+
+        return version_compare($actual, $ver, '>=');
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    public function connect(): void
+    {
+        if ($this->connection === null) {
+            if (!class_exists('PDO') || !in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+                // @codeCoverageIgnoreStart
+                throw new RuntimeException('You need to enable the PDO_SQLITE extension for Migrations to run properly.');
+                // @codeCoverageIgnoreEnd
+            }
+
+            $options = $this->getOptions();
+
+            if (PHP_VERSION_ID < 80100 && (!empty($options['mode']) || !empty($options['cache']))) {
+                throw new RuntimeException('SQLite URI support requires PHP 8.1.');
+            } elseif ((!empty($options['mode']) || !empty($options['cache'])) && !empty($options['memory'])) {
+                throw new RuntimeException('Memory must not be set when cache or mode are.');
+            } elseif (PHP_VERSION_ID >= 80100 && (!empty($options['mode']) || !empty($options['cache']))) {
+                $params = [];
+                if (!empty($options['cache'])) {
+                    $params[] = 'cache=' . $options['cache'];
+                }
+                if (!empty($options['mode'])) {
+                    $params[] = 'mode=' . $options['mode'];
+                }
+                $dsn = 'sqlite:file:' . ($options['name'] ?? '') . '?' . implode('&', $params);
+            } else {
+                // use a memory database if the option was specified
+                if (!empty($options['memory']) || $options['name'] === static::MEMORY) {
+                    $dsn = 'sqlite:' . static::MEMORY;
+                } else {
+                    $dsn = 'sqlite:' . $options['name'] . $this->suffix;
+                }
+            }
+
+            $driverOptions = [];
+
+            // use custom data fetch mode
+            if (!empty($options['fetch_mode'])) {
+                $driverOptions[PDO::ATTR_DEFAULT_FETCH_MODE] = constant('\PDO::FETCH_' . strtoupper($options['fetch_mode']));
+            }
+
+            // pass \PDO::ATTR_PERSISTENT to driver options instead of useless setting it after instantiation
+            if (isset($options['attr_persistent'])) {
+                $driverOptions[PDO::ATTR_PERSISTENT] = $options['attr_persistent'];
+            }
+
+            $db = $this->createPdoConnection($dsn, null, null, $driverOptions);
+
+            $this->setConnection($db);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setOptions(array $options): AdapterInterface
+    {
+        parent::setOptions($options);
+
+        if (isset($options['suffix'])) {
+            $this->suffix = $options['suffix'];
+        }
+        //don't "fix" the file extension if it is blank, some people
+        //might want a SQLITE db file with absolutely no extension.
+        if ($this->suffix !== '' && strpos($this->suffix, '.') !== 0) {
+            $this->suffix = '.' . $this->suffix;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function disconnect(): void
+    {
+        $this->connection = null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasTransactions(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function beginTransaction(): void
+    {
+        $this->getConnection()->beginTransaction();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function commitTransaction(): void
+    {
+        $this->getConnection()->commit();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function rollbackTransaction(): void
+    {
+        $this->getConnection()->rollBack();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function quoteTableName($tableName): string
+    {
+        return str_replace('.', '`.`', $this->quoteColumnName($tableName));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function quoteColumnName($columnName): string
+    {
+        return '`' . str_replace('`', '``', $columnName) . '`';
+    }
+
+    /**
+     * Generates a regular expression to match identifiers that may or
+     * may not be quoted with any of the supported quotes.
+     *
+     * @param string $identifier The identifier to match.
+     * @param bool $spacedNoQuotes Whether the non-quoted identifier requires to be surrounded by whitespace.
+     * @return string
+     */
+    protected function possiblyQuotedIdentifierRegex(string $identifier, bool $spacedNoQuotes = true): string
+    {
+        $identifiers = [];
+        $identifier = preg_quote($identifier, '/');
+
+        $hasTick = str_contains($identifier, '`');
+        $hasDoubleQuote = str_contains($identifier, '"');
+        $hasSingleQuote = str_contains($identifier, "'");
+
+        $identifiers[] = '\[' . $identifier . '\]';
+        $identifiers[] = '`' . ($hasTick ? str_replace('`', '``', $identifier) : $identifier) . '`';
+        $identifiers[] = '"' . ($hasDoubleQuote ? str_replace('"', '""', $identifier) : $identifier) . '"';
+        $identifiers[] = "'" . ($hasSingleQuote ? str_replace("'", "''", $identifier) : $identifier) . "'";
+
+        if (!$hasTick && !$hasDoubleQuote && !$hasSingleQuote) {
+            if ($spacedNoQuotes) {
+                $identifiers[] = "\s+$identifier\s+";
+            } else {
+                $identifiers[] = $identifier;
+            }
+        }
+
+        return '(' . implode('|', $identifiers) . ')';
+    }
+
+    /**
+     * @param string $tableName Table name
+     * @param bool $quoted Whether to return the schema name and table name escaped and quoted. If quoted, the schema (if any) will also be appended with a dot
+     * @return array
+     */
+    protected function getSchemaName(string $tableName, bool $quoted = false): array
+    {
+        if (preg_match("/.\.([^\.]+)$/", $tableName, $match)) {
+            $table = $match[1];
+            $schema = substr($tableName, 0, strlen($tableName) - strlen($match[0]) + 1);
+            $result = ['schema' => $schema, 'table' => $table];
+        } else {
+            $result = ['schema' => '', 'table' => $tableName];
+        }
+
+        if ($quoted) {
+            $result['schema'] = $result['schema'] !== '' ? $this->quoteColumnName($result['schema']) . '.' : '';
+            $result['table'] = $this->quoteColumnName($result['table']);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Retrieves information about a given table from one of the SQLite pragmas
+     *
+     * @param string $tableName The table to query
+     * @param string $pragma The pragma to query
+     * @return array
+     */
+    protected function getTableInfo(string $tableName, string $pragma = 'table_info'): array
+    {
+        $info = $this->getSchemaName($tableName, true);
+
+        return $this->fetchAll(sprintf('PRAGMA %s%s(%s)', $info['schema'], $pragma, $info['table']));
+    }
+
+    /**
+     * Searches through all available schemata to find a table and returns an array
+     * containing the bare schema name and whether the table exists at all.
+     * If no schema was specified and the table does not exist the "main" schema is returned
+     *
+     * @param string $tableName The name of the table to find
+     * @return array
+     */
+    protected function resolveTable(string $tableName): array
+    {
+        $info = $this->getSchemaName($tableName);
+        if ($info['schema'] === '') {
+            // if no schema is specified we search all schemata
+            $rows = $this->fetchAll('PRAGMA database_list;');
+            // the temp schema is always first to be searched
+            $schemata = ['temp'];
+            foreach ($rows as $row) {
+                if (strtolower($row['name']) !== 'temp') {
+                    $schemata[] = $row['name'];
+                }
+            }
+            $defaultSchema = 'main';
+        } else {
+            // otherwise we search just the specified schema
+            $schemata = (array)$info['schema'];
+            $defaultSchema = $info['schema'];
+        }
+
+        $table = strtolower($info['table']);
+        foreach ($schemata as $schema) {
+            if (strtolower($schema) === 'temp') {
+                $master = 'sqlite_temp_master';
+            } else {
+                $master = sprintf('%s.%s', $this->quoteColumnName($schema), 'sqlite_master');
+            }
+            try {
+                $rows = $this->fetchAll(sprintf("SELECT name FROM %s WHERE type='table' AND lower(name) = %s", $master, $this->quoteString($table)));
+            } catch (PDOException $e) {
+                // an exception can occur if the schema part of the table refers to a database which is not attached
+                break;
+            }
+
+            // this somewhat pedantic check with strtolower is performed because the SQL lower function may be redefined,
+            // and can act on all Unicode characters if the ICU extension is loaded, while SQL identifiers are only case-insensitive for ASCII
+            foreach ($rows as $row) {
+                if (strtolower($row['name']) === $table) {
+                    return ['schema' => $schema, 'table' => $row['name'], 'exists' => true];
+                }
+            }
+        }
+
+        return ['schema' => $defaultSchema, 'table' => $info['table'], 'exists' => false];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasTable(string $tableName): bool
+    {
+        return $this->hasCreatedTable($tableName) || $this->resolveTable($tableName)['exists'];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createTable(Table $table, array $columns = [], array $indexes = []): void
+    {
+        // Add the default primary key
+        $options = $table->getOptions();
+        if (!isset($options['id']) || (isset($options['id']) && $options['id'] === true)) {
+            $options['id'] = 'id';
+        }
+
+        if (isset($options['id']) && is_string($options['id'])) {
+            // Handle id => "field_name" to support AUTO_INCREMENT
+            $column = new Column();
+            $column->setName($options['id'])
+                   ->setType('integer')
+                   ->setOptions(['identity' => true]);
+
+            array_unshift($columns, $column);
+        }
+
+        $sql = 'CREATE TABLE ';
+        $sql .= $this->quoteTableName($table->getName()) . ' (';
+        foreach ($columns as $column) {
+            $sql .= $this->quoteColumnName($column->getName()) . ' ' . $this->getColumnSqlDefinition($column) . ', ';
+
+            if (isset($options['primary_key']) && $column->getIdentity()) {
+                //remove column from the primary key array as it is already defined as an autoincrement
+                //primary id
+                $identityColumnIndex = array_search($column->getName(), $options['primary_key'], true);
+                if ($identityColumnIndex !== false) {
+                    unset($options['primary_key'][$identityColumnIndex]);
+
+                    if (empty($options['primary_key'])) {
+                        //The last primary key has been removed
+                        unset($options['primary_key']);
+                    }
+                }
+            }
+        }
+
+        // set the primary key(s)
+        if (isset($options['primary_key'])) {
+            $sql = rtrim($sql);
+            $sql .= ' PRIMARY KEY (';
+            if (is_string($options['primary_key'])) { // handle primary_key => 'id'
+                $sql .= $this->quoteColumnName($options['primary_key']);
+            } elseif (is_array($options['primary_key'])) { // handle primary_key => array('tag_id', 'resource_id')
+                $sql .= implode(',', array_map([$this, 'quoteColumnName'], $options['primary_key']));
+            }
+            $sql .= ')';
+        } else {
+            $sql = substr(rtrim($sql), 0, -1); // no primary keys
+        }
+
+        $sql = rtrim($sql) . ');';
+        // execute the sql
+        $this->execute($sql);
+
+        foreach ($indexes as $index) {
+            $this->addIndex($table, $index);
+        }
+
+        $this->addCreatedTable($table->getName());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function getChangePrimaryKeyInstructions(Table $table, $newColumns): AlterInstructions
+    {
+        $instructions = new AlterInstructions();
+
+        // Drop the existing primary key
+        $primaryKey = $this->getPrimaryKey($table->getName());
+        if (!empty($primaryKey)) {
+            $instructions->merge(
+                // FIXME: array access is a hack to make this incomplete implementation work with a correct getPrimaryKey implementation
+                $this->getDropPrimaryKeyInstructions($table, $primaryKey[0])
+            );
+        }
+
+        // Add the primary key(s)
+        if (!empty($newColumns)) {
+            if (!is_string($newColumns)) {
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid value for primary key: %s',
+                    json_encode($newColumns)
+                ));
+            }
+
+            $instructions->merge(
+                $this->getAddPrimaryKeyInstructions($table, $newColumns)
+            );
+        }
+
+        return $instructions;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * SQLiteAdapter does not implement this functionality, and so will always throw an exception if used.
+     *
+     * @throws \BadMethodCallException
+     */
+    protected function getChangeCommentInstructions(Table $table, $newComment): AlterInstructions
+    {
+        throw new BadMethodCallException('SQLite does not have table comments');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getRenameTableInstructions(string $tableName, string $newTableName): AlterInstructions
+    {
+        $this->updateCreatedTableName($tableName, $newTableName);
+        $sql = sprintf(
+            'ALTER TABLE %s RENAME TO %s',
+            $this->quoteTableName($tableName),
+            $this->quoteTableName($newTableName)
+        );
+
+        return new AlterInstructions([], [$sql]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDropTableInstructions(string $tableName): AlterInstructions
+    {
+        $this->removeCreatedTable($tableName);
+        $sql = sprintf('DROP TABLE %s', $this->quoteTableName($tableName));
+
+        return new AlterInstructions([], [$sql]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function truncateTable(string $tableName): void
+    {
+        $info = $this->resolveTable($tableName);
+        // first try deleting the rows
+        $this->execute(sprintf(
+            'DELETE FROM %s.%s',
+            $this->quoteColumnName($info['schema']),
+            $this->quoteColumnName($info['table'])
+        ));
+
+        // assuming no error occurred, reset the autoincrement (if any)
+        if ($this->hasTable($info['schema'] . '.sqlite_sequence')) {
+            $this->execute(sprintf(
+                'DELETE FROM %s.%s where name  = %s',
+                $this->quoteColumnName($info['schema']),
+                'sqlite_sequence',
+                $this->quoteString($info['table'])
+            ));
+        }
+    }
+
+    /**
+     * Parses a default-value expression to yield either a Literal representing
+     * a string value, a string representing an expression, or some other scalar
+     *
+     * @param mixed $default The default-value expression to interpret
+     * @param string $columnType The Phinx type of the column
+     * @return mixed
+     */
+    protected function parseDefaultValue(mixed $default, string $columnType): mixed
+    {
+        if ($default === null) {
+            return null;
+        }
+
+        // split the input into tokens
+        $trimChars = " \t\n\r\0\x0B";
+        $pattern = <<<PCRE_PATTERN
+            /
+                '(?:[^']|'')*'|                 # String literal
+                "(?:[^"]|"")*"|                 # Standard identifier
+                `(?:[^`]|``)*`|                 # MySQL identifier
+                \[[^\]]*\]|                     # SQL Server identifier
+                --[^\r\n]*|                     # Single-line comment
+                \/\*(?:\*(?!\/)|[^\*])*\*\/|    # Multi-line comment
+                [^\/\-]+|                       # Non-special characters
+                .                               # Any other single character
+            /sx
+PCRE_PATTERN;
+        preg_match_all($pattern, $default, $matches);
+        // strip out any comment tokens
+        $matches = array_map(function ($v) {
+            return preg_match('/^(?:\/\*|--)/', $v) ? ' ' : $v;
+        }, $matches[0]);
+        // reconstitute the string, trimming whitespace as well as parentheses
+        $defaultClean = trim(implode('', $matches));
+        $defaultBare = rtrim(ltrim($defaultClean, $trimChars . '('), $trimChars . ')');
+
+        // match the string against one of several patterns
+        if (preg_match('/^CURRENT_(?:DATE|TIME|TIMESTAMP)$/i', $defaultBare)) {
+            // magic date or time
+            return strtoupper($defaultBare);
+        } elseif (preg_match('/^\'(?:[^\']|\'\')*\'$/i', $defaultBare)) {
+            // string literal
+            $str = str_replace("''", "'", substr($defaultBare, 1, strlen($defaultBare) - 2));
+
+            return Literal::from($str);
+        } elseif (preg_match('/^[+-]?\d+$/i', $defaultBare)) {
+            $int = (int)$defaultBare;
+            // integer literal
+            if ($columnType === self::PHINX_TYPE_BOOLEAN && ($int === 0 || $int === 1)) {
+                return (bool)$int;
+            } else {
+                return $int;
+            }
+        } elseif (preg_match('/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i', $defaultBare)) {
+            // float literal
+            return (float)$defaultBare;
+        } elseif (preg_match('/^0x[0-9a-f]+$/i', $defaultBare)) {
+            // hexadecimal literal
+            return hexdec(substr($defaultBare, 2));
+        } elseif (preg_match('/^null$/i', $defaultBare)) {
+            // null literal
+            return null;
+        } elseif (preg_match('/^true|false$/i', $defaultBare)) {
+            // boolean literal
+            return filter_var($defaultClean, FILTER_VALIDATE_BOOLEAN);
+        } else {
+            // any other expression: return the expression with parentheses, but without comments
+            return Expression::from($defaultClean);
+        }
+    }
+
+    /**
+     * Returns the name of the specified table's identity column, or null if the table has no identity
+     *
+     * The process of finding an identity column is somewhat convoluted as SQLite has no direct way of querying whether a given column is an alias for the table's row ID
+     *
+     * @param string $tableName The name of the table
+     * @return string|null
+     */
+    protected function resolveIdentity(string $tableName): ?string
+    {
+        $result = null;
+        // make sure the table has only one primary key column which is of type integer
+        foreach ($this->getTableInfo($tableName) as $col) {
+            $type = strtolower($col['type']);
+            if ($col['pk'] > 1) {
+                // the table has a composite primary key
+                return null;
+            } elseif ($col['pk'] == 0) {
+                // the column is not a primary key column and is thus not relevant
+                continue;
+            } elseif ($type !== 'integer') {
+                // if the primary key's type is not exactly INTEGER, it cannot be a row ID alias
+                return null;
+            } else {
+                // the column is a candidate for a row ID alias
+                $result = $col['name'];
+            }
+        }
+        // if there is no suitable PK column, stop now
+        if ($result === null) {
+            return null;
+        }
+        // make sure the table does not have a PK-origin autoindex
+        // such an autoindex would indicate either that the primary key was specified as descending, or that this is a WITHOUT ROWID table
+        foreach ($this->getTableInfo($tableName, 'index_list') as $idx) {
+            if ($idx['origin'] === 'pk') {
+                return null;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getColumns(string $tableName): array
+    {
+        $columns = [];
+
+        $rows = $this->getTableInfo($tableName);
+        $identity = $this->resolveIdentity($tableName);
+
+        foreach ($rows as $columnInfo) {
+            $column = new Column();
+            $type = $this->getPhinxType($columnInfo['type']);
+            $default = $this->parseDefaultValue($columnInfo['dflt_value'], $type['name']);
+
+            $column->setName($columnInfo['name'])
+                // SQLite on PHP 8.1 returns int for notnull, older versions return a string
+                   ->setNull((int)$columnInfo['notnull'] !== 1)
+                   ->setDefault($default)
+                   ->setType($type['name'])
+                   ->setLimit($type['limit'])
+                   ->setScale($type['scale'])
+                   ->setIdentity($columnInfo['name'] === $identity);
+
+            $columns[] = $column;
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasColumn(string $tableName, string $columnName): bool
+    {
+        $rows = $this->getTableInfo($tableName);
+        foreach ($rows as $column) {
+            if (strcasecmp($column['name'], $columnName) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions
+    {
+        $tableName = $table->getName();
+
+        $instructions = $this->beginAlterByCopyTable($tableName);
+
+        $instructions->addPostStep(function ($state) use ($tableName, $column) {
+            // we use the final column to anchor our regex to insert the new column,
+            // as the alternative is unwinding all possible table constraints which
+            // gets messy quickly with CHECK constraints.
+            $columns = $this->getColumns($tableName);
+            if (!$columns) {
+                return $state;
+            }
+            $finalColumnName = end($columns)->getName();
+            $sql = preg_replace(
+                sprintf(
+                    "/(%s(?:\/\*.*?\*\/|\([^)]+\)|'[^']*?'|[^,])+)([,)])/",
+                    $this->quoteColumnName($finalColumnName)
+                ),
+                sprintf(
+                    '$1, %s %s$2',
+                    $this->quoteColumnName($column->getName()),
+                    $this->getColumnSqlDefinition($column)
+                ),
+                $state['createSQL'],
+                1
+            );
+            $this->execute($sql);
+
+            return $state;
+        });
+
+        $instructions->addPostStep(function ($state) use ($tableName) {
+            $newState = $this->calculateNewTableColumns($tableName, false, false);
+
+            return $newState + $state;
+        });
+
+        return $this->endAlterByCopyTable($instructions, $tableName);
+    }
+
+    /**
+     * Returns the original CREATE statement for the give table
+     *
+     * @param string $tableName The table name to get the create statement for
+     * @return string
+     */
+    protected function getDeclaringSql(string $tableName): string
+    {
+        $rows = $this->fetchAll("SELECT * FROM sqlite_master WHERE `type` = 'table'");
+
+        $sql = '';
+        foreach ($rows as $table) {
+            if ($table['tbl_name'] === $tableName) {
+                $sql = $table['sql'];
+            }
+        }
+
+        $columnsInfo = $this->getTableInfo($tableName);
+
+        foreach ($columnsInfo as $column) {
+            $columnName = preg_quote($column['name'], '#');
+            $columnNamePattern = "\"$columnName\"|`$columnName`|\\[$columnName\\]|$columnName";
+            $columnNamePattern = "#([\(,]+\\s*)($columnNamePattern)(\\s)#iU";
+
+            $sql = preg_replace($columnNamePattern, "$1`{$column['name']}`$3", $sql);
+        }
+
+        $tableNamePattern = "\"$tableName\"|`$tableName`|\\[$tableName\\]|$tableName";
+        $tableNamePattern = "#^(CREATE TABLE)\s*($tableNamePattern)\s*(\()#Ui";
+
+        $sql = preg_replace($tableNamePattern, "$1 `$tableName` $3", $sql, 1);
+
+        return $sql;
+    }
+
+    /**
+     * Returns the original CREATE statement for the give index
+     *
+     * @param string $tableName The table name to get the create statement for
+     * @param string $indexName The table index
+     * @return string
+     */
+    protected function getDeclaringIndexSql(string $tableName, string $indexName): string
+    {
+        $rows = $this->fetchAll("SELECT * FROM sqlite_master WHERE `type` = 'index'");
+
+        $sql = '';
+        foreach ($rows as $table) {
+            if ($table['tbl_name'] === $tableName && $table['name'] === $indexName) {
+                $sql = $table['sql'] . '; ';
+            }
+        }
+
+        return $sql;
+    }
+
+    /**
+     * Obtains index and trigger information for a table.
+     *
+     * They will be stored in the state as arrays under the `indices` and `triggers`
+     * keys accordingly.
+     *
+     * Index columns defined as expressions, as for example in `ON (ABS(id), other)`,
+     * will appear as `null`, so for the given example the columns for the index would
+     * look like `[null, 'other']`.
+     *
+     * @param \Migrations\Db\AlterInstructions $instructions The instructions to modify
+     * @param string $tableName The name of table being processed
+     * @return \Migrations\Db\AlterInstructions
+     */
+    protected function bufferIndicesAndTriggers(AlterInstructions $instructions, string $tableName): AlterInstructions
+    {
+        $instructions->addPostStep(function (array $state) use ($tableName): array {
+            $state['indices'] = [];
+            $state['triggers'] = [];
+
+            $rows = $this->fetchAll(
+                sprintf(
+                    "
+                        SELECT *
+                        FROM sqlite_master
+                        WHERE
+                            (`type` = 'index' OR `type` = 'trigger')
+                            AND tbl_name = %s
+                            AND sql IS NOT NULL
+                    ",
+                    $this->quoteValue($tableName)
+                )
+            );
+
+            $schema = $this->getSchemaName($tableName, true)['schema'];
+
+            foreach ($rows as $row) {
+                switch ($row['type']) {
+                    case 'index':
+                        $info = $this->fetchAll(
+                            sprintf('PRAGMA %sindex_info(%s)', $schema, $this->quoteValue($row['name']))
+                        );
+
+                        $columns = array_map(
+                            function ($column) {
+                                if ($column === null) {
+                                    return null;
+                                }
+
+                                return strtolower($column);
+                            },
+                            array_column($info, 'name')
+                        );
+                        $hasExpressions = in_array(null, $columns, true);
+
+                        $index = [
+                            'columns' => $columns,
+                            'hasExpressions' => $hasExpressions,
+                        ];
+
+                        $state['indices'][] = $index + $row;
+                        break;
+
+                    case 'trigger':
+                        $state['triggers'][] = $row;
+                        break;
+                }
+            }
+
+            return $state;
+        });
+
+        return $instructions;
+    }
+
+    /**
+     * Filters out indices that reference a removed column.
+     *
+     * @param \Migrations\Db\AlterInstructions $instructions The instructions to modify
+     * @param string $columnName The name of the removed column
+     * @return \Migrations\Db\AlterInstructions
+     */
+    protected function filterIndicesForRemovedColumn(
+        AlterInstructions $instructions,
+        string $columnName
+    ): AlterInstructions {
+        $instructions->addPostStep(function (array $state) use ($columnName): array {
+            foreach ($state['indices'] as $key => $index) {
+                if (
+                    !$index['hasExpressions'] &&
+                    in_array(strtolower($columnName), $index['columns'], true)
+                ) {
+                    unset($state['indices'][$key]);
+                }
+            }
+
+            return $state;
+        });
+
+        return $instructions;
+    }
+
+    /**
+     * Updates indices that reference a renamed column.
+     *
+     * @param \Migrations\Db\AlterInstructions $instructions The instructions to modify
+     * @param string $oldColumnName The old column name
+     * @param string $newColumnName The new column name
+     * @return \Migrations\Db\AlterInstructions
+     */
+    protected function updateIndicesForRenamedColumn(
+        AlterInstructions $instructions,
+        string $oldColumnName,
+        string $newColumnName
+    ): AlterInstructions {
+        $instructions->addPostStep(function (array $state) use ($oldColumnName, $newColumnName): array {
+            foreach ($state['indices'] as $key => $index) {
+                if (
+                    !$index['hasExpressions'] &&
+                    in_array(strtolower($oldColumnName), $index['columns'], true)
+                ) {
+                    $pattern = '
+                        /
+                            (INDEX.+?ON\s.+?)
+                                (\(\s*|,\s*)        # opening parenthesis or comma
+                                (?:`|"|\[)?         # optional opening quote
+                                (%s)                # column name
+                                (?:`|"|\])?         # optional closing quote
+                                (\s+COLLATE\s+.+?)? # optional collation
+                                (\s+(?:ASC|DESC))?  # optional order
+                                (\s*,|\s*\))        # comma or closing parenthesis
+                        /isx';
+
+                    $newColumnName = $this->quoteColumnName($newColumnName);
+
+                    $state['indices'][$key]['sql'] = preg_replace(
+                        sprintf($pattern, preg_quote($oldColumnName, '/')),
+                        "\\1\\2$newColumnName\\4\\5\\6",
+                        $index['sql']
+                    );
+                }
+            }
+
+            return $state;
+        });
+
+        return $instructions;
+    }
+
+    /**
+     * Recreates indices and triggers.
+     *
+     * @param \Migrations\Db\AlterInstructions $instructions The instructions to process
+     * @return \Migrations\Db\AlterInstructions
+     */
+    protected function recreateIndicesAndTriggers(AlterInstructions $instructions): AlterInstructions
+    {
+        $instructions->addPostStep(function (array $state): array {
+            foreach ($state['indices'] as $index) {
+                $this->execute($index['sql']);
+            }
+
+            foreach ($state['triggers'] as $trigger) {
+                $this->execute($trigger['sql']);
+            }
+
+            return $state;
+        });
+
+        return $instructions;
+    }
+
+    /**
+     * Returns instructions for validating the foreign key constraints of
+     * the given table, and of those tables whose constraints are
+     * targeting it.
+     *
+     * @param \Migrations\Db\AlterInstructions $instructions The instructions to process
+     * @param string $tableName The name of the table for which to check constraints.
+     * @return \Migrations\Db\AlterInstructions
+     */
+    protected function validateForeignKeys(AlterInstructions $instructions, string $tableName): AlterInstructions
+    {
+        $instructions->addPostStep(function ($state) use ($tableName) {
+            $tablesToCheck = [
+                $tableName,
+            ];
+
+            $otherTables = $this
+                ->query(
+                    "SELECT name FROM sqlite_master WHERE type = 'table' AND name != ?",
+                    [$tableName]
+                )
+                ->fetchAll();
+
+            foreach ($otherTables as $otherTable) {
+                $foreignKeyList = $this->getTableInfo($otherTable['name'], 'foreign_key_list');
+                foreach ($foreignKeyList as $foreignKey) {
+                    if (strcasecmp($foreignKey['table'], $tableName) === 0) {
+                        $tablesToCheck[] = $otherTable['name'];
+                        break;
+                    }
+                }
+            }
+
+            $tablesToCheck = array_unique(array_map('strtolower', $tablesToCheck));
+
+            foreach ($tablesToCheck as $tableToCheck) {
+                $schema = $this->getSchemaName($tableToCheck, true)['schema'];
+
+                $stmt = $this->query(
+                    sprintf('PRAGMA %sforeign_key_check(%s)', $schema, $this->quoteTableName($tableToCheck))
+                );
+                $row = $stmt->fetch();
+                $stmt->closeCursor();
+
+                if (is_array($row)) {
+                    throw new RuntimeException(sprintf(
+                        'Integrity constraint violation: FOREIGN KEY constraint on `%s` failed.',
+                        $tableToCheck
+                    ));
+                }
+            }
+
+            return $state;
+        });
+
+        return $instructions;
+    }
+
+    /**
+     * Copies all the data from a tmp table to another table
+     *
+     * @param string $tableName The table name to copy the data to
+     * @param string $tmpTableName The tmp table name where the data is stored
+     * @param string[] $writeColumns The list of columns in the target table
+     * @param string[] $selectColumns The list of columns in the tmp table
+     * @return void
+     */
+    protected function copyDataToNewTable(string $tableName, string $tmpTableName, array $writeColumns, array $selectColumns): void
+    {
+        $sql = sprintf(
+            'INSERT INTO %s(%s) SELECT %s FROM %s',
+            $this->quoteTableName($tableName),
+            implode(', ', $writeColumns),
+            implode(', ', $selectColumns),
+            $this->quoteTableName($tmpTableName)
+        );
+        $this->execute($sql);
+    }
+
+    /**
+     * Modifies the passed instructions to copy all data from the table into
+     * the provided tmp table and then drops the table and rename tmp table.
+     *
+     * @param \Migrations\Db\AlterInstructions $instructions The instructions to modify
+     * @param string $tableName The table name to copy the data to
+     * @return \Migrations\Db\AlterInstructions
+     */
+    protected function copyAndDropTmpTable(AlterInstructions $instructions, string $tableName): AlterInstructions
+    {
+        $instructions->addPostStep(function ($state) use ($tableName) {
+            $this->copyDataToNewTable(
+                $state['tmpTableName'],
+                $tableName,
+                $state['writeColumns'],
+                $state['selectColumns']
+            );
+
+            $this->execute(sprintf('DROP TABLE %s', $this->quoteTableName($tableName)));
+            $this->execute(sprintf(
+                'ALTER TABLE %s RENAME TO %s',
+                $this->quoteTableName($state['tmpTableName']),
+                $this->quoteTableName($tableName)
+            ));
+
+            return $state;
+        });
+
+        return $instructions;
+    }
+
+    /**
+     * Returns the columns and type to use when copying a table to another in the process
+     * of altering a table
+     *
+     * @param string $tableName The table to modify
+     * @param string|false $columnName The column name that is about to change
+     * @param string|false $newColumnName Optionally the new name for the column
+     * @throws \InvalidArgumentException
+     * @return array
+     */
+    protected function calculateNewTableColumns(string $tableName, string|false $columnName, string|false $newColumnName): array
+    {
+        $columns = $this->fetchAll(sprintf('pragma table_info(%s)', $this->quoteTableName($tableName)));
+        $selectColumns = [];
+        $writeColumns = [];
+        $columnType = null;
+        $found = false;
+
+        foreach ($columns as $column) {
+            $selectName = $column['name'];
+            $writeName = $selectName;
+
+            if ($selectName === $columnName) {
+                $writeName = $newColumnName;
+                $found = true;
+                $columnType = $column['type'];
+                $selectName = $newColumnName === false ? $newColumnName : $selectName;
+            }
+
+            $selectColumns[] = $selectName;
+            $writeColumns[] = $writeName;
+        }
+
+        $selectColumns = array_filter($selectColumns, 'strlen');
+        $writeColumns = array_filter($writeColumns, 'strlen');
+        $selectColumns = array_map([$this, 'quoteColumnName'], $selectColumns);
+        $writeColumns = array_map([$this, 'quoteColumnName'], $writeColumns);
+
+        if ($columnName && !$found) {
+            throw new InvalidArgumentException(sprintf(
+                'The specified column doesn\'t exist: ' . $columnName
+            ));
+        }
+
+        return compact('writeColumns', 'selectColumns', 'columnType');
+    }
+
+    /**
+     * Returns the initial instructions to alter a table using the
+     * create-copy-drop strategy
+     *
+     * @param string $tableName The table to modify
+     * @return \Migrations\Db\AlterInstructions
+     */
+    protected function beginAlterByCopyTable(string $tableName): AlterInstructions
+    {
+        $instructions = new AlterInstructions();
+        $instructions->addPostStep(function ($state) use ($tableName) {
+            $tmpTableName = "tmp_{$tableName}";
+            $createSQL = $this->getDeclaringSql($tableName);
+
+            // Table name in SQLite can be hilarious inside declaring SQL:
+            // - tableName
+            // - `tableName`
+            // - "tableName"
+            // - [this is a valid table name too!]
+            // - etc.
+            // Just remove all characters before first "(" and build them again
+            $createSQL = preg_replace(
+                "/^CREATE TABLE .* \(/Ui",
+                '',
+                $createSQL
+            );
+
+            $createSQL = "CREATE TABLE {$this->quoteTableName($tmpTableName)} ({$createSQL}";
+
+            return compact('createSQL', 'tmpTableName') + $state;
+        });
+
+        return $instructions;
+    }
+
+    /**
+     * Returns the final instructions to alter a table using the
+     * create-copy-drop strategy.
+     *
+     * @param \Migrations\Db\AlterInstructions $instructions The instructions to modify
+     * @param string $tableName The name of table being processed
+     * @param ?string $renamedOrRemovedColumnName The name of the renamed or removed column when part of a column
+     *  rename/drop operation.
+     * @param ?string $newColumnName The new column name when part of a column rename operation.
+     * @param bool $validateForeignKeys Whether to validate foreign keys after the copy and drop operations. Note that
+     *  enabling this option only has an effect when the `foreign_keys` PRAGMA is set to `ON`!
+     * @return \Migrations\Db\AlterInstructions
+     */
+    protected function endAlterByCopyTable(
+        AlterInstructions $instructions,
+        string $tableName,
+        ?string $renamedOrRemovedColumnName = null,
+        ?string $newColumnName = null,
+        bool $validateForeignKeys = true
+    ): AlterInstructions {
+        $instructions = $this->bufferIndicesAndTriggers($instructions, $tableName);
+
+        if ($renamedOrRemovedColumnName !== null) {
+            if ($newColumnName !== null) {
+                $this->updateIndicesForRenamedColumn($instructions, $renamedOrRemovedColumnName, $newColumnName);
+            } else {
+                $this->filterIndicesForRemovedColumn($instructions, $renamedOrRemovedColumnName);
+            }
+        }
+
+        $foreignKeysEnabled = (bool)$this->fetchRow('PRAGMA foreign_keys')['foreign_keys'];
+
+        if ($foreignKeysEnabled) {
+            $instructions->addPostStep('PRAGMA foreign_keys = OFF');
+        }
+
+        $instructions = $this->copyAndDropTmpTable($instructions, $tableName);
+        $instructions = $this->recreateIndicesAndTriggers($instructions);
+
+        if ($foreignKeysEnabled) {
+            $instructions->addPostStep('PRAGMA foreign_keys = ON');
+        }
+
+        if (
+            $foreignKeysEnabled &&
+            $validateForeignKeys
+        ) {
+            $instructions = $this->validateForeignKeys($instructions, $tableName);
+        }
+
+        return $instructions;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getRenameColumnInstructions(string $tableName, string $columnName, string $newColumnName): AlterInstructions
+    {
+        $instructions = $this->beginAlterByCopyTable($tableName);
+
+        $instructions->addPostStep(function ($state) use ($columnName, $newColumnName) {
+            $sql = str_replace(
+                $this->quoteColumnName($columnName),
+                $this->quoteColumnName($newColumnName),
+                $state['createSQL']
+            );
+            $this->execute($sql);
+
+            return $state;
+        });
+
+        $instructions->addPostStep(function ($state) use ($columnName, $newColumnName, $tableName) {
+            $newState = $this->calculateNewTableColumns($tableName, $columnName, $newColumnName);
+
+            return $newState + $state;
+        });
+
+        return $this->endAlterByCopyTable($instructions, $tableName, $columnName, $newColumnName);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getChangeColumnInstructions(string $tableName, string $columnName, Column $newColumn): AlterInstructions
+    {
+        $instructions = $this->beginAlterByCopyTable($tableName);
+
+        $newColumnName = $newColumn->getName();
+        $instructions->addPostStep(function ($state) use ($columnName, $newColumn) {
+            $sql = preg_replace(
+                sprintf("/%s(?:\/\*.*?\*\/|\([^)]+\)|'[^']*?'|[^,])+([,)])/", $this->quoteColumnName($columnName)),
+                sprintf('%s %s$1', $this->quoteColumnName($newColumn->getName()), $this->getColumnSqlDefinition($newColumn)),
+                $state['createSQL'],
+                1
+            );
+            $this->execute($sql);
+
+            return $state;
+        });
+
+        $instructions->addPostStep(function ($state) use ($columnName, $newColumnName, $tableName) {
+            $newState = $this->calculateNewTableColumns($tableName, $columnName, $newColumnName);
+
+            return $newState + $state;
+        });
+
+        return $this->endAlterByCopyTable($instructions, $tableName);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDropColumnInstructions(string $tableName, string $columnName): AlterInstructions
+    {
+        $instructions = $this->beginAlterByCopyTable($tableName);
+
+        $instructions->addPostStep(function ($state) use ($tableName, $columnName) {
+            $newState = $this->calculateNewTableColumns($tableName, $columnName, false);
+
+            return $newState + $state;
+        });
+
+        $instructions->addPostStep(function ($state) use ($columnName) {
+            $sql = preg_replace(
+                sprintf("/%s\s%s.*(,\s(?!')|\)$)/U", preg_quote($this->quoteColumnName($columnName)), preg_quote($state['columnType'])),
+                '',
+                $state['createSQL']
+            );
+
+            if (substr($sql, -2) === ', ') {
+                $sql = substr($sql, 0, -2) . ')';
+            }
+
+            $this->execute($sql);
+
+            return $state;
+        });
+
+        return $this->endAlterByCopyTable($instructions, $tableName, $columnName);
+    }
+
+    /**
+     * Get an array of indexes from a particular table.
+     *
+     * @param string $tableName Table name
+     * @return array
+     */
+    protected function getIndexes(string $tableName): array
+    {
+        $indexes = [];
+        $schema = $this->getSchemaName($tableName, true)['schema'];
+        $indexList = $this->getTableInfo($tableName, 'index_list');
+
+        foreach ($indexList as $index) {
+            $indexData = $this->fetchAll(sprintf('pragma %sindex_info(%s)', $schema, $this->quoteColumnName($index['name'])));
+            $cols = [];
+            foreach ($indexData as $indexItem) {
+                $cols[] = $indexItem['name'];
+            }
+            $indexes[$index['name']] = $cols;
+        }
+
+        return $indexes;
+    }
+
+    /**
+     * Finds the names of a table's indexes matching the supplied columns
+     *
+     * @param string $tableName The table to which the index belongs
+     * @param string|string[] $columns The columns of the index
+     * @return array
+     */
+    protected function resolveIndex(string $tableName, string|array $columns): array
+    {
+        $columns = array_map('strtolower', (array)$columns);
+        $indexes = $this->getIndexes($tableName);
+        $matches = [];
+
+        foreach ($indexes as $name => $index) {
+            $indexCols = array_map('strtolower', $index);
+            if ($columns == $indexCols) {
+                $matches[] = $name;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasIndex(string $tableName, string|array $columns): bool
+    {
+        return (bool)$this->resolveIndex($tableName, $columns);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasIndexByName(string $tableName, string $indexName): bool
+    {
+        $indexName = strtolower($indexName);
+        $indexes = $this->getIndexes($tableName);
+
+        foreach (array_keys($indexes) as $index) {
+            if ($indexName === strtolower($index)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
+    {
+        $indexColumnArray = [];
+        foreach ($index->getColumns() as $column) {
+            $indexColumnArray[] = sprintf('`%s` ASC', $column);
+        }
+        $indexColumns = implode(',', $indexColumnArray);
+        $sql = sprintf(
+            'CREATE %s ON %s (%s)',
+            $this->getIndexSqlDefinition($table, $index),
+            $this->quoteTableName($table->getName()),
+            $indexColumns
+        );
+
+        return new AlterInstructions([], [$sql]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDropIndexByColumnsInstructions(string $tableName, $columns): AlterInstructions
+    {
+        $instructions = new AlterInstructions();
+        $indexNames = $this->resolveIndex($tableName, $columns);
+        $schema = $this->getSchemaName($tableName, true)['schema'];
+        foreach ($indexNames as $indexName) {
+            if (strpos($indexName, 'sqlite_autoindex_') !== 0) {
+                $instructions->addPostStep(sprintf(
+                    'DROP INDEX %s%s',
+                    $schema,
+                    $this->quoteColumnName($indexName)
+                ));
+            }
+        }
+
+        return $instructions;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDropIndexByNameInstructions(string $tableName, string $indexName): AlterInstructions
+    {
+        $instructions = new AlterInstructions();
+        $indexName = strtolower($indexName);
+        $indexes = $this->getIndexes($tableName);
+
+        $found = false;
+        foreach (array_keys($indexes) as $index) {
+            if ($indexName === strtolower($index)) {
+                $found = true;
+                break;
+            }
+        }
+
+        if ($found) {
+            $schema = $this->getSchemaName($tableName, true)['schema'];
+                $instructions->addPostStep(sprintf(
+                    'DROP INDEX %s%s',
+                    $schema,
+                    $this->quoteColumnName($indexName)
+                ));
+        }
+
+        return $instructions;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function hasPrimaryKey(string $tableName, $columns, ?string $constraint = null): bool
+    {
+        if ($constraint !== null) {
+            throw new InvalidArgumentException('SQLite does not support named constraints.');
+        }
+
+        $columns = array_map('strtolower', (array)$columns);
+        $primaryKey = array_map('strtolower', $this->getPrimaryKey($tableName));
+
+        if (array_diff($primaryKey, $columns) || array_diff($columns, $primaryKey)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the primary key from a particular table.
+     *
+     * @param string $tableName Table name
+     * @return string[]
+     */
+    protected function getPrimaryKey(string $tableName): array
+    {
+        $primaryKey = [];
+
+        $rows = $this->getTableInfo($tableName);
+
+        foreach ($rows as $row) {
+            if ($row['pk'] > 0) {
+                $primaryKey[$row['pk'] - 1] = $row['name'];
+            }
+        }
+
+        return $primaryKey;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
+    {
+        if ($constraint !== null) {
+            return preg_match(
+                "/,?\s*CONSTRAINT\s*" . $this->possiblyQuotedIdentifierRegex($constraint) . '\s*FOREIGN\s+KEY/is',
+                $this->getDeclaringSql($tableName)
+            ) === 1;
+        }
+
+        $columns = array_map('mb_strtolower', (array)$columns);
+
+        foreach ($this->getForeignKeys($tableName) as $key) {
+            if (array_map('mb_strtolower', $key) === $columns) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get an array of foreign keys from a particular table.
+     *
+     * @param string $tableName Table name
+     * @return array
+     */
+    protected function getForeignKeys(string $tableName): array
+    {
+        $foreignKeys = [];
+
+        $rows = $this->getTableInfo($tableName, 'foreign_key_list');
+
+        foreach ($rows as $row) {
+            if (!isset($foreignKeys[$row['id']])) {
+                $foreignKeys[$row['id']] = [];
+            }
+            $foreignKeys[$row['id']][$row['seq']] = $row['from'];
+        }
+
+        return $foreignKeys;
+    }
+
+    /**
+     * @param \Migrations\Db\Table\Table $table The Table
+     * @param string $column Column Name
+     * @return \Migrations\Db\AlterInstructions
+     */
+    protected function getAddPrimaryKeyInstructions(Table $table, string $column): AlterInstructions
+    {
+        $instructions = $this->beginAlterByCopyTable($table->getName());
+
+        $tableName = $table->getName();
+        $instructions->addPostStep(function ($state) use ($column) {
+            $matchPattern = "/(`$column`)\s+(\w+(\(\d+\))?)\s+((NOT )?NULL)/";
+
+            $sql = $state['createSQL'];
+
+            if (preg_match($matchPattern, $state['createSQL'], $matches)) {
+                if (isset($matches[2])) {
+                    if ($matches[2] === 'INTEGER') {
+                        $replace = '$1 INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT';
+                    } else {
+                        $replace = '$1 $2 NOT NULL PRIMARY KEY';
+                    }
+
+                    $sql = preg_replace($matchPattern, $replace, $state['createSQL'], 1);
+                }
+            }
+
+            $this->execute($sql);
+
+            return $state;
+        });
+
+        $instructions->addPostStep(function ($state) {
+            $columns = $this->fetchAll(sprintf('pragma table_info(%s)', $this->quoteTableName($state['tmpTableName'])));
+            $names = array_map([$this, 'quoteColumnName'], array_column($columns, 'name'));
+            $selectColumns = $writeColumns = $names;
+
+            return compact('selectColumns', 'writeColumns') + $state;
+        });
+
+        return $this->endAlterByCopyTable($instructions, $tableName);
+    }
+
+    /**
+     * @param \Migrations\Db\Table\Table $table Table
+     * @param string $column Column Name
+     * @return \Migrations\Db\AlterInstructions
+     */
+    protected function getDropPrimaryKeyInstructions(Table $table, string $column): AlterInstructions
+    {
+        $tableName = $table->getName();
+        $instructions = $this->beginAlterByCopyTable($tableName);
+
+        $instructions->addPostStep(function ($state) {
+            $search = "/(,?\s*PRIMARY KEY\s*\([^\)]*\)|\s+PRIMARY KEY(\s+AUTOINCREMENT)?)/";
+            $sql = preg_replace($search, '', $state['createSQL'], 1);
+
+            if ($sql) {
+                $this->execute($sql);
+            }
+
+            return $state;
+        });
+
+        $instructions->addPostStep(function ($state) use ($column) {
+            $newState = $this->calculateNewTableColumns($state['tmpTableName'], $column, $column);
+
+            return $newState + $state;
+        });
+
+        return $this->endAlterByCopyTable($instructions, $tableName, null, null, false);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey): AlterInstructions
+    {
+        $instructions = $this->beginAlterByCopyTable($table->getName());
+
+        $tableName = $table->getName();
+        $instructions->addPostStep(function ($state) use ($foreignKey, $tableName) {
+            $this->execute('pragma foreign_keys = ON');
+            $sql = substr($state['createSQL'], 0, -1) . ',' . $this->getForeignKeySqlDefinition($foreignKey) . '); ';
+
+            //Delete indexes from original table and recreate them in temporary table
+            $schema = $this->getSchemaName($tableName, true)['schema'];
+            $tmpTableName = $state['tmpTableName'];
+            $indexes = $this->getIndexes($tableName);
+            foreach (array_keys($indexes) as $indexName) {
+                if (strpos($indexName, 'sqlite_autoindex_') !== 0) {
+                    $sql .= sprintf(
+                        'DROP INDEX %s%s; ',
+                        $schema,
+                        $this->quoteColumnName($indexName)
+                    );
+                    $createIndexSQL = $this->getDeclaringIndexSQL($tableName, $indexName);
+                    $sql .= preg_replace(
+                        "/\b{$tableName}\b/",
+                        $tmpTableName,
+                        $createIndexSQL
+                    );
+                }
+            }
+
+            $this->execute($sql);
+
+            return $state;
+        });
+
+        $instructions->addPostStep(function ($state) {
+            $columns = $this->fetchAll(sprintf('pragma table_info(%s)', $this->quoteTableName($state['tmpTableName'])));
+            $names = array_map([$this, 'quoteColumnName'], array_column($columns, 'name'));
+            $selectColumns = $writeColumns = $names;
+
+            return compact('selectColumns', 'writeColumns') + $state;
+        });
+
+        return $this->endAlterByCopyTable($instructions, $tableName);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * SQLiteAdapter does not implement this functionality, and so will always throw an exception if used.
+     *
+     * @throws \BadMethodCallException
+     */
+    protected function getDropForeignKeyInstructions(string $tableName, string $constraint): AlterInstructions
+    {
+        throw new BadMethodCallException('SQLite does not have named foreign keys');
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function getDropForeignKeyByColumnsInstructions(string $tableName, array $columns): AlterInstructions
+    {
+        if (!$this->hasForeignKey($tableName, $columns)) {
+            throw new InvalidArgumentException(sprintf(
+                'No foreign key on column(s) `%s` exists',
+                implode(', ', $columns)
+            ));
+        }
+
+        $instructions = $this->beginAlterByCopyTable($tableName);
+
+        $instructions->addPostStep(function ($state) use ($columns) {
+            $search = sprintf(
+                "/,[^,]+?\(\s*%s\s*\)\s*REFERENCES[^,]*\([^\)]*\)[^,)]*/is",
+                implode(
+                    '\s*,\s*',
+                    array_map(
+                        fn ($column) => $this->possiblyQuotedIdentifierRegex($column, false),
+                        $columns
+                    )
+                ),
+            );
+            $sql = preg_replace($search, '', $state['createSQL']);
+
+            if ($sql) {
+                $this->execute($sql);
+            }
+
+            return $state;
+        });
+
+        $instructions->addPostStep(function ($state) {
+            $newState = $this->calculateNewTableColumns($state['tmpTableName'], false, false);
+
+            return $newState + $state;
+        });
+
+        return $this->endAlterByCopyTable($instructions, $tableName);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws \Migrations\Db\Adapter\UnsupportedColumnTypeException
+     */
+    public function getSqlType(Literal|string $type, ?int $limit = null): array
+    {
+        if ($type instanceof Literal) {
+            $name = $type;
+        } else {
+            $typeLC = strtolower($type);
+
+            if (isset(static::$supportedColumnTypes[$typeLC])) {
+                $name = static::$supportedColumnTypes[$typeLC];
+            } elseif (in_array($typeLC, static::$unsupportedColumnTypes, true)) {
+                throw new UnsupportedColumnTypeException('Column type "' . $type . '" is not supported by SQLite.');
+            } else {
+                throw new UnsupportedColumnTypeException('Column type "' . $type . '" is not known by SQLite.');
+            }
+        }
+
+        return ['name' => $name, 'limit' => $limit];
+    }
+
+    /**
+     * Returns Phinx type by SQL type
+     *
+     * @param string|null $sqlTypeDef SQL Type definition
+     * @return array
+     */
+    public function getPhinxType(?string $sqlTypeDef): array
+    {
+        $limit = null;
+        $scale = null;
+        if ($sqlTypeDef === null) {
+            // in SQLite columns can legitimately have null as a type, which is distinct from the empty string
+            $name = null;
+        } elseif (!preg_match('/^([a-z]+)(_(?:integer|float|text|blob))?(?:\((\d+)(?:,(\d+))?\))?$/i', $sqlTypeDef, $match)) {
+            // doesn't match the pattern of a type we'd know about
+            $name = Literal::from($sqlTypeDef);
+        } else {
+            // possibly a known type
+            $type = $match[1];
+            $typeLC = strtolower($type);
+            $affinity = $match[2] ?? '';
+            $limit = isset($match[3]) && strlen($match[3]) ? (int)$match[3] : null;
+            $scale = isset($match[4]) && strlen($match[4]) ? (int)$match[4] : null;
+            if (in_array($typeLC, ['tinyint', 'tinyinteger'], true) && $limit === 1) {
+                // the type is a MySQL-style boolean
+                $name = static::PHINX_TYPE_BOOLEAN;
+                $limit = null;
+            } elseif (isset(static::$supportedColumnTypes[$typeLC])) {
+                // the type is an explicitly supported type
+                $name = $typeLC;
+            } elseif (isset(static::$supportedColumnTypeAliases[$typeLC])) {
+                // the type is an alias for a supported type
+                $name = static::$supportedColumnTypeAliases[$typeLC];
+            } elseif (in_array($typeLC, static::$unsupportedColumnTypes, true)) {
+                // unsupported but known types are passed through lowercased, and without appended affinity
+                $name = Literal::from($typeLC);
+            } else {
+                // unknown types are passed through as-is
+                $name = Literal::from($type . $affinity);
+            }
+        }
+
+        return [
+            'name' => $name,
+            'limit' => $limit,
+            'scale' => $scale,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createDatabase(string $name, array $options = []): void
+    {
+        touch($name . $this->suffix);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasDatabase(string $name): bool
+    {
+        return is_file($name . $this->suffix);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function dropDatabase(string $name): void
+    {
+        $this->createdTables = [];
+        if ($this->getOption('memory')) {
+            $this->disconnect();
+            $this->connect();
+        }
+        if (file_exists($name . $this->suffix)) {
+            unlink($name . $this->suffix);
+        }
+    }
+
+    /**
+     * Gets the SQLite Column Definition for a Column object.
+     *
+     * @param \Migrations\Db\Table\Column $column Column
+     * @return string
+     */
+    protected function getColumnSqlDefinition(Column $column): string
+    {
+        $isLiteralType = $column->getType() instanceof Literal;
+        if ($isLiteralType) {
+            $def = (string)$column->getType();
+        } else {
+            $sqlType = $this->getSqlType($column->getType());
+            $def = strtoupper($sqlType['name']);
+
+            $limitable = in_array(strtoupper($sqlType['name']), $this->definitionsWithLimits, true);
+            if (($column->getLimit() || isset($sqlType['limit'])) && $limitable) {
+                $def .= '(' . ($column->getLimit() ?: $sqlType['limit']) . ')';
+            }
+        }
+        if ($column->getPrecision() && $column->getScale()) {
+            $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
+        }
+
+        $default = $column->getDefault();
+
+        $def .= $column->isNull() ? ' NULL' : ' NOT NULL';
+        $def .= $this->getDefaultValueDefinition($default, $column->getType());
+        $def .= $column->isIdentity() ? ' PRIMARY KEY AUTOINCREMENT' : '';
+
+        $def .= $this->getCommentDefinition($column);
+
+        return $def;
+    }
+
+    /**
+     * Gets the comment Definition for a Column object.
+     *
+     * @param \Migrations\Db\Table\Column $column Column
+     * @return string
+     */
+    protected function getCommentDefinition(Column $column): string
+    {
+        if ($column->getComment()) {
+            return ' /* ' . $column->getComment() . ' */ ';
+        }
+
+        return '';
+    }
+
+    /**
+     * Gets the SQLite Index Definition for an Index object.
+     *
+     * @param \Migrations\Db\Table\Table $table Table
+     * @param \Migrations\Db\Table\Index $index Index
+     * @return string
+     */
+    protected function getIndexSqlDefinition(Table $table, Index $index): string
+    {
+        if ($index->getType() === Index::UNIQUE) {
+            $def = 'UNIQUE INDEX';
+        } else {
+            $def = 'INDEX';
+        }
+        if (is_string($index->getName())) {
+            $indexName = $index->getName();
+        } else {
+            $indexName = $table->getName() . '_';
+            foreach ($index->getColumns() as $column) {
+                $indexName .= $column . '_';
+            }
+            $indexName .= 'index';
+        }
+        $def .= ' `' . $indexName . '`';
+
+        return $def;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getColumnTypes(): array
+    {
+        return array_keys(static::$supportedColumnTypes);
+    }
+
+    /**
+     * Gets the SQLite Foreign Key Definition for an ForeignKey object.
+     *
+     * @param \Migrations\Db\Table\ForeignKey $foreignKey Foreign key
+     * @return string
+     */
+    protected function getForeignKeySqlDefinition(ForeignKey $foreignKey): string
+    {
+        $def = '';
+        if ($foreignKey->getConstraint()) {
+            $def .= ' CONSTRAINT ' . $this->quoteColumnName($foreignKey->getConstraint());
+        }
+        $columnNames = [];
+        foreach ($foreignKey->getColumns() as $column) {
+            $columnNames[] = $this->quoteColumnName($column);
+        }
+        $def .= ' FOREIGN KEY (' . implode(',', $columnNames) . ')';
+        $refColumnNames = [];
+        foreach ($foreignKey->getReferencedColumns() as $column) {
+            $refColumnNames[] = $this->quoteColumnName($column);
+        }
+        $def .= ' REFERENCES ' . $this->quoteTableName($foreignKey->getReferencedTable()->getName()) . ' (' . implode(',', $refColumnNames) . ')';
+        if ($foreignKey->getOnDelete()) {
+            $def .= ' ON DELETE ' . $foreignKey->getOnDelete();
+        }
+        if ($foreignKey->getOnUpdate()) {
+            $def .= ' ON UPDATE ' . $foreignKey->getOnUpdate();
+        }
+
+        return $def;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDecoratedConnection(): Connection
+    {
+        if (isset($this->decoratedConnection)) {
+            return $this->decoratedConnection;
+        }
+
+        $options = $this->getOptions();
+        $options['quoteIdentifiers'] = true;
+
+        if (!empty($options['name'])) {
+            $options['database'] = $options['name'];
+
+            if (file_exists($options['name'] . $this->suffix)) {
+                $options['database'] = $options['name'] . $this->suffix;
+            }
+        }
+
+        return $this->decoratedConnection = $this->buildConnection(SqliteDriver::class, $options);
+    }
+}

--- a/src/Db/Expression.php
+++ b/src/Db/Expression.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Migrations\Db;
+
+class Expression
+{
+    /**
+     * @var string The expression
+     */
+    protected string $value;
+
+    /**
+     * @param string $value The expression
+     */
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return string Returns the expression
+     */
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string $value The expression
+     * @return self
+     */
+    public static function from(string $value): Expression
+    {
+        return new self($value);
+    }
+}

--- a/src/Db/Table/Column.php
+++ b/src/Db/Table/Column.php
@@ -82,7 +82,7 @@ class Column
     /**
      * @var mixed
      */
-    protected mixed $default;
+    protected mixed $default = null;
 
     /**
      * @var bool

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Migrations\Test\Db\Adapter;
 
 use Cake\Database\Query;
+use Cake\Datasource\ConnectionManager;
 use InvalidArgumentException;
 use Migrations\Db\Adapter\AdapterInterface;
 use Migrations\Db\Adapter\MysqlAdapter;
@@ -29,17 +30,31 @@ class MysqlAdapterTest extends TestCase
      */
     private $adapter;
 
+    /**
+     * @var array
+     */
+    private $config;
+
     protected function setUp(): void
     {
-        if (!defined('MYSQL_DB_CONFIG')) {
+        $config = ConnectionManager::getConfig('test');
+        // Emulate the results of Util::parseDsn()
+        $this->config = [
+            'adapter' => $config['scheme'],
+            'user' => $config['username'],
+            'pass' => $config['password'],
+            'host' => $config['host'],
+            'name' => $config['database'],
+        ];
+        if ($this->config['adapter'] !== 'mysql') {
             $this->markTestSkipped('Mysql tests disabled.');
         }
 
-        $this->adapter = new MysqlAdapter(MYSQL_DB_CONFIG, new ArrayInput([]), new NullOutput());
+        $this->adapter = new MysqlAdapter($this->config, new ArrayInput([]), new NullOutput());
 
         // ensure the database is empty for each test
-        $this->adapter->dropDatabase(MYSQL_DB_CONFIG['name']);
-        $this->adapter->createDatabase(MYSQL_DB_CONFIG['name']);
+        $this->adapter->dropDatabase($this->config['name']);
+        $this->adapter->createDatabase($this->config['name']);
 
         // leave the adapter in a disconnected state for each test
         $this->adapter->disconnect();
@@ -80,7 +95,7 @@ class MysqlAdapterTest extends TestCase
 
     public function testConnectionWithInvalidCredentials()
     {
-        $options = ['user' => 'invalid', 'pass' => 'invalid'] + MYSQL_DB_CONFIG;
+        $options = ['user' => 'invalid', 'pass' => 'invalid'] + $this->config;
 
         try {
             $adapter = new MysqlAdapter($options, new ArrayInput([]), new NullOutput());
@@ -102,7 +117,7 @@ class MysqlAdapterTest extends TestCase
             $this->markTestSkipped('MySQL socket connection skipped.');
         }
 
-        $options = ['unix_socket' => getenv('MYSQL_UNIX_SOCKET')] + MYSQL_DB_CONFIG;
+        $options = ['unix_socket' => getenv('MYSQL_UNIX_SOCKET')] + $this->config;
         $adapter = new MysqlAdapter($options, new ArrayInput([]), new NullOutput());
         $adapter->connect();
 
@@ -184,7 +199,7 @@ class MysqlAdapterTest extends TestCase
 
         $rows = $this->adapter->fetchAll(sprintf(
             "SELECT TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='ntable'",
-            MYSQL_DB_CONFIG['name']
+            $this->config['name']
         ));
         $comment = $rows[0];
 
@@ -212,7 +227,7 @@ class MysqlAdapterTest extends TestCase
             "SELECT TABLE_NAME, COLUMN_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME
              FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
              WHERE TABLE_SCHEMA='%s' AND REFERENCED_TABLE_NAME='ntable_tag'",
-            MYSQL_DB_CONFIG['name']
+            $this->config['name']
         ));
         $foreignKey = $rows[0];
 
@@ -405,7 +420,7 @@ class MysqlAdapterTest extends TestCase
 
     public function testCreateTableAndInheritDefaultCollation()
     {
-        $options = MYSQL_DB_CONFIG + [
+        $options = $this->config + [
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
         ];
@@ -521,7 +536,7 @@ class MysqlAdapterTest extends TestCase
 
     public function testCreateTableWithSchema()
     {
-        $table = new Table(MYSQL_DB_CONFIG['name'] . '.ntable', [], $this->adapter);
+        $table = new Table($this->config['name'] . '.ntable', [], $this->adapter);
         $table->addColumn('realname', 'string')
             ->addColumn('email', 'integer')
             ->save();
@@ -588,7 +603,7 @@ class MysqlAdapterTest extends TestCase
                     FROM INFORMATION_SCHEMA.TABLES
                     WHERE TABLE_SCHEMA='%s'
                         AND TABLE_NAME='%s'",
-                MYSQL_DB_CONFIG['name'],
+                $this->config['name'],
                 'table1'
             )
         );
@@ -610,7 +625,7 @@ class MysqlAdapterTest extends TestCase
                     FROM INFORMATION_SCHEMA.TABLES
                     WHERE TABLE_SCHEMA='%s'
                         AND TABLE_NAME='%s'",
-                MYSQL_DB_CONFIG['name'],
+                $this->config['name'],
                 'table1'
             )
         );
@@ -632,7 +647,7 @@ class MysqlAdapterTest extends TestCase
                     FROM INFORMATION_SCHEMA.TABLES
                     WHERE TABLE_SCHEMA='%s'
                         AND TABLE_NAME='%s'",
-                MYSQL_DB_CONFIG['name'],
+                $this->config['name'],
                 'table1'
             )
         );
@@ -947,6 +962,7 @@ class MysqlAdapterTest extends TestCase
               ->save();
         $newColumn1 = new Column();
         $newColumn1->setDefault('test1')
+                   ->setName('column1')
                    ->setType('string');
         $table->changeColumn('column1', $newColumn1)->save();
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM t');
@@ -961,6 +977,7 @@ class MysqlAdapterTest extends TestCase
               ->save();
         $newColumn1 = new Column();
         $newColumn1->setDefault(0)
+                   ->setName('column1')
                    ->setType('integer');
         $table->changeColumn('column1', $newColumn1)->save();
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM t');
@@ -975,6 +992,7 @@ class MysqlAdapterTest extends TestCase
               ->save();
         $newColumn1 = new Column();
         $newColumn1->setDefault(null)
+                   ->setName('column1')
                    ->setType('string');
         $table->changeColumn('column1', $newColumn1)->save();
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM t');
@@ -1372,7 +1390,7 @@ class MysqlAdapterTest extends TestCase
 
         $this->assertContains($described['TABLE_TYPE'], ['VIEW', 'BASE TABLE']);
         $this->assertEquals($described['TABLE_NAME'], 't');
-        $this->assertEquals($described['TABLE_SCHEMA'], MYSQL_DB_CONFIG['name']);
+        $this->assertEquals($described['TABLE_SCHEMA'], $this->config['name']);
         $this->assertEquals($described['TABLE_ROWS'], 0);
     }
 
@@ -1450,7 +1468,7 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($table->hasIndex('email'));
         $index_data = $this->adapter->query(sprintf(
             'SELECT SUB_PART FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = "%s" AND TABLE_NAME = "table1" AND INDEX_NAME = "email"',
-            MYSQL_DB_CONFIG['name']
+            $this->config['name']
         ))->fetch(PDO::FETCH_ASSOC);
         $expected_limit = $index_data['SUB_PART'];
         $this->assertEquals($expected_limit, 50);
@@ -1468,13 +1486,13 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($table->hasIndex(['email', 'username']));
         $index_data = $this->adapter->query(sprintf(
             'SELECT SUB_PART FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = "%s" AND TABLE_NAME = "table1" AND INDEX_NAME = "email" AND COLUMN_NAME = "email"',
-            MYSQL_DB_CONFIG['name']
+            $this->config['name']
         ))->fetch(PDO::FETCH_ASSOC);
         $expected_limit = $index_data['SUB_PART'];
         $this->assertEquals($expected_limit, 3);
         $index_data = $this->adapter->query(sprintf(
             'SELECT SUB_PART FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = "%s" AND TABLE_NAME = "table1" AND INDEX_NAME = "email" AND COLUMN_NAME = "username"',
-            MYSQL_DB_CONFIG['name']
+            $this->config['name']
         ))->fetch(PDO::FETCH_ASSOC);
         $expected_limit = $index_data['SUB_PART'];
         $this->assertEquals($expected_limit, 2);
@@ -1492,7 +1510,7 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($table->hasIndex('email'));
         $index_data = $this->adapter->query(sprintf(
             'SELECT SUB_PART FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = "%s" AND TABLE_NAME = "table1" AND INDEX_NAME = "email" AND COLUMN_NAME = "email"',
-            MYSQL_DB_CONFIG['name']
+            $this->config['name']
         ))->fetch(PDO::FETCH_ASSOC);
         $expected_limit = $index_data['SUB_PART'];
         $this->assertEquals($expected_limit, 3);
@@ -1919,14 +1937,14 @@ class MysqlAdapterTest extends TestCase
             ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
             ->save();
 
-        $this->assertTrue($this->adapter->hasForeignKey(MYSQL_DB_CONFIG['name'] . '.' . $table->getName(), ['ref_table_id']));
-        $this->assertFalse($this->adapter->hasForeignKey(MYSQL_DB_CONFIG['name'] . '.' . $table->getName(), ['ref_table_id2']));
+        $this->assertTrue($this->adapter->hasForeignKey($this->config['name'] . '.' . $table->getName(), ['ref_table_id']));
+        $this->assertFalse($this->adapter->hasForeignKey($this->config['name'] . '.' . $table->getName(), ['ref_table_id2']));
     }
 
     public function testHasDatabase()
     {
         $this->assertFalse($this->adapter->hasDatabase('fake_database_name'));
-        $this->assertTrue($this->adapter->hasDatabase(MYSQL_DB_CONFIG['name']));
+        $this->assertTrue($this->adapter->hasDatabase($this->config['name']));
     }
 
     public function testDropDatabase()
@@ -1948,7 +1966,7 @@ class MysqlAdapterTest extends TestCase
             FROM information_schema.columns
             WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='table1'
             ORDER BY ORDINAL_POSITION",
-            MYSQL_DB_CONFIG['name']
+            $this->config['name']
         ));
         $columnWithComment = $rows[1];
 
@@ -2482,7 +2500,7 @@ INPUT;
 
         $rows = $this->adapter->fetchAll(sprintf(
             "SELECT COLUMN_DEFAULT FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='exampleCurrentTimestamp3'",
-            MYSQL_DB_CONFIG['name']
+            $this->config['name']
         ));
         $colDef = $rows[0];
         $this->assertEqualsIgnoringCase('CURRENT_TIMESTAMP(3)', $colDef['COLUMN_DEFAULT']);
@@ -2501,7 +2519,7 @@ INPUT;
      */
     public function testInvalidPdoAttribute($attribute)
     {
-        $adapter = new MysqlAdapter(MYSQL_DB_CONFIG + [$attribute => true]);
+        $adapter = new MysqlAdapter($this->config + [$attribute => true]);
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('Invalid PDO attribute: ' . $attribute . ' (\PDO::' . strtoupper($attribute) . ')');
         $adapter->connect();
@@ -2548,13 +2566,13 @@ INPUT;
 
     public function testPdoPersistentConnection()
     {
-        $adapter = new MysqlAdapter(MYSQL_DB_CONFIG + ['attr_persistent' => true]);
+        $adapter = new MysqlAdapter($this->config + ['attr_persistent' => true]);
         $this->assertTrue($adapter->getConnection()->getAttribute(PDO::ATTR_PERSISTENT));
     }
 
     public function testPdoNotPersistentConnection()
     {
-        $adapter = new MysqlAdapter(MYSQL_DB_CONFIG);
+        $adapter = new MysqlAdapter($this->config);
         $this->assertFalse($adapter->getConnection()->getAttribute(PDO::ATTR_PERSISTENT));
     }
 }

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -54,7 +54,7 @@ class MysqlAdapterTest extends TestCase
 
         // ensure the database is empty for each test
         $this->adapter->dropDatabase($this->config['name']);
-        $this->adapter->createDatabase($this->config['name']);
+        $this->adapter->createDatabase($this->config['name'], ['charset' => 'utf8mb4']);
 
         // leave the adapter in a disconnected state for each test
         $this->adapter->disconnect();

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -1,0 +1,3371 @@
+<?php
+declare(strict_types=1);
+
+namespace Migrations\Test\Db\Adapter;
+
+use BadMethodCallException;
+use Cake\Database\Query;
+use Cake\Datasource\ConnectionManager;
+use Exception;
+use InvalidArgumentException;
+use Migrations\Db\Adapter\SqliteAdapter;
+use Migrations\Db\Adapter\UnsupportedColumnTypeException;
+use Migrations\Db\Expression;
+use Migrations\Db\Literal;
+use Migrations\Db\Table;
+use Migrations\Db\Table\Column;
+use Migrations\Db\Table\ForeignKey;
+use PDO;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+use ReflectionObject;
+use RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\NullOutput;
+use UnexpectedValueException;
+
+class SqliteAdapterTest extends TestCase
+{
+    /**
+     * @var \Migrations\Db\Adapter\SqliteAdapter
+     */
+    private $adapter;
+
+    /**
+     * @var array
+     */
+    private $config;
+
+    protected function setUp(): void
+    {
+        $config = ConnectionManager::getConfig('test');
+        // Emulate the results of Util::parseDsn()
+        $this->config = [
+            'adapter' => $config['scheme'],
+            'host' => $config['host'],
+            'name' => $config['database'],
+        ];
+        if ($this->config['adapter'] !== 'sqlite') {
+            $this->markTestSkipped('SQLite tests disabled.');
+        }
+        $this->adapter = new SqliteAdapter($this->config, new ArrayInput([]), new NullOutput());
+
+        if ($this->config['name'] !== ':memory:') {
+            // ensure the database is empty for each test
+            $this->adapter->dropDatabase($this->config['name']);
+            $this->adapter->createDatabase($this->config['name']);
+        }
+
+        // leave the adapter in a disconnected state for each test
+        $this->adapter->disconnect();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->adapter);
+    }
+
+    public function testConnection()
+    {
+        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
+        $this->assertSame(PDO::ERRMODE_EXCEPTION, $this->adapter->getConnection()->getAttribute(PDO::ATTR_ERRMODE));
+    }
+
+    public function testConnectionWithFetchMode()
+    {
+        $options = $this->adapter->getOptions();
+        $options['fetch_mode'] = 'assoc';
+        $this->adapter->setOptions($options);
+        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
+        $this->assertSame(PDO::FETCH_ASSOC, $this->adapter->getConnection()->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE));
+    }
+
+    public function testBeginTransaction()
+    {
+        $this->adapter->beginTransaction();
+
+        $this->assertTrue(
+            $this->adapter->getConnection()->inTransaction(),
+            'Underlying PDO instance did not detect new transaction'
+        );
+    }
+
+    public function testRollbackTransaction()
+    {
+        $this->adapter->getConnection()
+            ->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->adapter->beginTransaction();
+        $this->adapter->rollbackTransaction();
+
+        $this->assertFalse(
+            $this->adapter->getConnection()->inTransaction(),
+            'Underlying PDO instance did not detect rolled back transaction'
+        );
+    }
+
+    public function testCommitTransactionTransaction()
+    {
+        $this->adapter->getConnection()
+            ->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->adapter->beginTransaction();
+        $this->adapter->commitTransaction();
+
+        $this->assertFalse(
+            $this->adapter->getConnection()->inTransaction(),
+            "Underlying PDO instance didn't detect committed transaction"
+        );
+    }
+
+    public function testCreatingTheSchemaTableOnConnect()
+    {
+        $this->adapter->connect();
+        $this->assertTrue($this->adapter->hasTable($this->adapter->getSchemaTableName()));
+        $this->adapter->dropTable($this->adapter->getSchemaTableName());
+        $this->assertFalse($this->adapter->hasTable($this->adapter->getSchemaTableName()));
+        $this->adapter->disconnect();
+        $this->adapter->connect();
+        $this->assertTrue($this->adapter->hasTable($this->adapter->getSchemaTableName()));
+    }
+
+    public function testSchemaTableIsCreatedWithPrimaryKey()
+    {
+        $this->adapter->connect();
+        new Table($this->adapter->getSchemaTableName(), [], $this->adapter);
+        $this->assertTrue($this->adapter->hasIndex($this->adapter->getSchemaTableName(), ['version']));
+    }
+
+    public function testQuoteTableName()
+    {
+        $this->assertEquals('`test_table`', $this->adapter->quoteTableName('test_table'));
+    }
+
+    public function testQuoteColumnName()
+    {
+        $this->assertEquals('`test_column`', $this->adapter->quoteColumnName('test_column'));
+    }
+
+    public function testCreateTable()
+    {
+        $table = new Table('ntable', [], $this->adapter);
+        $table->addColumn('realname', 'string')
+            ->addColumn('email', 'integer')
+            ->save();
+        $this->assertTrue($this->adapter->hasTable('ntable'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'realname'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'email'));
+        $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
+    }
+
+    public function testCreateTableCustomIdColumn()
+    {
+        $table = new Table('ntable', ['id' => 'custom_id'], $this->adapter);
+        $table->addColumn('realname', 'string')
+            ->addColumn('email', 'integer')
+            ->save();
+
+        $this->assertTrue($this->adapter->hasTable('ntable'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'custom_id'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'realname'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'email'));
+        $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
+
+        //ensure the primary key is not nullable
+        /** @var \Migrations\Db\Table\Column $idColumn */
+        $idColumn = $this->adapter->getColumns('ntable')[0];
+        $this->assertTrue($idColumn->getIdentity());
+        $this->assertFalse($idColumn->isNull());
+    }
+
+    public function testCreateTableIdentityIdColumn()
+    {
+        $table = new Table('ntable', ['id' => false, 'primary_key' => ['custom_id']], $this->adapter);
+        $table->addColumn('custom_id', 'integer', ['identity' => true])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasTable('ntable'));
+        $this->assertTrue($this->adapter->hasColumn('ntable', 'custom_id'));
+
+        /** @var \Migrations\Db\Table\Column $idColumn */
+        $idColumn = $this->adapter->getColumns('ntable')[0];
+        $this->assertTrue($idColumn->getIdentity());
+    }
+
+    public function testCreateTableWithNoPrimaryKey()
+    {
+        $options = [
+            'id' => false,
+        ];
+        $table = new Table('atable', $options, $this->adapter);
+        $table->addColumn('user_id', 'integer')
+            ->save();
+        $this->assertFalse($this->adapter->hasColumn('atable', 'id'));
+    }
+
+    public function testCreateTableWithMultiplePrimaryKeys()
+    {
+        $options = [
+            'id' => false,
+            'primary_key' => ['user_id', 'tag_id'],
+        ];
+        $table = new Table('table1', $options, $this->adapter);
+        $table->addColumn('user_id', 'integer')
+            ->addColumn('tag_id', 'integer')
+            ->save();
+        $this->assertTrue($this->adapter->hasIndex('table1', ['user_id', 'tag_id']));
+        $this->assertTrue($this->adapter->hasIndex('table1', ['USER_ID', 'tag_id']));
+        $this->assertFalse($this->adapter->hasIndex('table1', ['tag_id', 'USER_ID']));
+        $this->assertFalse($this->adapter->hasIndex('table1', ['tag_id', 'user_email']));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateTableWithPrimaryKeyAsUuid()
+    {
+        $options = [
+            'id' => false,
+            'primary_key' => 'id',
+        ];
+        $table = new Table('ztable', $options, $this->adapter);
+        $table->addColumn('id', 'uuid')->save();
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateTableWithPrimaryKeyAsBinaryUuid()
+    {
+        $options = [
+            'id' => false,
+            'primary_key' => 'id',
+        ];
+        $table = new Table('ztable', $options, $this->adapter);
+        $table->addColumn('id', 'binaryuuid')->save();
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
+    }
+
+    public function testCreateTableWithMultipleIndexes()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->addColumn('name', 'string')
+            ->addIndex('email')
+            ->addIndex('name')
+            ->save();
+        $this->assertTrue($this->adapter->hasIndex('table1', ['email']));
+        $this->assertTrue($this->adapter->hasIndex('table1', ['name']));
+        $this->assertFalse($this->adapter->hasIndex('table1', ['email', 'user_email']));
+        $this->assertFalse($this->adapter->hasIndex('table1', ['email', 'user_name']));
+    }
+
+    public function testCreateTableWithUniqueIndexes()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->addIndex('email', ['unique' => true])
+            ->save();
+        $this->assertTrue($this->adapter->hasIndex('table1', ['email']));
+        $this->assertFalse($this->adapter->hasIndex('table1', ['email', 'user_email']));
+    }
+
+    public function testCreateTableWithNamedIndexes()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->addIndex('email', ['name' => 'myemailindex'])
+            ->save();
+        $this->assertTrue($this->adapter->hasIndex('table1', ['email']));
+        $this->assertFalse($this->adapter->hasIndex('table1', ['email', 'user_email']));
+        $this->assertTrue($this->adapter->hasIndexByName('table1', 'myemailindex'));
+    }
+
+    public function testCreateTableWithMultiplePKsAndUniqueIndexes()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testCreateTableWithForeignKey()
+    {
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable->addColumn('field1', 'string')->save();
+
+        $table = new Table('table', [], $this->adapter);
+        $table->addColumn('ref_table_id', 'integer');
+        $table->addForeignKey('ref_table_id', 'ref_table', 'id');
+        $table->save();
+
+        $this->assertTrue($this->adapter->hasTable($table->getName()));
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
+    }
+
+    public function testCreateTableWithIndexesAndForeignKey()
+    {
+        $refTable = new Table('tbl_master', [], $this->adapter);
+        $refTable->create();
+
+        $table = new Table('tbl_child', [], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer')
+            ->addColumn('column2', 'integer')
+            ->addColumn('master_id', 'integer')
+            ->addIndex(['column2'])
+            ->addIndex(['column1', 'column2'], ['unique' => true, 'name' => 'uq_tbl_child_column1_column2_ndx'])
+            ->addForeignKey(
+                'master_id',
+                'tbl_master',
+                'id',
+                ['delete' => 'NO_ACTION', 'update' => 'NO_ACTION', 'constraint' => 'fk_master_id']
+            )
+            ->create();
+
+        $this->assertTrue($this->adapter->hasIndex('tbl_child', 'column2'));
+        $this->assertTrue($this->adapter->hasIndex('tbl_child', ['column1', 'column2']));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', ['master_id']));
+
+        $row = $this->adapter->fetchRow(
+            "SELECT * FROM sqlite_master WHERE `type` = 'table' AND `tbl_name` = 'tbl_child'"
+        );
+        $this->assertStringContainsString(
+            'CONSTRAINT `fk_master_id` FOREIGN KEY (`master_id`) REFERENCES `tbl_master` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION',
+            $row['sql']
+        );
+    }
+
+    public function testCreateTableWithoutAutoIncrementingPrimaryKeyAndWithForeignKey()
+    {
+        $refTable = (new Table('tbl_master', ['id' => false, 'primary_key' => 'id'], $this->adapter))
+            ->addColumn('id', 'text');
+        $refTable->create();
+
+        $table = (new Table('tbl_child', ['id' => false, 'primary_key' => 'master_id'], $this->adapter))
+            ->addColumn('master_id', 'text')
+            ->addForeignKey(
+                'master_id',
+                'tbl_master',
+                'id',
+                ['delete' => 'NO_ACTION', 'update' => 'NO_ACTION', 'constraint' => 'fk_master_id']
+            );
+        $table->create();
+
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', ['master_id']));
+
+        $row = $this->adapter->fetchRow(
+            "SELECT * FROM sqlite_master WHERE `type` = 'table' AND `tbl_name` = 'tbl_child'"
+        );
+        $this->assertStringContainsString(
+            'CONSTRAINT `fk_master_id` FOREIGN KEY (`master_id`) REFERENCES `tbl_master` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION',
+            $row['sql']
+        );
+    }
+
+    public function testAddPrimaryKey()
+    {
+        $table = new Table('table1', ['id' => false], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer')
+            ->addColumn('column2', 'integer')
+            ->save();
+
+        $table
+            ->changePrimaryKey('column1')
+            ->save();
+
+        $this->assertTrue($this->adapter->hasPrimaryKey('table1', ['column1']));
+    }
+
+    public function testChangePrimaryKey()
+    {
+        $table = new Table('table1', ['id' => false, 'primary_key' => 'column1'], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer')
+            ->addColumn('column2', 'integer')
+            ->save();
+
+        $table
+            ->changePrimaryKey('column2')
+            ->save();
+
+        $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['column1']));
+        $this->assertTrue($this->adapter->hasPrimaryKey('table1', ['column2']));
+    }
+
+    public function testChangePrimaryKeyNonInteger()
+    {
+        $table = new Table('table1', ['id' => false, 'primary_key' => 'column1'], $this->adapter);
+        $table
+            ->addColumn('column1', 'string')
+            ->addColumn('column2', 'string')
+            ->save();
+
+        $table
+            ->changePrimaryKey('column2')
+            ->save();
+
+        $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['column1']));
+        $this->assertTrue($this->adapter->hasPrimaryKey('table1', ['column2']));
+    }
+
+    public function testDropPrimaryKey()
+    {
+        $table = new Table('table1', ['id' => false, 'primary_key' => 'column1'], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer')
+            ->addColumn('column2', 'integer')
+            ->save();
+
+        $table
+            ->changePrimaryKey(null)
+            ->save();
+
+        $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['column1']));
+    }
+
+    public function testAddMultipleColumnPrimaryKeyFails()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table
+            ->addColumn('column1', 'integer')
+            ->addColumn('column2', 'integer')
+            ->save();
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $table
+            ->changePrimaryKey(['column1', 'column2'])
+            ->save();
+    }
+
+    public function testChangeCommentFails()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->save();
+
+        $this->expectException(BadMethodCallException::class);
+
+        $table
+            ->changeComment('comment1')
+            ->save();
+    }
+
+    public function testRenameTable()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->save();
+        $this->assertTrue($this->adapter->hasTable('table1'));
+        $this->assertFalse($this->adapter->hasTable('table2'));
+        $this->adapter->renameTable('table1', 'table2');
+        $this->assertFalse($this->adapter->hasTable('table1'));
+        $this->assertTrue($this->adapter->hasTable('table2'));
+    }
+
+    public function testAddColumn()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->save();
+        $this->assertFalse($table->hasColumn('email'));
+        $table->addColumn('email', 'string', ['null' => true])
+            ->save();
+        $this->assertTrue($table->hasColumn('email'));
+
+        // In SQLite it is not possible to dictate order of added columns.
+        // $table->addColumn('realname', 'string', array('after' => 'id'))
+        //       ->save();
+        // $this->assertEquals('realname', $rows[1]['Field']);
+    }
+
+    public function testAddColumnWithDefaultValue()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->save();
+        $table->addColumn('default_zero', 'string', ['default' => 'test'])
+            ->save();
+        $rows = $this->adapter->fetchAll(sprintf('pragma table_info(%s)', 'table1'));
+        $this->assertEquals("'test'", $rows[1]['dflt_value']);
+    }
+
+    public function testAddColumnWithDefaultZero()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->save();
+        $table->addColumn('default_zero', 'integer', ['default' => 0])
+            ->save();
+        $rows = $this->adapter->fetchAll(sprintf('pragma table_info(%s)', 'table1'));
+        $this->assertNotNull($rows[1]['dflt_value']);
+        $this->assertEquals('0', $rows[1]['dflt_value']);
+    }
+
+    public function testAddColumnWithDefaultEmptyString()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->save();
+        $table->addColumn('default_empty', 'string', ['default' => ''])
+            ->save();
+        $rows = $this->adapter->fetchAll(sprintf('pragma table_info(%s)', 'table1'));
+        $this->assertEquals("''", $rows[1]['dflt_value']);
+    }
+
+    public function testAddColumnWithCustomType()
+    {
+        $this->adapter->setDataDomain([
+            'custom' => [
+                'type' => 'string',
+                'null' => true,
+                'limit' => 15,
+            ],
+        ]);
+
+        (new Table('table1', [], $this->adapter))
+            ->addColumn('custom', 'custom')
+            ->addColumn('custom_ext', 'custom', [
+                'null' => false,
+                'limit' => 30,
+            ])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasTable('table1'));
+
+        $columns = $this->adapter->getColumns('table1');
+        $this->assertArrayHasKey(1, $columns);
+        $this->assertArrayHasKey(2, $columns);
+
+        $column = $this->adapter->getColumns('table1')[1];
+        $this->assertSame('custom', $column->getName());
+        $this->assertSame('string', $column->getType());
+        $this->assertSame(15, $column->getLimit());
+        $this->assertTrue($column->getNull());
+
+        $column = $this->adapter->getColumns('table1')[2];
+        $this->assertSame('custom_ext', $column->getName());
+        $this->assertSame('string', $column->getType());
+        $this->assertSame(30, $column->getLimit());
+        $this->assertFalse($column->getNull());
+    }
+
+    public static function irregularCreateTableProvider()
+    {
+        return [
+            ["CREATE TABLE \"users\"\n( `id` INTEGER NOT NULL )", ['id', 'foo']],
+            ['CREATE TABLE users   (    id INTEGER NOT NULL )', ['id', 'foo']],
+            ["CREATE TABLE [users]\n(\nid INTEGER NOT NULL)", ['id', 'foo']],
+            ["CREATE TABLE \"users\" ([id] \n INTEGER NOT NULL\n, \"bar\" INTEGER)", ['id', 'bar', 'foo']],
+        ];
+    }
+
+    /**
+     * @dataProvider irregularCreateTableProvider
+     */
+    public function testAddColumnToIrregularCreateTableStatements(string $createTableSql, array $expectedColumns): void
+    {
+        $this->adapter->execute($createTableSql);
+        $table = new Table('users', [], $this->adapter);
+        $table->addColumn('foo', 'string');
+        $table->update();
+
+        $columns = $this->adapter->getColumns('users');
+        $columnCount = count($columns);
+        for ($i = 0; $i < $columnCount; $i++) {
+            $this->assertEquals($expectedColumns[$i], $columns[$i]->getName());
+        }
+    }
+
+    public function testAddDoubleColumn()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->save();
+        $table->addColumn('foo', 'double', ['null' => true])
+            ->save();
+        $rows = $this->adapter->fetchAll(sprintf('pragma table_info(%s)', 'table1'));
+        $this->assertEquals('DOUBLE', $rows[1]['type']);
+    }
+
+    public function testRenameColumn()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'string')
+            ->save();
+        $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
+        $this->adapter->renameColumn('t', 'column1', 'column2');
+        $this->assertFalse($this->adapter->hasColumn('t', 'column1'));
+        $this->assertTrue($this->adapter->hasColumn('t', 'column2'));
+    }
+
+    public function testRenamingANonExistentColumn()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'string')
+            ->save();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("The specified column doesn't exist: column2");
+        $this->adapter->renameColumn('t', 'column2', 'column1');
+    }
+
+    public function testRenameColumnWithIndex()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->addIndex('indexcol')
+            ->create();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcol'));
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), 'newindexcol'));
+
+        $table->renameColumn('indexcol', 'newindexcol')->update();
+
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), 'indexcol'));
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'newindexcol'));
+    }
+
+    public function testRenameColumnWithUniqueIndex()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->addIndex('indexcol', ['unique' => true])
+            ->create();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcol'));
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), 'newindexcol'));
+
+        $table->renameColumn('indexcol', 'newindexcol')->update();
+
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), 'indexcol'));
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'newindexcol'));
+    }
+
+    public function testRenameColumnWithCompositeIndex()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol1', 'integer')
+            ->addColumn('indexcol2', 'integer')
+            ->addIndex(['indexcol1', 'indexcol2'])
+            ->create();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), ['indexcol1', 'indexcol2']));
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), ['indexcol1', 'newindexcol2']));
+
+        $table->renameColumn('indexcol2', 'newindexcol2')->update();
+
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), ['indexcol1', 'indexcol2']));
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), ['indexcol1', 'newindexcol2']));
+    }
+
+    /**
+     * Tests that rewriting the index SQL does not accidentally change
+     * the table name in case it matches the column name.
+     */
+    public function testRenameColumnWithIndexMatchingTheTableName()
+    {
+        $table = new Table('indexcol', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->addIndex('indexcol')
+            ->create();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcol'));
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), 'newindexcol'));
+
+        $table->renameColumn('indexcol', 'newindexcol')->update();
+
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), 'indexcol'));
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'newindexcol'));
+    }
+
+    /**
+     * Tests that rewriting the index SQL does not accidentally change
+     * column names that partially match the column to rename.
+     */
+    public function testRenameColumnWithIndexColumnPartialMatch()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->addColumn('indexcolumn', 'integer')
+            ->create();
+
+        $this->adapter->execute('CREATE INDEX custom_idx ON t (indexcolumn, indexcol)');
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), ['indexcolumn', 'indexcol']));
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), ['indexcolumn', 'newindexcol']));
+
+        $table->renameColumn('indexcol', 'newindexcol')->update();
+
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), ['indexcolumn', 'indexcol']));
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), ['indexcolumn', 'newindexcol']));
+    }
+
+    public function testRenameColumnWithIndexColumnRequiringQuoting()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->addIndex('indexcol')
+            ->create();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcol'));
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), 'new index col'));
+
+        $table->renameColumn('indexcol', 'new index col')->update();
+
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), 'indexcol'));
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'new index col'));
+    }
+
+    /**
+     * Indices that are using expressions are not being updated.
+     */
+    public function testRenameColumnWithExpressionIndex()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->create();
+
+        $this->adapter->execute('CREATE INDEX custom_idx ON t (`indexcol`, ABS(`indexcol`))');
+
+        $this->assertTrue($this->adapter->hasIndexByName('t', 'custom_idx'));
+
+        $this->expectException(PDOException::class);
+        $this->expectExceptionMessage('no such column: indexcol');
+
+        $table->renameColumn('indexcol', 'newindexcol')->update();
+    }
+
+    /**
+     * Index SQL is mostly returned as-is, hence custom indices can contain
+     * a wide variety of formats.
+     */
+    public static function customIndexSQLDataProvider(): array
+    {
+        return [
+            [
+                'CREATE INDEX test_idx ON t(indexcol);',
+                'CREATE INDEX test_idx ON t(`newindexcol`)',
+            ],
+            [
+                'CREATE INDEX test_idx ON t(`indexcol`);',
+                'CREATE INDEX test_idx ON t(`newindexcol`)',
+            ],
+            [
+                'CREATE INDEX test_idx ON t("indexcol");',
+                'CREATE INDEX test_idx ON t(`newindexcol`)',
+            ],
+            [
+                'CREATE INDEX test_idx ON t([indexcol]);',
+                'CREATE INDEX test_idx ON t(`newindexcol`)',
+            ],
+            [
+                'CREATE INDEX test_idx ON t(indexcol ASC);',
+                'CREATE INDEX test_idx ON t(`newindexcol` ASC)',
+            ],
+            [
+                'CREATE INDEX test_idx ON t(`indexcol` ASC);',
+                'CREATE INDEX test_idx ON t(`newindexcol` ASC)',
+            ],
+            [
+                'CREATE INDEX test_idx ON t("indexcol" DESC);',
+                'CREATE INDEX test_idx ON t(`newindexcol` DESC)',
+            ],
+            [
+                'CREATE INDEX test_idx ON t([indexcol] DESC);',
+                'CREATE INDEX test_idx ON t(`newindexcol` DESC)',
+            ],
+            [
+                'CREATE INDEX test_idx ON t(indexcol COLLATE BINARY);',
+                'CREATE INDEX test_idx ON t(`newindexcol` COLLATE BINARY)',
+            ],
+            [
+                'CREATE INDEX test_idx ON t(indexcol COLLATE BINARY ASC);',
+                'CREATE INDEX test_idx ON t(`newindexcol` COLLATE BINARY ASC)',
+            ],
+            [
+                '
+                    cReATE uniQUE inDEx
+                        iF   nOT   ExISts
+                            main.test_idx   on   t  (
+                                ( ((
+                                    inDEXcoL
+                                ) )) COLLATE   BINARY   ASC
+                            );
+                ',
+                'CREATE UNIQUE INDEX test_idx   on   t  (
+                                ( ((
+                                    `newindexcol`
+                                ) )) COLLATE   BINARY   ASC
+                            )',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider customIndexSQLDataProvider
+     * @param string $indexSQL Index creation SQL
+     * @param string $newIndexSQL Expected new index creation SQL
+     */
+    public function testRenameColumnWithCustomIndex(string $indexSQL, string $newIndexSQL)
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->create();
+
+        $this->adapter->execute($indexSQL);
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcol'));
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), 'newindexcol'));
+
+        $table->renameColumn('indexcol', 'newindexcol')->update();
+
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), 'indexcol'));
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'newindexcol'));
+
+        $index = $this->adapter->fetchRow("SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'test_idx'");
+        $this->assertSame($newIndexSQL, $index['sql']);
+    }
+
+    /**
+     * Index SQL is mostly returned as-is, hence custom indices can contain
+     * a wide variety of formats.
+     */
+    public static function customCompositeIndexSQLDataProvider(): array
+    {
+        return [
+            [
+                'CREATE INDEX test_idx ON t(indexcol1, indexcol2, indexcol3);',
+                'CREATE INDEX test_idx ON t(indexcol1, `newindexcol`, indexcol3)',
+            ],
+            [
+                'CREATE INDEX test_idx ON t(`indexcol1`, `indexcol2`, `indexcol3`);',
+                'CREATE INDEX test_idx ON t(`indexcol1`, `newindexcol`, `indexcol3`)',
+            ],
+            [
+                'CREATE INDEX test_idx ON t("indexcol1", "indexcol2", "indexcol3");',
+                'CREATE INDEX test_idx ON t("indexcol1", `newindexcol`, "indexcol3")',
+            ],
+            [
+                'CREATE INDEX test_idx ON t([indexcol1], [indexcol2], [indexcol3]);',
+                'CREATE INDEX test_idx ON t([indexcol1], `newindexcol`, [indexcol3])',
+            ],
+            [
+                'CREATE INDEX test_idx ON t(indexcol1 ASC, indexcol2 DESC, indexcol3);',
+                'CREATE INDEX test_idx ON t(indexcol1 ASC, `newindexcol` DESC, indexcol3)',
+            ],
+            [
+                'CREATE INDEX test_idx ON t(`indexcol1` ASC, `indexcol2` DESC, `indexcol3`);',
+                'CREATE INDEX test_idx ON t(`indexcol1` ASC, `newindexcol` DESC, `indexcol3`)',
+            ],
+            [
+                'CREATE INDEX test_idx ON t("indexcol1" ASC, "indexcol2" DESC, "indexcol3");',
+                'CREATE INDEX test_idx ON t("indexcol1" ASC, `newindexcol` DESC, "indexcol3")',
+            ],
+            [
+                'CREATE INDEX test_idx ON t([indexcol1] ASC, [indexcol2] DESC, [indexcol3]);',
+                'CREATE INDEX test_idx ON t([indexcol1] ASC, `newindexcol` DESC, [indexcol3])',
+            ],
+            [
+                'CREATE INDEX test_idx ON t(indexcol1 COLLATE BINARY, indexcol2 COLLATE NOCASE, indexcol3);',
+                'CREATE INDEX test_idx ON t(indexcol1 COLLATE BINARY, `newindexcol` COLLATE NOCASE, indexcol3)',
+            ],
+            [
+                'CREATE INDEX test_idx ON t(indexcol1 COLLATE BINARY ASC, indexcol2 COLLATE NOCASE DESC, indexcol3);',
+                'CREATE INDEX test_idx ON t(indexcol1 COLLATE BINARY ASC, `newindexcol` COLLATE NOCASE DESC, indexcol3)',
+            ],
+            [
+                '
+                    cReATE uniQUE inDEx
+                        iF   nOT   ExISts
+                            main.test_idx   on   t  (
+                                inDEXcoL1 ,
+                                ( ((
+                                    inDEXcoL2
+                                ) )) COLLATE   BINARY   ASC ,
+                                inDEXcoL3
+                            );
+                ',
+                'CREATE UNIQUE INDEX test_idx   on   t  (
+                                inDEXcoL1 ,
+                                ( ((
+                                    `newindexcol`
+                                ) )) COLLATE   BINARY   ASC ,
+                                inDEXcoL3
+                            )',
+            ],
+        ];
+    }
+
+    /**
+     * Index SQL is mostly returned as-is, hence custom indices can contain
+     * a wide variety of formats.
+     *
+     * @dataProvider customCompositeIndexSQLDataProvider
+     * @param string $indexSQL Index creation SQL
+     * @param string $newIndexSQL Expected new index creation SQL
+     */
+    public function testRenameColumnWithCustomCompositeIndex(string $indexSQL, string $newIndexSQL)
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol1', 'integer')
+            ->addColumn('indexcol2', 'integer')
+            ->addColumn('indexcol3', 'integer')
+            ->create();
+
+        $this->adapter->execute($indexSQL);
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), ['indexcol1', 'indexcol2', 'indexcol3']));
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), ['indexcol1', 'newindexcol', 'indexcol3']));
+
+        $table->renameColumn('indexcol2', 'newindexcol')->update();
+
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), ['indexcol1', 'indexcol2', 'indexcol3']));
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), ['indexcol1', 'newindexcol', 'indexcol3']));
+
+        $index = $this->adapter->fetchRow("SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'test_idx'");
+        $this->assertSame($newIndexSQL, $index['sql']);
+    }
+
+    public function testChangeColumn()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'string')
+            ->save();
+        $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
+        $newColumn1 = new Column();
+        $newColumn1->setName('column1');
+        $newColumn1->setType('string');
+        $table->changeColumn('column1', $newColumn1);
+        $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
+        $newColumn2 = new Column();
+        $newColumn2->setName('column2')
+            ->setType('string');
+        $table->changeColumn('column1', $newColumn2)->save();
+        $this->assertFalse($this->adapter->hasColumn('t', 'column1'));
+        $this->assertTrue($this->adapter->hasColumn('t', 'column2'));
+    }
+
+    public function testChangeColumnDefaultValue()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'string', ['default' => 'test'])
+            ->save();
+        $newColumn1 = new Column();
+        $newColumn1
+            ->setName('column1')
+            ->setDefault('test1')
+            ->setType('string');
+        $table->changeColumn('column1', $newColumn1)->save();
+        $rows = $this->adapter->fetchAll('pragma table_info(t)');
+
+        $this->assertEquals("'test1'", $rows[1]['dflt_value']);
+    }
+
+    /**
+     * @group bug922
+     */
+    public function testChangeColumnWithForeignKey()
+    {
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable->addColumn('field1', 'string')->save();
+
+        $table = new Table('another_table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer')
+            ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
+
+        $table->changeColumn('ref_table_id', 'float')->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
+    }
+
+    public function testChangeColumnWithIndex()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->addIndex(
+                'indexcol',
+                ['unique' => true]
+            )
+            ->create();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcol'));
+
+        $table->changeColumn('indexcol', 'integer', ['null' => false])->update();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcol'));
+    }
+
+    public function testChangeColumnWithTrigger()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('triggercol', 'integer')
+            ->addColumn('othercol', 'integer')
+            ->create();
+
+        $triggerSQL =
+            'CREATE TRIGGER update_t_othercol UPDATE OF triggercol ON t
+                BEGIN
+                    UPDATE t SET othercol = new.triggercol;
+                END';
+
+        $this->adapter->execute($triggerSQL);
+
+        $rows = $this->adapter->fetchAll(
+            "SELECT * FROM sqlite_master WHERE `type` = 'trigger' AND tbl_name = 't'"
+        );
+        $this->assertCount(1, $rows);
+        $this->assertEquals('trigger', $rows[0]['type']);
+        $this->assertEquals('update_t_othercol', $rows[0]['name']);
+        $this->assertEquals($triggerSQL, $rows[0]['sql']);
+
+        $table->changeColumn('triggercol', 'integer', ['null' => false])->update();
+
+        $rows = $this->adapter->fetchAll(
+            "SELECT * FROM sqlite_master WHERE `type` = 'trigger' AND tbl_name = 't'"
+        );
+        $this->assertCount(1, $rows);
+        $this->assertEquals('trigger', $rows[0]['type']);
+        $this->assertEquals('update_t_othercol', $rows[0]['name']);
+        $this->assertEquals($triggerSQL, $rows[0]['sql']);
+    }
+
+    public function testChangeColumnDefaultToZero()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'integer')
+            ->save();
+        $newColumn1 = new Column();
+        $newColumn1->setDefault(0)
+            ->setName('column1')
+            ->setType('integer');
+        $table->changeColumn('column1', $newColumn1)->save();
+        $rows = $this->adapter->fetchAll('pragma table_info(t)');
+        $this->assertEquals('0', $rows[1]['dflt_value']);
+    }
+
+    public function testChangeColumnDefaultToNull()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'string', ['default' => 'test'])
+            ->save();
+        $newColumn1 = new Column();
+        $newColumn1->setDefault(null)
+            ->setName('column1')
+            ->setType('string');
+        $table->changeColumn('column1', $newColumn1)->save();
+        $rows = $this->adapter->fetchAll('pragma table_info(t)');
+        $this->assertNull($rows[1]['dflt_value']);
+    }
+
+    public function testChangeColumnWithCommasInCommentsOrDefaultValue()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'string', ['default' => 'one, two or three', 'comment' => 'three, two or one'])
+            ->save();
+        $newColumn1 = new Column();
+        $newColumn1->setDefault('another default')
+            ->setName('column1')
+            ->setComment('another comment')
+            ->setType('string');
+        $table->changeColumn('column1', $newColumn1)->save();
+        $cols = $this->adapter->getColumns('t');
+        $this->assertEquals('another default', (string)$cols[1]->getDefault());
+    }
+
+    /**
+     * @dataProvider columnCreationArgumentProvider
+     */
+    public function testDropColumn($columnCreationArgs)
+    {
+        $table = new Table('t', [], $this->adapter);
+        $columnName = $columnCreationArgs[0];
+        call_user_func_array([$table, 'addColumn'], $columnCreationArgs);
+        $table->save();
+        $this->assertTrue($this->adapter->hasColumn('t', $columnName));
+
+        $table->removeColumn($columnName)->save();
+
+        $this->assertFalse($this->adapter->hasColumn('t', $columnName));
+    }
+
+    public function testDropColumnWithIndex()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->addIndex('indexcol')
+            ->create();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcol'));
+
+        $table->removeColumn('indexcol')->update();
+
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), 'indexcol'));
+    }
+
+    public function testDropColumnWithUniqueIndex()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->addIndex('indexcol', ['unique' => true])
+            ->create();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcol'));
+
+        $table->removeColumn('indexcol')->update();
+
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), 'indexcol'));
+    }
+
+    public function testDropColumnWithCompositeIndex()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol1', 'integer')
+            ->addColumn('indexcol2', 'integer')
+            ->addIndex(['indexcol1', 'indexcol2'])
+            ->create();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), ['indexcol1', 'indexcol2']));
+
+        $table->removeColumn('indexcol2')->update();
+
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), ['indexcol1', 'indexcol2']));
+    }
+
+    /**
+     * Tests that removing columns does not accidentally drop indices
+     * on table names that match the column to remove.
+     */
+    public function testDropColumnWithIndexMatchingTheTableName()
+    {
+        $table = new Table('indexcol', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->addColumn('indexcolumn', 'integer')
+            ->addIndex('indexcolumn')
+            ->create();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcolumn'));
+
+        $table->removeColumn('indexcol')->update();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcolumn'));
+    }
+
+    /**
+     * Tests that removing columns does not accidentally drop indices
+     * that contain column names that partially match the column to remove.
+     */
+    public function testDropColumnWithIndexColumnPartialMatch()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->addColumn('indexcolumn', 'integer')
+            ->create();
+
+        $this->adapter->execute('CREATE INDEX custom_idx ON t (indexcolumn)');
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcolumn'));
+
+        $table->removeColumn('indexcol')->update();
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcolumn'));
+    }
+
+    /**
+     * Indices with expressions are not being removed.
+     */
+    public function testDropColumnWithExpressionIndex()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->create();
+
+        $this->adapter->execute('CREATE INDEX custom_idx ON t (ABS(indexcol))');
+
+        $this->assertTrue($this->adapter->hasIndexByName('t', 'custom_idx'));
+
+        $this->expectException(PDOException::class);
+        $this->expectExceptionMessage('no such column: indexcol');
+
+        $table->removeColumn('indexcol')->update();
+    }
+
+    /**
+     * @dataProvider customIndexSQLDataProvider
+     * @param string $indexSQL Index creation SQL
+     */
+    public function testDropColumnWithCustomIndex(string $indexSQL)
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol', 'integer')
+            ->create();
+
+        $this->adapter->execute($indexSQL);
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), 'indexcol'));
+
+        $table->removeColumn('indexcol')->update();
+
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), 'indexcol'));
+    }
+
+    /**
+     * @dataProvider customCompositeIndexSQLDataProvider
+     * @param string $indexSQL Index creation SQL
+     */
+    public function testDropColumnWithCustomCompositeIndex(string $indexSQL)
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table
+            ->addColumn('indexcol1', 'integer')
+            ->addColumn('indexcol2', 'integer')
+            ->addColumn('indexcol3', 'integer')
+            ->create();
+
+        $this->adapter->execute($indexSQL);
+
+        $this->assertTrue($this->adapter->hasIndex($table->getName(), ['indexcol1', 'indexcol2', 'indexcol3']));
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), ['indexcol1', 'indexcol3']));
+
+        $table->removeColumn('indexcol2')->update();
+
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), ['indexcol1', 'indexcol2', 'indexcol3']));
+        $this->assertFalse($this->adapter->hasIndex($table->getName(), ['indexcol1', 'indexcol3']));
+    }
+
+    public static function columnCreationArgumentProvider()
+    {
+        return [
+            [['column1', 'string']],
+            [['profile_colour', 'integer']],
+        ];
+    }
+
+    public static function columnsProvider()
+    {
+        return [
+            ['column1', 'string', []],
+            ['column2', 'integer', []],
+            ['column3', 'biginteger', []],
+            ['column4', 'text', []],
+            ['column5', 'float', []],
+            ['column7', 'datetime', []],
+            ['column8', 'time', []],
+            ['column9', 'timestamp', []],
+            ['column10', 'date', []],
+            ['column11', 'binary', []],
+            ['column13', 'string', ['limit' => 10]],
+            ['column15', 'smallinteger', []],
+            ['column15', 'integer', []],
+            ['column23', 'json', []],
+        ];
+    }
+
+    public function testAddIndex()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->save();
+        $this->assertFalse($table->hasIndex('email'));
+        $table->addIndex('email')
+            ->save();
+        $this->assertTrue($table->hasIndex('email'));
+    }
+
+    public function testDropIndex()
+    {
+        // single column index
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->addIndex('email')
+            ->save();
+        $this->assertTrue($table->hasIndex('email'));
+        $this->adapter->dropIndex($table->getName(), 'email');
+        $this->assertFalse($table->hasIndex('email'));
+
+        // multiple column index
+        $table2 = new Table('table2', [], $this->adapter);
+        $table2->addColumn('fname', 'string')
+            ->addColumn('lname', 'string')
+            ->addIndex(['fname', 'lname'])
+            ->save();
+        $this->assertTrue($table2->hasIndex(['fname', 'lname']));
+        $this->adapter->dropIndex($table2->getName(), ['fname', 'lname']);
+        $this->assertFalse($table2->hasIndex(['fname', 'lname']));
+
+        // single column index with name specified
+        $table3 = new Table('table3', [], $this->adapter);
+        $table3->addColumn('email', 'string')
+            ->addIndex('email', ['name' => 'someindexname'])
+            ->save();
+        $this->assertTrue($table3->hasIndex('email'));
+        $this->adapter->dropIndex($table3->getName(), 'email');
+        $this->assertFalse($table3->hasIndex('email'));
+
+        // multiple column index with name specified
+        $table4 = new Table('table4', [], $this->adapter);
+        $table4->addColumn('fname', 'string')
+            ->addColumn('lname', 'string')
+            ->addIndex(['fname', 'lname'], ['name' => 'multiname'])
+            ->save();
+        $this->assertTrue($table4->hasIndex(['fname', 'lname']));
+        $this->adapter->dropIndex($table4->getName(), ['fname', 'lname']);
+        $this->assertFalse($table4->hasIndex(['fname', 'lname']));
+    }
+
+    public function testDropIndexByName()
+    {
+        // single column index
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->addIndex('email', ['name' => 'myemailindex'])
+            ->save();
+        $this->assertTrue($table->hasIndex('email'));
+        $this->adapter->dropIndexByName($table->getName(), 'myemailindex');
+        $this->assertFalse($table->hasIndex('email'));
+
+        // multiple column index
+        $table2 = new Table('table2', [], $this->adapter);
+        $table2->addColumn('fname', 'string')
+            ->addColumn('lname', 'string')
+            ->addIndex(['fname', 'lname'], ['name' => 'twocolumnindex'])
+            ->save();
+        $this->assertTrue($table2->hasIndex(['fname', 'lname']));
+        $this->adapter->dropIndexByName($table2->getName(), 'twocolumnindex');
+        $this->assertFalse($table2->hasIndex(['fname', 'lname']));
+    }
+
+    public function testAddForeignKey()
+    {
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable->addColumn('field1', 'string')->save();
+
+        $table = new Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer')
+            ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
+    }
+
+    public function testDropForeignKey()
+    {
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable->addColumn('field1', 'string')
+            ->addIndex(['field1'], ['unique' => true])
+            ->save();
+
+        $table = new Table('another_table', [], $this->adapter);
+        $opts = [
+            'update' => 'CASCADE',
+            'delete' => 'CASCADE',
+        ];
+        $table
+            ->addColumn('ref_table_id', 'integer')
+            ->addColumn('ref_table_field', 'string')
+            ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
+            ->addForeignKey(['ref_table_field'], 'ref_table', ['field1'], $opts)
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
+
+        $this->adapter->dropForeignKey($table->getName(), ['ref_table_id']);
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_field']));
+
+        $this->adapter->dropForeignKey($table->getName(), ['ref_table_field']);
+        $this->assertTrue($this->adapter->hasTable($table->getName()));
+    }
+
+    public function testDropForeignKeyWithQuoteVariants()
+    {
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable->addColumn('field1', 'string')
+            ->addIndex(['field1'], ['unique' => true])
+            ->save();
+
+        $this->adapter->execute("
+            CREATE TABLE `table` (
+                `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                [ref_[_brackets] INTEGER NOT NULL,
+                `ref_``_ticks` INTEGER NOT NULL,
+                \"ref_\"\"_double_quotes\" INTEGER NOT NULL,
+                'ref_''_single_quotes' INTEGER NOT NULL,
+                ref_no_quotes INTEGER NOT NULL,
+                ref_no_space INTEGER NOT NULL,
+                ref_lots_of_space INTEGER NOT NULL,
+                FOREIGN KEY ([ref_[_brackets]) REFERENCES `ref_table` (`id`),
+                FOREIGN KEY (`ref_``_ticks`) REFERENCES `ref_table` (`id`),
+                FOREIGN KEY (\"ref_\"\"_double_quotes\") REFERENCES `ref_table` (`id`),
+                FOREIGN KEY ('ref_''_single_quotes') REFERENCES `ref_table` (`id`),
+                FOREIGN KEY (ref_no_quotes) REFERENCES `ref_table` (`id`),
+                FOREIGN KEY (`ref_``_ticks`, 'ref_''_single_quotes') REFERENCES `ref_table` (`id`, `field1`),
+                FOREIGN KEY(`ref_no_space`,`ref_no_space`)REFERENCES`ref_table`(`id`,`id`),
+                foreign      KEY
+                    ( `ref_lots_of_space`		,`ref_lots_of_space`    )
+                        REFErences   `ref_table`  (`id`    ,	`id`)
+            )
+        ");
+
+        $this->assertTrue($this->adapter->hasForeignKey('table', ['ref_[_brackets']));
+        $this->adapter->dropForeignKey('table', ['ref_[_brackets']);
+        $this->assertFalse($this->adapter->hasForeignKey('table', ['ref_[_brackets']));
+
+        $this->assertTrue($this->adapter->hasForeignKey('table', ['ref_"_double_quotes']));
+        $this->adapter->dropForeignKey('table', ['ref_"_double_quotes']);
+        $this->assertFalse($this->adapter->hasForeignKey('table', ['ref_"_double_quotes']));
+
+        $this->assertTrue($this->adapter->hasForeignKey('table', ["ref_'_single_quotes"]));
+        $this->adapter->dropForeignKey('table', ["ref_'_single_quotes"]);
+        $this->assertFalse($this->adapter->hasForeignKey('table', ["ref_'_single_quotes"]));
+
+        $this->assertTrue($this->adapter->hasForeignKey('table', ['ref_no_quotes']));
+        $this->adapter->dropForeignKey('table', ['ref_no_quotes']);
+        $this->assertFalse($this->adapter->hasForeignKey('table', ['ref_no_quotes']));
+
+        $this->assertTrue($this->adapter->hasForeignKey('table', ['ref_`_ticks', "ref_'_single_quotes"]));
+        $this->adapter->dropForeignKey('table', ['ref_`_ticks', "ref_'_single_quotes"]);
+        $this->assertFalse($this->adapter->hasForeignKey('table', ['ref_`_ticks', "ref_'_single_quotes"]));
+
+        $this->assertTrue($this->adapter->hasForeignKey('table', ['ref_no_space', 'ref_no_space']));
+        $this->adapter->dropForeignKey('table', ['ref_no_space', 'ref_no_space']);
+        $this->assertFalse($this->adapter->hasForeignKey('table', ['ref_no_space', 'ref_no_space']));
+
+        $this->assertTrue($this->adapter->hasForeignKey('table', ['ref_lots_of_space', 'ref_lots_of_space']));
+        $this->adapter->dropForeignKey('table', ['ref_lots_of_space', 'ref_lots_of_space']);
+        $this->assertFalse($this->adapter->hasForeignKey('table', ['ref_lots_of_space', 'ref_lots_of_space']));
+    }
+
+    public function testDropForeignKeyWithMultipleColumns()
+    {
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable
+            ->addColumn('field1', 'string')
+            ->addColumn('field2', 'string')
+            ->addIndex(['id', 'field1'], ['unique' => true])
+            ->addIndex(['field1', 'id'], ['unique' => true])
+            ->addIndex(['id', 'field1', 'field2'], ['unique' => true])
+            ->save();
+
+        $table = new Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer')
+            ->addColumn('ref_table_field1', 'string')
+            ->addColumn('ref_table_field2', 'string')
+            ->addForeignKey(
+                ['ref_table_id', 'ref_table_field1'],
+                'ref_table',
+                ['id', 'field1']
+            )
+            ->addForeignKey(
+                ['ref_table_field1', 'ref_table_id'],
+                'ref_table',
+                ['field1', 'id']
+            )
+            ->addForeignKey(
+                ['ref_table_id', 'ref_table_field1', 'ref_table_field2'],
+                'ref_table',
+                ['id', 'field1', 'field2']
+            )
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
+        $this->adapter->dropForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']);
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
+        $this->assertTrue(
+            $this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1', 'ref_table_field2']),
+            'dropForeignKey() should only affect foreign keys that comprise of exactly the given columns'
+        );
+        $this->assertTrue(
+            $this->adapter->hasForeignKey($table->getName(), ['ref_table_field1', 'ref_table_id']),
+            'dropForeignKey() should only affect foreign keys that comprise of columns in exactly the given order'
+        );
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_field1', 'ref_table_id']));
+        $this->adapter->dropForeignKey($table->getName(), ['ref_table_field1', 'ref_table_id']);
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_field1', 'ref_table_id']));
+    }
+
+    public function testDropForeignKeyWithIdenticalMultipleColumns()
+    {
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable
+            ->addColumn('field1', 'string')
+            ->addIndex(['id', 'field1'], ['unique' => true])
+            ->save();
+
+        $table = new Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer', ['signed' => false])
+            ->addColumn('ref_table_field1', 'string')
+            ->addForeignKeyWithName(
+                'ref_table_fk_1',
+                ['ref_table_id', 'ref_table_field1'],
+                'ref_table',
+                ['id', 'field1'],
+            )
+            ->addForeignKeyWithName(
+                'ref_table_fk_2',
+                ['ref_table_id', 'ref_table_field1'],
+                'ref_table',
+                ['id', 'field1']
+            )
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_1'));
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_2'));
+
+        $this->adapter->dropForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']);
+
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_1'));
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_2'));
+    }
+
+    public static function nonExistentForeignKeyColumnsProvider(): array
+    {
+        return [
+            [['ref_table_id']],
+            [['ref_table_field1']],
+            [['ref_table_field1', 'ref_table_id']],
+            [['non_existent_column']],
+        ];
+    }
+
+    /**
+     * @dataProvider nonExistentForeignKeyColumnsProvider
+     * @param array $columns
+     */
+    public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
+    {
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable
+            ->addColumn('field1', 'string')
+            ->addIndex(['id', 'field1'], ['unique' => true])
+            ->save();
+
+        $table = new Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer')
+            ->addColumn('ref_table_field1', 'string')
+            ->addForeignKey(
+                ['ref_table_id', 'ref_table_field1'],
+                'ref_table',
+                ['id', 'field1']
+            )
+            ->save();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'No foreign key on column(s) `%s` exists',
+            implode(', ', $columns)
+        ));
+
+        $this->adapter->dropForeignKey($table->getName(), $columns);
+    }
+
+    public function testDropForeignKeyCaseInsensitivity()
+    {
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable->save();
+
+        $table = new Table('another_table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer')
+            ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
+            ->save();
+
+        $this->adapter->dropForeignKey($table->getName(), ['REF_TABLE_ID']);
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
+    }
+
+    public function testDropForeignKeyByName()
+    {
+        $this->expectExceptionMessage('SQLite does not have named foreign keys');
+        $this->expectException(BadMethodCallException::class);
+
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable->save();
+
+        $table = new Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer', ['signed' => false])
+            ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])
+            ->save();
+
+        $this->adapter->dropForeignKey($table->getName(), [], 'my_constraint');
+    }
+
+    public function testHasDatabase()
+    {
+        if ($this->config['database'] === ':memory:') {
+            $this->markTestSkipped('Skipping hasDatabase() when testing in-memory db.');
+        }
+        $this->assertFalse($this->adapter->hasDatabase('fake_database_name'));
+        $this->assertTrue($this->adapter->hasDatabase($this->config['name']));
+    }
+
+    public function testDropDatabase()
+    {
+        $this->assertFalse($this->adapter->hasDatabase('phinx_temp_database'));
+        $this->adapter->createDatabase('phinx_temp_database');
+        $this->assertTrue($this->adapter->hasDatabase('phinx_temp_database'));
+        $this->adapter->dropDatabase('phinx_temp_database');
+    }
+
+    public function testAddColumnWithComment()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('column1', 'string', ['comment' => $comment = 'Comments from "column1"'])
+            ->save();
+
+        $rows = $this->adapter->fetchAll('select * from sqlite_master where `type` = \'table\'');
+
+        foreach ($rows as $row) {
+            if ($row['tbl_name'] === 'table1') {
+                $sql = $row['sql'];
+            }
+        }
+
+        $this->assertMatchesRegularExpression('/\/\* Comments from "column1" \*\//', $sql);
+    }
+
+    public function testPhinxTypeLiteral()
+    {
+        $this->assertEquals(
+            [
+                'name' => Literal::from('fake'),
+                'limit' => null,
+                'scale' => null,
+            ],
+            $this->adapter->getPhinxType('fake')
+        );
+    }
+
+    public function testPhinxTypeNotValidTypeRegex()
+    {
+        $exp = [
+            'name' => Literal::from('?int?'),
+            'limit' => null,
+            'scale' => null,
+        ];
+        $this->assertEquals($exp, $this->adapter->getPhinxType('?int?'));
+    }
+
+    public function testAddIndexTwoTablesSameIndex()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->save();
+        $table2 = new Table('table2', [], $this->adapter);
+        $table2->addColumn('email', 'string')
+            ->save();
+
+        $this->assertFalse($table->hasIndex('email'));
+        $this->assertFalse($table2->hasIndex('email'));
+
+        $table->addIndex('email')
+            ->save();
+        $table2->addIndex('email')
+            ->save();
+
+        $this->assertTrue($table->hasIndex('email'));
+        $this->assertTrue($table2->hasIndex('email'));
+    }
+
+    public function testBulkInsertData()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('column1', 'string')
+            ->addColumn('column2', 'integer', ['null' => true])
+            ->insert([
+                [
+                    'column1' => 'value1',
+                    'column2' => 1,
+                ],
+                [
+                    'column1' => 'value2',
+                    'column2' => 2,
+                ],
+            ])
+            ->insert(
+                [
+                    'column1' => 'value3',
+                    'column2' => 3,
+                ]
+            )
+            ->insert(
+                [
+                    'column1' => '\'value4\'',
+                    'column2' => null,
+                ]
+            )
+            ->save();
+        $rows = $this->adapter->fetchAll('SELECT * FROM table1');
+
+        $this->assertEquals('value1', $rows[0]['column1']);
+        $this->assertEquals('value2', $rows[1]['column1']);
+        $this->assertEquals('value3', $rows[2]['column1']);
+        $this->assertEquals('\'value4\'', $rows[3]['column1']);
+        $this->assertEquals(1, $rows[0]['column2']);
+        $this->assertEquals(2, $rows[1]['column2']);
+        $this->assertEquals(3, $rows[2]['column2']);
+        $this->assertNull($rows[3]['column2']);
+    }
+
+    public function testInsertData()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('column1', 'string')
+            ->addColumn('column2', 'integer', ['null' => true])
+            ->insert([
+                [
+                    'column1' => 'value1',
+                    'column2' => 1,
+                ],
+                [
+                    'column1' => 'value2',
+                    'column2' => 2,
+                ],
+            ])
+            ->insert(
+                [
+                    'column1' => 'value3',
+                    'column2' => 3,
+                ]
+            )
+            ->insert(
+                [
+                    'column1' => '\'value4\'',
+                    'column2' => null,
+                ]
+            )
+            ->save();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM table1');
+
+        $this->assertEquals('value1', $rows[0]['column1']);
+        $this->assertEquals('value2', $rows[1]['column1']);
+        $this->assertEquals('value3', $rows[2]['column1']);
+        $this->assertEquals('\'value4\'', $rows[3]['column1']);
+        $this->assertEquals(1, $rows[0]['column2']);
+        $this->assertEquals(2, $rows[1]['column2']);
+        $this->assertEquals(3, $rows[2]['column2']);
+        $this->assertNull($rows[3]['column2']);
+    }
+
+    public function testBulkInsertDataEnum()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('column1', 'string')
+            ->addColumn('column2', 'string', ['null' => true])
+            ->addColumn('column3', 'string', ['default' => 'c'])
+            ->insert([
+                'column1' => 'a',
+            ])
+            ->save();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM table1');
+
+        $this->assertEquals('a', $rows[0]['column1']);
+        $this->assertNull($rows[0]['column2']);
+        $this->assertEquals('c', $rows[0]['column3']);
+    }
+
+    public function testNullWithoutDefaultValue()
+    {
+        $this->markTestSkipped('Skipping for now. See Github Issue #265.');
+
+        // construct table with default/null combinations
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('aa', 'string', ['null' => true]) // no default value
+        ->addColumn('bb', 'string', ['null' => false]) // no default value
+        ->addColumn('cc', 'string', ['null' => true, 'default' => 'some1'])
+            ->addColumn('dd', 'string', ['null' => false, 'default' => 'some2'])
+            ->save();
+
+        // load table info
+        $columns = $this->adapter->getColumns('table1');
+
+        $this->assertCount(5, $columns);
+
+        $aa = $columns[1];
+        $bb = $columns[2];
+        $cc = $columns[3];
+        $dd = $columns[4];
+
+        $this->assertEquals('aa', $aa->getName());
+        $this->assertTrue($aa->isNull());
+        $this->assertNull($aa->getDefault());
+
+        $this->assertEquals('bb', $bb->getName());
+        $this->assertFalse($bb->isNull());
+        $this->assertNull($bb->getDefault());
+
+        $this->assertEquals('cc', $cc->getName());
+        $this->assertTrue($cc->isNull());
+        $this->assertEquals('some1', $cc->getDefault());
+
+        $this->assertEquals('dd', $dd->getName());
+        $this->assertFalse($dd->isNull());
+        $this->assertEquals('some2', $dd->getDefault());
+    }
+
+    public function testDumpCreateTable()
+    {
+        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
+        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
+
+        $consoleOutput = new BufferedOutput();
+        $this->adapter->setOutput($consoleOutput);
+
+        $table = new Table('table1', [], $this->adapter);
+
+        $table->addColumn('column1', 'string', ['null' => false])
+            ->addColumn('column2', 'integer')
+            ->addColumn('column3', 'string', ['default' => 'test'])
+            ->save();
+
+        $expectedOutput = <<<'OUTPUT'
+CREATE TABLE `table1` (`id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, `column1` VARCHAR NOT NULL, `column2` INTEGER NULL, `column3` VARCHAR NULL DEFAULT 'test');
+OUTPUT;
+        $actualOutput = $consoleOutput->fetch();
+        $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create table query to the output');
+    }
+
+    /**
+     * Creates the table "table1".
+     * Then sets phinx to dry run mode and inserts a record.
+     * Asserts that phinx outputs the insert statement and doesn't insert a record.
+     */
+    public function testDumpInsert()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('string_col', 'string')
+            ->addColumn('int_col', 'integer')
+            ->save();
+
+        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
+        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
+
+        $consoleOutput = new BufferedOutput();
+        $this->adapter->setOutput($consoleOutput);
+
+        $this->adapter->insert($table->getTable(), [
+            'string_col' => 'test data',
+        ]);
+
+        $this->adapter->insert($table->getTable(), [
+            'string_col' => null,
+        ]);
+
+        $this->adapter->insert($table->getTable(), [
+            'int_col' => 23,
+        ]);
+
+        $expectedOutput = <<<'OUTPUT'
+INSERT INTO `table1` (`string_col`) VALUES ('test data');
+INSERT INTO `table1` (`string_col`) VALUES (null);
+INSERT INTO `table1` (`int_col`) VALUES (23);
+OUTPUT;
+        $actualOutput = $consoleOutput->fetch();
+        $actualOutput = preg_replace("/\r\n|\r/", "\n", $actualOutput); // normalize line endings for Windows
+        $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option doesn\'t dump the insert to the output');
+
+        $countQuery = $this->adapter->query('SELECT COUNT(*) FROM table1');
+        $this->assertTrue($countQuery->execute());
+        $res = $countQuery->fetchAll();
+        $this->assertEquals(0, $res[0]['COUNT(*)']);
+    }
+
+    /**
+     * Creates the table "table1".
+     * Then sets phinx to dry run mode and inserts some records.
+     * Asserts that phinx outputs the insert statement and doesn't insert any record.
+     */
+    public function testDumpBulkinsert()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('string_col', 'string')
+            ->addColumn('int_col', 'integer')
+            ->save();
+
+        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
+        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
+
+        $consoleOutput = new BufferedOutput();
+        $this->adapter->setOutput($consoleOutput);
+
+        $this->adapter->bulkinsert($table->getTable(), [
+            [
+                'string_col' => 'test_data1',
+                'int_col' => 23,
+            ],
+            [
+                'string_col' => null,
+                'int_col' => 42,
+            ],
+        ]);
+
+        $expectedOutput = <<<'OUTPUT'
+INSERT INTO `table1` (`string_col`, `int_col`) VALUES ('test_data1', 23), (null, 42);
+OUTPUT;
+        $actualOutput = $consoleOutput->fetch();
+        $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option doesn\'t dump the bulkinsert to the output');
+
+        $countQuery = $this->adapter->query('SELECT COUNT(*) FROM table1');
+        $this->assertTrue($countQuery->execute());
+        $res = $countQuery->fetchAll();
+        $this->assertEquals(0, $res[0]['COUNT(*)']);
+    }
+
+    public function testDumpCreateTableAndThenInsert()
+    {
+        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
+        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
+
+        $consoleOutput = new BufferedOutput();
+        $this->adapter->setOutput($consoleOutput);
+
+        $table = new Table('table1', ['id' => false, 'primary_key' => ['column1']], $this->adapter);
+
+        $table->addColumn('column1', 'string', ['null' => false])
+            ->addColumn('column2', 'integer')
+            ->save();
+
+        $expectedOutput = 'C';
+
+        $table = new Table('table1', [], $this->adapter);
+        $table->insert([
+            'column1' => 'id1',
+            'column2' => 1,
+        ])->save();
+
+        $expectedOutput = <<<'OUTPUT'
+CREATE TABLE `table1` (`column1` VARCHAR NOT NULL, `column2` INTEGER NULL, PRIMARY KEY (`column1`));
+INSERT INTO `table1` (`column1`, `column2`) VALUES ('id1', 1);
+OUTPUT;
+        $actualOutput = $consoleOutput->fetch();
+        $actualOutput = preg_replace("/\r\n|\r/", "\n", $actualOutput); // normalize line endings for Windows
+        $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
+    }
+
+    /**
+     * Tests interaction with the query builder
+     */
+    public function testQueryBuilder()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('string_col', 'string')
+            ->addColumn('int_col', 'integer')
+            ->save();
+
+        $builder = $this->adapter->getQueryBuilder(Query::TYPE_INSERT);
+        $stm = $builder
+            ->insert(['string_col', 'int_col'])
+            ->into('table1')
+            ->values(['string_col' => 'value1', 'int_col' => 1])
+            ->values(['string_col' => 'value2', 'int_col' => 2])
+            ->execute();
+
+        $this->assertEquals(2, $stm->rowCount());
+
+        $builder = $this->adapter->getQueryBuilder(Query::TYPE_SELECT);
+        $stm = $builder
+            ->select('*')
+            ->from('table1')
+            ->where(['int_col >=' => 2])
+            ->execute();
+
+        $this->assertEquals(0, $stm->rowCount());
+        $this->assertEquals(
+            ['id' => 2, 'string_col' => 'value2', 'int_col' => '2'],
+            $stm->fetch('assoc')
+        );
+
+        $builder = $this->adapter->getQueryBuilder(Query::TYPE_DELETE);
+        $stm = $builder
+            ->delete('table1')
+            ->where(['int_col <' => 2])
+            ->execute();
+
+        $this->assertEquals(1, $stm->rowCount());
+    }
+
+    public function testQueryWithParams()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('string_col', 'string')
+            ->addColumn('int_col', 'integer')
+            ->save();
+
+        $this->adapter->insert($table->getTable(), [
+            'string_col' => 'test data',
+            'int_col' => 10,
+        ]);
+
+        $this->adapter->insert($table->getTable(), [
+            'string_col' => null,
+        ]);
+
+        $this->adapter->insert($table->getTable(), [
+            'int_col' => 23,
+        ]);
+
+        $countQuery = $this->adapter->query('SELECT COUNT(*) AS c FROM table1 WHERE int_col > ?', [5]);
+        $res = $countQuery->fetchAll();
+        $this->assertEquals(2, $res[0]['c']);
+
+        $this->adapter->execute('UPDATE table1 SET int_col = ? WHERE int_col IS NULL', [12]);
+
+        $countQuery->execute([1]);
+        $res = $countQuery->fetchAll();
+        $this->assertEquals(3, $res[0]['c']);
+    }
+
+    /**
+     * Tests adding more than one column to a table
+     * that already exists due to adapters having different add column instructions
+     */
+    public function testAlterTableColumnAdd()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->create();
+
+        $table->addColumn('string_col', 'string', ['default' => '']);
+        $table->addColumn('string_col_2', 'string', ['null' => true]);
+        $table->addColumn('string_col_3', 'string', ['null' => false]);
+        $table->addTimestamps();
+        $table->save();
+
+        $columns = $this->adapter->getColumns('table1');
+        $expected = [
+            ['name' => 'id', 'type' => 'integer', 'default' => null, 'null' => false],
+            ['name' => 'string_col', 'type' => 'string', 'default' => '', 'null' => true],
+            ['name' => 'string_col_2', 'type' => 'string', 'default' => null, 'null' => true],
+            ['name' => 'string_col_3', 'type' => 'string', 'default' => null, 'null' => false],
+            ['name' => 'created_at', 'type' => 'timestamp', 'default' => 'CURRENT_TIMESTAMP', 'null' => false],
+            ['name' => 'updated_at', 'type' => 'timestamp', 'default' => null, 'null' => true],
+        ];
+
+        $this->assertEquals(count($expected), count($columns));
+
+        $columnCount = count($columns);
+        for ($i = 0; $i < $columnCount; $i++) {
+            $this->assertSame($expected[$i]['name'], $columns[$i]->getName(), "Wrong name for {$expected[$i]['name']}");
+            $this->assertSame($expected[$i]['type'], $columns[$i]->getType(), "Wrong type for {$expected[$i]['name']}");
+            $this->assertSame($expected[$i]['default'], $columns[$i]->getDefault() instanceof Literal ? (string)$columns[$i]->getDefault() : $columns[$i]->getDefault(), "Wrong default for {$expected[$i]['name']}");
+            $this->assertSame($expected[$i]['null'], $columns[$i]->getNull(), "Wrong null for {$expected[$i]['name']}");
+        }
+    }
+
+    public function testAlterTableWithConstraints()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->create();
+
+        $table2 = new Table('table2', [], $this->adapter);
+        $table2->create();
+
+        $table
+            ->addColumn('table2_id', 'integer', ['null' => false])
+            ->addForeignKey('table2_id', 'table2', 'id', [
+                'delete' => 'SET NULL',
+            ]);
+        $table->update();
+
+        $table->addColumn('column3', 'string', ['default' => null, 'null' => true]);
+        $table->update();
+
+        $columns = $this->adapter->getColumns('table1');
+        $expected = [
+            ['name' => 'id', 'type' => 'integer', 'default' => null, 'null' => false],
+            ['name' => 'table2_id', 'type' => 'integer', 'default' => null, 'null' => false],
+            ['name' => 'column3', 'type' => 'string', 'default' => null, 'null' => true],
+        ];
+
+        $this->assertEquals(count($expected), count($columns));
+
+        $columnCount = count($columns);
+        for ($i = 0; $i < $columnCount; $i++) {
+            $this->assertSame($expected[$i]['name'], $columns[$i]->getName(), "Wrong name for {$expected[$i]['name']}");
+            $this->assertSame($expected[$i]['type'], $columns[$i]->getType(), "Wrong type for {$expected[$i]['name']}");
+            $this->assertSame($expected[$i]['default'], $columns[$i]->getDefault() instanceof Literal ? (string)$columns[$i]->getDefault() : $columns[$i]->getDefault(), "Wrong default for {$expected[$i]['name']}");
+            $this->assertSame($expected[$i]['null'], $columns[$i]->getNull(), "Wrong null for {$expected[$i]['name']}");
+        }
+    }
+
+    /**
+     * Tests that operations that trigger implicit table drops will not cause
+     * a foreign key constraint violation error.
+     */
+    public function testAlterTableDoesNotViolateRestrictedForeignKeyConstraint()
+    {
+        $this->adapter->execute('PRAGMA foreign_keys = ON');
+
+        $articlesTable = new Table('articles', [], $this->adapter);
+        $articlesTable
+            ->insert(['id' => 1])
+            ->save();
+
+        $commentsTable = new Table('comments', [], $this->adapter);
+        $commentsTable
+            ->addColumn('article_id', 'integer')
+            ->addForeignKey('article_id', 'articles', 'id', [
+                'update' => ForeignKey::RESTRICT,
+                'delete' => ForeignKey::RESTRICT,
+            ])
+            ->insert(['id' => 1, 'article_id' => 1])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey('comments', ['article_id']));
+
+        $articlesTable
+            ->addColumn('new_column', 'integer')
+            ->update();
+
+        $articlesTable
+            ->renameColumn('new_column', 'new_column_renamed')
+            ->update();
+
+        $articlesTable
+            ->changeColumn('new_column_renamed', 'integer', [
+                'default' => 1,
+            ])
+            ->update();
+
+        $articlesTable
+            ->removeColumn('new_column_renamed')
+            ->update();
+
+        $articlesTable
+            ->addIndex('id', ['name' => 'ID_IDX'])
+            ->update();
+
+        $articlesTable
+            ->removeIndex('id')
+            ->update();
+
+        $articlesTable
+            ->addForeignKey('id', 'comments', 'id')
+            ->update();
+
+        $articlesTable
+            ->dropForeignKey('id')
+            ->update();
+
+        $articlesTable
+            ->addColumn('id2', 'integer')
+            ->addIndex('id', ['unique' => true])
+            ->changePrimaryKey('id2')
+            ->update();
+    }
+
+    /**
+     * Tests that foreign key constraint violations introduced around the table
+     * alteration process (being it implicitly by the process itself or by the user)
+     * will trigger an error accordingly.
+     */
+    public function testAlterTableDoesViolateForeignKeyConstraintOnTargetTableChange()
+    {
+        $articlesTable = new Table('articles', [], $this->adapter);
+        $articlesTable
+            ->insert(['id' => 1])
+            ->save();
+
+        $commentsTable = new Table('comments', [], $this->adapter);
+        $commentsTable
+            ->addColumn('article_id', 'integer')
+            ->addForeignKey('article_id', 'articles', 'id', [
+                'update' => ForeignKey::RESTRICT,
+                'delete' => ForeignKey::RESTRICT,
+            ])
+            ->insert(['id' => 1, 'article_id' => 1])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey('comments', ['article_id']));
+
+        $this->adapter->execute('PRAGMA foreign_keys = OFF');
+        $this->adapter->execute('DELETE FROM articles');
+        $this->adapter->execute('PRAGMA foreign_keys = ON');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Integrity constraint violation: FOREIGN KEY constraint on `comments` failed.');
+
+        $articlesTable
+            ->addColumn('new_column', 'integer')
+            ->update();
+    }
+
+    /**
+     * Tests that foreign key constraint violations introduced around the table
+     * alteration process (being it implicitly by the process itself or by the user)
+     * will trigger an error accordingly.
+     */
+    public function testAlterTableDoesViolateForeignKeyConstraintOnSourceTableChange()
+    {
+        $adapter = $this
+            ->getMockBuilder(SqliteAdapter::class)
+            ->setConstructorArgs([$this->config, new ArrayInput([]), new NullOutput()])
+            ->onlyMethods(['query'])
+            ->getMock();
+
+        $adapterReflection = new ReflectionObject($adapter);
+        $queryReflection = $adapterReflection->getParentClass()->getMethod('query');
+
+        $adapter
+            ->expects($this->atLeastOnce())
+            ->method('query')
+            ->willReturnCallback(function (string $sql, array $params = []) use ($adapter, $queryReflection) {
+                if ($sql === 'PRAGMA foreign_key_check(`comments`)') {
+                    $adapter->execute('PRAGMA foreign_keys = OFF');
+                    $adapter->execute('DELETE FROM articles');
+                    $adapter->execute('PRAGMA foreign_keys = ON');
+                }
+
+                return $queryReflection->invoke($adapter, $sql, $params);
+            });
+
+        $articlesTable = new Table('articles', [], $adapter);
+        $articlesTable
+            ->insert(['id' => 1])
+            ->save();
+
+        $commentsTable = new Table('comments', [], $adapter);
+        $commentsTable
+            ->addColumn('article_id', 'integer')
+            ->addForeignKey('article_id', 'articles', 'id', [
+                'update' => ForeignKey::RESTRICT,
+                'delete' => ForeignKey::RESTRICT,
+            ])
+            ->insert(['id' => 1, 'article_id' => 1])
+            ->save();
+
+        $this->assertTrue($adapter->hasForeignKey('comments', ['article_id']));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Integrity constraint violation: FOREIGN KEY constraint on `comments` failed.');
+
+        $commentsTable
+            ->addColumn('new_column', 'integer')
+            ->update();
+    }
+
+    /**
+     * Tests that the adapter's foreign key validation does not apply when
+     * the `foreign_keys` pragma is set to `OFF`.
+     */
+    public function testAlterTableForeignKeyConstraintValidationNotRunningWithDisabledForeignKeys()
+    {
+        $articlesTable = new Table('articles', [], $this->adapter);
+        $articlesTable
+            ->insert(['id' => 1])
+            ->save();
+
+        $commentsTable = new Table('comments', [], $this->adapter);
+        $commentsTable
+            ->addColumn('article_id', 'integer')
+            ->addForeignKey('article_id', 'articles', 'id', [
+                'update' => ForeignKey::RESTRICT,
+                'delete' => ForeignKey::RESTRICT,
+            ])
+            ->insert(['id' => 1, 'article_id' => 1])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey('comments', ['article_id']));
+
+        $this->adapter->execute('PRAGMA foreign_keys = OFF');
+        $this->adapter->execute('DELETE FROM articles');
+
+        $noException = false;
+        try {
+            $articlesTable
+                ->addColumn('new_column1', 'integer')
+                ->update();
+
+            $noException = true;
+        } finally {
+            $this->assertTrue($noException);
+        }
+
+        $this->adapter->execute('PRAGMA foreign_keys = ON');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Integrity constraint violation: FOREIGN KEY constraint on `comments` failed.');
+
+        $articlesTable
+            ->addColumn('new_column2', 'integer')
+            ->update();
+    }
+
+    public function testLiteralSupport()
+    {
+        $createQuery = <<<'INPUT'
+CREATE TABLE `test` (`real_col` DECIMAL)
+INPUT;
+        $this->adapter->execute($createQuery);
+        $table = new Table('test', [], $this->adapter);
+        $columns = $table->getColumns();
+        $this->assertCount(1, $columns);
+        $this->assertEquals(Literal::from('decimal'), array_pop($columns)->getType());
+    }
+
+    /**
+     * @dataProvider provideTableNamesForPresenceCheck
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::hasTable
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::resolveTable
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::quoteString
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getSchemaName
+     */
+    public function testHasTable($createName, $tableName, $exp)
+    {
+        // Test case for issue #1535
+        $conn = $this->adapter->getConnection();
+        $conn->exec('ATTACH DATABASE \':memory:\' as etc');
+        $conn->exec('ATTACH DATABASE \':memory:\' as "main.db"');
+        $conn->exec(sprintf('DROP TABLE IF EXISTS %s', $createName));
+        $this->assertFalse($this->adapter->hasTable($tableName), sprintf('Adapter claims table %s exists when it does not', $tableName));
+        $conn->exec(sprintf('CREATE TABLE %s (a text)', $createName));
+        if ($exp == true) {
+            $this->assertTrue($this->adapter->hasTable($tableName), sprintf('Adapter claims table %s does not exist when it does', $tableName));
+        } else {
+            $this->assertFalse($this->adapter->hasTable($tableName), sprintf('Adapter claims table %s exists when it does not', $tableName));
+        }
+    }
+
+    public static function provideTableNamesForPresenceCheck()
+    {
+        return [
+            'Ordinary table' => ['t', 't', true],
+            'Ordinary table with schema' => ['t', 'main.t', true],
+            'Temporary table' => ['temp.t', 't', true],
+            'Temporary table with schema' => ['temp.t', 'temp.t', true],
+            'Attached table' => ['etc.t', 't', true],
+            'Attached table with schema' => ['etc.t', 'etc.t', true],
+            'Attached table with unusual schema' => ['"main.db".t', 'main.db.t', true],
+            'Wrong schema 1' => ['t', 'etc.t', false],
+            'Wrong schema 2' => ['t', 'temp.t', false],
+            'Missing schema' => ['t', 'not_attached.t', false],
+            'Malicious table' => ['"\'"', '\'', true],
+            'Malicious missing table' => ['t', '\'', false],
+            'Table name case 1' => ['t', 'T', true],
+            'Table name case 2' => ['T', 't', true],
+            'Schema name case 1' => ['main.t', 'MAIN.t', true],
+            'Schema name case 2' => ['MAIN.t', 'main.t', true],
+            'Schema name case 3' => ['temp.t', 'TEMP.t', true],
+            'Schema name case 4' => ['TEMP.t', 'temp.t', true],
+            'Schema name case 5' => ['etc.t', 'ETC.t', true],
+            'Schema name case 6' => ['ETC.t', 'etc.t', true],
+            'PHP zero string 1' => ['"0"', '0', true],
+            'PHP zero string 2' => ['"0"', '0e2', false],
+            'PHP zero string 3' => ['"0e2"', '0', false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideIndexColumnsToCheck
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getSchemaName
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getTableInfo
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getIndexes
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::resolveIndex
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::hasIndex
+     */
+    public function testHasIndex($tableDef, $cols, $exp)
+    {
+        $conn = $this->adapter->getConnection();
+        $conn->exec($tableDef);
+        $this->assertEquals($exp, $this->adapter->hasIndex('t', $cols));
+    }
+
+    public static function provideIndexColumnsToCheck()
+    {
+        return [
+            ['create table t(a text)', 'a', false],
+            ['create table t(a text); create index test on t(a);', 'a', true],
+            ['create table t(a text unique)', 'a', true],
+            ['create table t(a text primary key)', 'a', true],
+            ['create table t(a text unique, b text unique)', ['a', 'b'], false],
+            ['create table t(a text, b text, unique(a,b))', ['a', 'b'], true],
+            ['create table t(a text, b text); create index test on t(a,b)', ['a', 'b'], true],
+            ['create table t(a text, b text); create index test on t(a,b)', ['b', 'a'], false],
+            ['create table t(a text, b text); create index test on t(a,b)', ['a'], false],
+            ['create table t(a text, b text); create index test on t(a)', ['a', 'b'], false],
+            ['create table t(a text, b text); create index test on t(a,b)', ['A', 'B'], true],
+            ['create table t("A" text, "B" text); create index test on t("A","B")', ['a', 'b'], true],
+            ['create table not_t(a text, b text, unique(a,b))', ['A', 'B'], false], // test checks table t which does not exist
+            ['create table t(a text, b text); create index test on t(a)', ['a', 'a'], false],
+            ['create table t(a text unique); create temp table t(a text)', 'a', false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideIndexNamesToCheck
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getSchemaName
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getTableInfo
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getIndexes
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::hasIndexByName
+     */
+    public function testHasIndexByName($tableDef, $index, $exp)
+    {
+        $conn = $this->adapter->getConnection();
+        $conn->exec($tableDef);
+        $this->assertEquals($exp, $this->adapter->hasIndexByName('t', $index));
+    }
+
+    public static function provideIndexNamesToCheck()
+    {
+        return [
+            ['create table t(a text)', 'test', false],
+            ['create table t(a text); create index test on t(a);', 'test', true],
+            ['create table t(a text); create index test on t(a);', 'TEST', true],
+            ['create table t(a text); create index "TEST" on t(a);', 'test', true],
+            ['create table t(a text unique)', 'sqlite_autoindex_t_1', true],
+            ['create table t(a text primary key)', 'sqlite_autoindex_t_1', true],
+            ['create table not_t(a text); create index test on not_t(a);', 'test', false], // test checks table t which does not exist
+            ['create table t(a text unique); create temp table t(a text)', 'sqlite_autoindex_t_1', false],
+        ];
+    }
+
+    /**
+     * @dataProvider providePrimaryKeysToCheck
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getSchemaName
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getTableInfo
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::hasPrimaryKey
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getPrimaryKey
+     */
+    public function testHasPrimaryKey($tableDef, $key, $exp)
+    {
+        $this->assertFalse($this->adapter->hasTable('t'), 'Dirty test fixture');
+        $conn = $this->adapter->getConnection();
+        $conn->exec($tableDef);
+        $this->assertSame($exp, $this->adapter->hasPrimaryKey('t', $key));
+    }
+
+    public static function providePrimaryKeysToCheck()
+    {
+        return [
+            ['create table t(a integer)', 'a', false],
+            ['create table t(a integer)', [], true],
+            ['create table t(a integer primary key)', 'a', true],
+            ['create table t(a integer primary key)', [], false],
+            ['create table t(a integer PRIMARY KEY)', 'a', true],
+            ['create table t(`a` integer PRIMARY KEY)', 'a', true],
+            ['create table t("a" integer PRIMARY KEY)', 'a', true],
+            ['create table t([a] integer PRIMARY KEY)', 'a', true],
+            ['create table t(`a` integer PRIMARY KEY)', 'a', true],
+            ['create table t(\'a\' integer PRIMARY KEY)', 'a', true],
+            ['create table t(`a.a` integer PRIMARY KEY)', 'a.a', true],
+            ['create table t(a integer primary key)', ['a'], true],
+            ['create table t(a integer primary key)', ['a', 'b'], false],
+            ['create table t(a integer, primary key(a))', 'a', true],
+            ['create table t(a integer, primary key("a"))', 'a', true],
+            ['create table t(a integer, primary key([a]))', 'a', true],
+            ['create table t(a integer, primary key(`a`))', 'a', true],
+            ['create table t(a integer, b integer primary key)', 'a', false],
+            ['create table t(a integer, b text primary key)', 'b', true],
+            ['create table t(a integer, b integer default 2112 primary key)', ['a'], false],
+            ['create table t(a integer, b integer primary key)', ['b'], true],
+            ['create table t(a integer, b integer primary key)', ['b', 'b'], true], // duplicate column is collapsed
+            ['create table t(a integer, b integer, primary key(a,b))', ['b', 'a'], true],
+            ['create table t(a integer, b integer, primary key(a,b))', ['a', 'b'], true],
+            ['create table t(a integer, b integer, primary key(a,b))', 'a', false],
+            ['create table t(a integer, b integer, primary key(a,b))', ['a'], false],
+            ['create table t(a integer, b integer, primary key(a,b))', ['a', 'b', 'c'], false],
+            ['create table t(a integer, b integer, primary key(a,b))', ['a', 'B'], true],
+            ['create table t(a integer, "B" integer, primary key(a,b))', ['a', 'b'], true],
+            ['create table t(a integer, b integer, constraint t_pk primary key(a,b))', ['a', 'b'], true],
+            ['create table t(a integer); create temp table t(a integer primary key)', 'a', true],
+            ['create temp table t(a integer primary key)', 'a', true],
+            ['create table t("0" integer primary key)', ['0'], true],
+            ['create table t("0" integer primary key)', ['0e0'], false],
+            ['create table t("0e0" integer primary key)', ['0'], false],
+            ['create table not_t(a integer)', 'a', false], // test checks table t which does not exist
+        ];
+    }
+
+    /**
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::hasPrimaryKey
+     */
+    public function testHasNamedPrimaryKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->adapter->hasPrimaryKey('t', [], 'named_constraint');
+    }
+
+    /**
+     * @dataProvider provideForeignKeysToCheck
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getSchemaName
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getTableInfo
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::hasForeignKey
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getForeignKeys
+     */
+    public function testHasForeignKey($tableDef, $key, $exp)
+    {
+        $conn = $this->adapter->getConnection();
+        $conn->exec('CREATE TABLE other(a integer, b integer, c integer)');
+        $conn->exec($tableDef);
+        $this->assertSame($exp, $this->adapter->hasForeignKey('t', $key));
+    }
+
+    public static function provideForeignKeysToCheck()
+    {
+        return [
+            ['create table t(a integer)', 'a', false],
+            ['create table t(a integer)', [], false],
+            ['create table t(a integer primary key)', 'a', false],
+            ['create table t(a integer references other(a))', 'a', true],
+            ['create table t(a integer references other(b))', 'a', true],
+            ['create table t(a integer references other(b))', ['a'], true],
+            ['create table t(a integer references other(b))', ['a', 'a'], false],
+            ['create table t(a integer, foreign key(a) references other(a))', 'a', true],
+            ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', 'a', false],
+            ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['a', 'b'], true],
+            ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['b', 'a'], false],
+            ['create table t(a integer, "B" integer, foreign key(a,"B") references other(a,b))', ['a', 'b'], true],
+            ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['a', 'B'], true],
+            ['create table t(a integer, b integer, c integer, foreign key(a,b,c) references other(a,b,c))', ['a', 'b'], false],
+            ['create table t(a integer, foreign key(a) references other(a))', ['a', 'b'], false],
+            ['create table t(a integer references other(a), b integer references other(b))', ['a', 'b'], false],
+            ['create table t(a integer references other(a), b integer references other(b))', ['a', 'b'], false],
+            ['create table t(a integer); create temp table t(a integer references other(a))', ['a'], true],
+            ['create temp table t(a integer references other(a))', ['a'], true],
+            ['create table t("0" integer references other(a))', '0', true],
+            ['create table t("0" integer references other(a))', '0e0', false],
+            ['create table t("0e0" integer references other(a))', '0', false],
+        ];
+    }
+
+    /** @covers \Migrations\Db\Adapter\SqliteAdapter::hasForeignKey */
+    public function testHasNamedForeignKey()
+    {
+        $refTable = new Table('tbl_parent_1', [], $this->adapter);
+        $refTable->addColumn('column', 'string')->create();
+
+        $refTable = new Table('tbl_parent_2', [], $this->adapter);
+        $refTable->create();
+
+        $refTable = new Table('tbl_parent_3', [
+            'id' => false,
+            'primary_key' => ['id', 'column'],
+        ], $this->adapter);
+        $refTable->addColumn('id', 'integer')->addColumn('column', 'string')->create();
+
+        // use raw sql instead of table builder so that we can have check constraints
+        $this->adapter->execute("
+        CREATE TABLE `tbl_child` (
+            `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            `column` VARCHAR NOT NULL, `parent_1_id` INTEGER NOT NULL,
+            `parent_2_id` INTEGER NOT NULL,
+            `parent_3_id` INTEGER NOT NULL,
+            CONSTRAINT `fk_parent_1_id` FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
+            CONSTRAINT [fk_[_brackets] FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
+            CONSTRAINT `fk_``_ticks` FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
+            CONSTRAINT \"fk_\"\"_double_quotes\" FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
+            CONSTRAINT 'fk_''_single_quotes' FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
+            CONSTRAINT fk_no_quotes FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
+            CONSTRAINT`fk_no_space`FOREIGN KEY(`parent_1_id`)REFERENCES`tbl_parent_1`(`id`),
+            constraint
+                `fk_lots_of_space`    FOReign		KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
+            FOREIGN KEY (`parent_2_id`) REFERENCES `tbl_parent_2` (`id`),
+            CONSTRAINT `check_constraint_1` CHECK (column<>'world'),
+            CONSTRAINT `fk_composite_key` FOREIGN KEY (`parent_3_id`,`column`) REFERENCES `tbl_parent_3` (`id`,`column`)
+            CONSTRAINT `check_constraint_2` CHECK (column<>'hello')
+        )");
+
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_parent_1_id'));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_[_brackets'));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_`_ticks'));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_"_double_quotes'));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], "fk_'_single_quotes"));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_no_quotes'));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_no_space'));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_lots_of_space'));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', ['parent_1_id']));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', ['parent_2_id']));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_composite_key'));
+        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', ['parent_3_id', 'column']));
+        $this->assertFalse($this->adapter->hasForeignKey('tbl_child', [], 'check_constraint_1'));
+        $this->assertFalse($this->adapter->hasForeignKey('tbl_child', [], 'check_constraint_2'));
+    }
+
+    /**
+     * @dataProvider providePhinxTypes
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getSqlType
+     */
+    public function testGetSqlType($phinxType, $limit, $exp)
+    {
+        if ($exp instanceof Exception) {
+            $this->expectException(get_class($exp));
+
+            $this->adapter->getSqlType($phinxType, $limit);
+        } else {
+            $exp = ['name' => $exp, 'limit' => $limit];
+            $this->assertEquals($exp, $this->adapter->getSqlType($phinxType, $limit));
+        }
+    }
+
+    public static function providePhinxTypes()
+    {
+        $unsupported = new UnsupportedColumnTypeException();
+
+        return [
+            [SqliteAdapter::PHINX_TYPE_BIG_INTEGER, null, SqliteAdapter::PHINX_TYPE_BIG_INTEGER],
+            [SqliteAdapter::PHINX_TYPE_BINARY, null, SqliteAdapter::PHINX_TYPE_BINARY . '_blob'],
+            [SqliteAdapter::PHINX_TYPE_BIT, null, $unsupported],
+            [SqliteAdapter::PHINX_TYPE_BLOB, null, SqliteAdapter::PHINX_TYPE_BLOB],
+            [SqliteAdapter::PHINX_TYPE_BOOLEAN, null, SqliteAdapter::PHINX_TYPE_BOOLEAN . '_integer'],
+            [SqliteAdapter::PHINX_TYPE_CHAR, null, SqliteAdapter::PHINX_TYPE_CHAR],
+            [SqliteAdapter::PHINX_TYPE_CIDR, null, $unsupported],
+            [SqliteAdapter::PHINX_TYPE_DATE, null, SqliteAdapter::PHINX_TYPE_DATE . '_text'],
+            [SqliteAdapter::PHINX_TYPE_DATETIME, null, SqliteAdapter::PHINX_TYPE_DATETIME . '_text'],
+            [SqliteAdapter::PHINX_TYPE_DECIMAL, null, SqliteAdapter::PHINX_TYPE_DECIMAL],
+            [SqliteAdapter::PHINX_TYPE_DOUBLE, null, SqliteAdapter::PHINX_TYPE_DOUBLE],
+            [SqliteAdapter::PHINX_TYPE_ENUM, null, $unsupported],
+            [SqliteAdapter::PHINX_TYPE_FILESTREAM, null, $unsupported],
+            [SqliteAdapter::PHINX_TYPE_FLOAT, null, SqliteAdapter::PHINX_TYPE_FLOAT],
+            [SqliteAdapter::PHINX_TYPE_GEOMETRY, null, $unsupported],
+            [SqliteAdapter::PHINX_TYPE_INET, null, $unsupported],
+            [SqliteAdapter::PHINX_TYPE_INTEGER, null, SqliteAdapter::PHINX_TYPE_INTEGER],
+            [SqliteAdapter::PHINX_TYPE_INTERVAL, null, $unsupported],
+            [SqliteAdapter::PHINX_TYPE_JSON, null, SqliteAdapter::PHINX_TYPE_JSON . '_text'],
+            [SqliteAdapter::PHINX_TYPE_JSONB, null, SqliteAdapter::PHINX_TYPE_JSONB . '_text'],
+            [SqliteAdapter::PHINX_TYPE_LINESTRING, null, $unsupported],
+            [SqliteAdapter::PHINX_TYPE_MACADDR, null, $unsupported],
+            [SqliteAdapter::PHINX_TYPE_POINT, null, $unsupported],
+            [SqliteAdapter::PHINX_TYPE_POLYGON, null, $unsupported],
+            [SqliteAdapter::PHINX_TYPE_SET, null, $unsupported],
+            [SqliteAdapter::PHINX_TYPE_SMALL_INTEGER, null, SqliteAdapter::PHINX_TYPE_SMALL_INTEGER],
+            [SqliteAdapter::PHINX_TYPE_STRING, null, 'varchar'],
+            [SqliteAdapter::PHINX_TYPE_TEXT, null, SqliteAdapter::PHINX_TYPE_TEXT],
+            [SqliteAdapter::PHINX_TYPE_TIME, null, SqliteAdapter::PHINX_TYPE_TIME . '_text'],
+            [SqliteAdapter::PHINX_TYPE_TIMESTAMP, null, SqliteAdapter::PHINX_TYPE_TIMESTAMP . '_text'],
+            [SqliteAdapter::PHINX_TYPE_UUID, null, SqliteAdapter::PHINX_TYPE_UUID . '_text'],
+            [SqliteAdapter::PHINX_TYPE_VARBINARY, null, SqliteAdapter::PHINX_TYPE_VARBINARY . '_blob'],
+            [SqliteAdapter::PHINX_TYPE_STRING, 5, 'varchar'],
+            [Literal::from('someType'), 5, Literal::from('someType')],
+            ['notAType', null, $unsupported],
+        ];
+    }
+
+    /**
+     * @dataProvider provideSqlTypes
+     * @covers \Migrations\Db\Adapter\SqliteAdapter::getPhinxType
+     */
+    public function testGetPhinxType($sqlType, $exp)
+    {
+        $this->assertEquals($exp, $this->adapter->getPhinxType($sqlType));
+    }
+
+    /**
+     * @return array
+     */
+    public static function provideSqlTypes()
+    {
+        return [
+            ['varchar', ['name' => SqliteAdapter::PHINX_TYPE_STRING, 'limit' => null, 'scale' => null]],
+            ['string', ['name' => SqliteAdapter::PHINX_TYPE_STRING, 'limit' => null, 'scale' => null]],
+            ['string_text', ['name' => SqliteAdapter::PHINX_TYPE_STRING, 'limit' => null, 'scale' => null]],
+            ['varchar(5)', ['name' => SqliteAdapter::PHINX_TYPE_STRING, 'limit' => 5, 'scale' => null]],
+            ['varchar(55,2)', ['name' => SqliteAdapter::PHINX_TYPE_STRING, 'limit' => 55, 'scale' => 2]],
+            ['char', ['name' => SqliteAdapter::PHINX_TYPE_CHAR, 'limit' => null, 'scale' => null]],
+            ['boolean', ['name' => SqliteAdapter::PHINX_TYPE_BOOLEAN, 'limit' => null, 'scale' => null]],
+            ['boolean_integer', ['name' => SqliteAdapter::PHINX_TYPE_BOOLEAN, 'limit' => null, 'scale' => null]],
+            ['int', ['name' => SqliteAdapter::PHINX_TYPE_INTEGER, 'limit' => null, 'scale' => null]],
+            ['integer', ['name' => SqliteAdapter::PHINX_TYPE_INTEGER, 'limit' => null, 'scale' => null]],
+            ['tinyint', ['name' => SqliteAdapter::PHINX_TYPE_TINY_INTEGER, 'limit' => null, 'scale' => null]],
+            ['tinyint(1)', ['name' => SqliteAdapter::PHINX_TYPE_BOOLEAN, 'limit' => null, 'scale' => null]],
+            ['tinyinteger', ['name' => SqliteAdapter::PHINX_TYPE_TINY_INTEGER, 'limit' => null, 'scale' => null]],
+            ['tinyinteger(1)', ['name' => SqliteAdapter::PHINX_TYPE_BOOLEAN, 'limit' => null, 'scale' => null]],
+            ['smallint', ['name' => SqliteAdapter::PHINX_TYPE_SMALL_INTEGER, 'limit' => null, 'scale' => null]],
+            ['smallinteger', ['name' => SqliteAdapter::PHINX_TYPE_SMALL_INTEGER, 'limit' => null, 'scale' => null]],
+            ['mediumint', ['name' => SqliteAdapter::PHINX_TYPE_INTEGER, 'limit' => null, 'scale' => null]],
+            ['mediuminteger', ['name' => SqliteAdapter::PHINX_TYPE_INTEGER, 'limit' => null, 'scale' => null]],
+            ['bigint', ['name' => SqliteAdapter::PHINX_TYPE_BIG_INTEGER, 'limit' => null, 'scale' => null]],
+            ['biginteger', ['name' => SqliteAdapter::PHINX_TYPE_BIG_INTEGER, 'limit' => null, 'scale' => null]],
+            ['text', ['name' => SqliteAdapter::PHINX_TYPE_TEXT, 'limit' => null, 'scale' => null]],
+            ['tinytext', ['name' => SqliteAdapter::PHINX_TYPE_TEXT, 'limit' => null, 'scale' => null]],
+            ['mediumtext', ['name' => SqliteAdapter::PHINX_TYPE_TEXT, 'limit' => null, 'scale' => null]],
+            ['longtext', ['name' => SqliteAdapter::PHINX_TYPE_TEXT, 'limit' => null, 'scale' => null]],
+            ['blob', ['name' => SqliteAdapter::PHINX_TYPE_BLOB, 'limit' => null, 'scale' => null]],
+            ['tinyblob', ['name' => SqliteAdapter::PHINX_TYPE_BLOB, 'limit' => null, 'scale' => null]],
+            ['mediumblob', ['name' => SqliteAdapter::PHINX_TYPE_BLOB, 'limit' => null, 'scale' => null]],
+            ['longblob', ['name' => SqliteAdapter::PHINX_TYPE_BLOB, 'limit' => null, 'scale' => null]],
+            ['float', ['name' => SqliteAdapter::PHINX_TYPE_FLOAT, 'limit' => null, 'scale' => null]],
+            ['real', ['name' => SqliteAdapter::PHINX_TYPE_FLOAT, 'limit' => null, 'scale' => null]],
+            ['double', ['name' => SqliteAdapter::PHINX_TYPE_DOUBLE, 'limit' => null, 'scale' => null]],
+            ['date', ['name' => SqliteAdapter::PHINX_TYPE_DATE, 'limit' => null, 'scale' => null]],
+            ['date_text', ['name' => SqliteAdapter::PHINX_TYPE_DATE, 'limit' => null, 'scale' => null]],
+            ['datetime', ['name' => SqliteAdapter::PHINX_TYPE_DATETIME, 'limit' => null, 'scale' => null]],
+            ['datetime_text', ['name' => SqliteAdapter::PHINX_TYPE_DATETIME, 'limit' => null, 'scale' => null]],
+            ['time', ['name' => SqliteAdapter::PHINX_TYPE_TIME, 'limit' => null, 'scale' => null]],
+            ['time_text', ['name' => SqliteAdapter::PHINX_TYPE_TIME, 'limit' => null, 'scale' => null]],
+            ['timestamp', ['name' => SqliteAdapter::PHINX_TYPE_TIMESTAMP, 'limit' => null, 'scale' => null]],
+            ['timestamp_text', ['name' => SqliteAdapter::PHINX_TYPE_TIMESTAMP, 'limit' => null, 'scale' => null]],
+            ['binary', ['name' => SqliteAdapter::PHINX_TYPE_BINARY, 'limit' => null, 'scale' => null]],
+            ['binary_blob', ['name' => SqliteAdapter::PHINX_TYPE_BINARY, 'limit' => null, 'scale' => null]],
+            ['varbinary', ['name' => SqliteAdapter::PHINX_TYPE_VARBINARY, 'limit' => null, 'scale' => null]],
+            ['varbinary_blob', ['name' => SqliteAdapter::PHINX_TYPE_VARBINARY, 'limit' => null, 'scale' => null]],
+            ['json', ['name' => SqliteAdapter::PHINX_TYPE_JSON, 'limit' => null, 'scale' => null]],
+            ['json_text', ['name' => SqliteAdapter::PHINX_TYPE_JSON, 'limit' => null, 'scale' => null]],
+            ['jsonb', ['name' => SqliteAdapter::PHINX_TYPE_JSONB, 'limit' => null, 'scale' => null]],
+            ['jsonb_text', ['name' => SqliteAdapter::PHINX_TYPE_JSONB, 'limit' => null, 'scale' => null]],
+            ['uuid', ['name' => SqliteAdapter::PHINX_TYPE_UUID, 'limit' => null, 'scale' => null]],
+            ['uuid_text', ['name' => SqliteAdapter::PHINX_TYPE_UUID, 'limit' => null, 'scale' => null]],
+            ['decimal', ['name' => Literal::from('decimal'), 'limit' => null, 'scale' => null]],
+            ['point', ['name' => Literal::from('point'), 'limit' => null, 'scale' => null]],
+            ['polygon', ['name' => Literal::from('polygon'), 'limit' => null, 'scale' => null]],
+            ['linestring', ['name' => Literal::from('linestring'), 'limit' => null, 'scale' => null]],
+            ['geometry', ['name' => Literal::from('geometry'), 'limit' => null, 'scale' => null]],
+            ['bit', ['name' => Literal::from('bit'), 'limit' => null, 'scale' => null]],
+            ['enum', ['name' => Literal::from('enum'), 'limit' => null, 'scale' => null]],
+            ['set', ['name' => Literal::from('set'), 'limit' => null, 'scale' => null]],
+            ['cidr', ['name' => Literal::from('cidr'), 'limit' => null, 'scale' => null]],
+            ['inet', ['name' => Literal::from('inet'), 'limit' => null, 'scale' => null]],
+            ['macaddr', ['name' => Literal::from('macaddr'), 'limit' => null, 'scale' => null]],
+            ['interval', ['name' => Literal::from('interval'), 'limit' => null, 'scale' => null]],
+            ['filestream', ['name' => Literal::from('filestream'), 'limit' => null, 'scale' => null]],
+            ['decimal_text', ['name' => Literal::from('decimal'), 'limit' => null, 'scale' => null]],
+            ['point_text', ['name' => Literal::from('point'), 'limit' => null, 'scale' => null]],
+            ['polygon_text', ['name' => Literal::from('polygon'), 'limit' => null, 'scale' => null]],
+            ['linestring_text', ['name' => Literal::from('linestring'), 'limit' => null, 'scale' => null]],
+            ['geometry_text', ['name' => Literal::from('geometry'), 'limit' => null, 'scale' => null]],
+            ['bit_text', ['name' => Literal::from('bit'), 'limit' => null, 'scale' => null]],
+            ['enum_text', ['name' => Literal::from('enum'), 'limit' => null, 'scale' => null]],
+            ['set_text', ['name' => Literal::from('set'), 'limit' => null, 'scale' => null]],
+            ['cidr_text', ['name' => Literal::from('cidr'), 'limit' => null, 'scale' => null]],
+            ['inet_text', ['name' => Literal::from('inet'), 'limit' => null, 'scale' => null]],
+            ['macaddr_text', ['name' => Literal::from('macaddr'), 'limit' => null, 'scale' => null]],
+            ['interval_text', ['name' => Literal::from('interval'), 'limit' => null, 'scale' => null]],
+            ['filestream_text', ['name' => Literal::from('filestream'), 'limit' => null, 'scale' => null]],
+            ['bit_text(2,12)', ['name' => Literal::from('bit'), 'limit' => 2, 'scale' => 12]],
+            ['VARCHAR', ['name' => SqliteAdapter::PHINX_TYPE_STRING, 'limit' => null, 'scale' => null]],
+            ['STRING', ['name' => SqliteAdapter::PHINX_TYPE_STRING, 'limit' => null, 'scale' => null]],
+            ['STRING_TEXT', ['name' => SqliteAdapter::PHINX_TYPE_STRING, 'limit' => null, 'scale' => null]],
+            ['VARCHAR(5)', ['name' => SqliteAdapter::PHINX_TYPE_STRING, 'limit' => 5, 'scale' => null]],
+            ['VARCHAR(55,2)', ['name' => SqliteAdapter::PHINX_TYPE_STRING, 'limit' => 55, 'scale' => 2]],
+            ['CHAR', ['name' => SqliteAdapter::PHINX_TYPE_CHAR, 'limit' => null, 'scale' => null]],
+            ['BOOLEAN', ['name' => SqliteAdapter::PHINX_TYPE_BOOLEAN, 'limit' => null, 'scale' => null]],
+            ['BOOLEAN_INTEGER', ['name' => SqliteAdapter::PHINX_TYPE_BOOLEAN, 'limit' => null, 'scale' => null]],
+            ['INT', ['name' => SqliteAdapter::PHINX_TYPE_INTEGER, 'limit' => null, 'scale' => null]],
+            ['INTEGER', ['name' => SqliteAdapter::PHINX_TYPE_INTEGER, 'limit' => null, 'scale' => null]],
+            ['TINYINT', ['name' => SqliteAdapter::PHINX_TYPE_TINY_INTEGER, 'limit' => null, 'scale' => null]],
+            ['TINYINT(1)', ['name' => SqliteAdapter::PHINX_TYPE_BOOLEAN, 'limit' => null, 'scale' => null]],
+            ['TINYINTEGER', ['name' => SqliteAdapter::PHINX_TYPE_TINY_INTEGER, 'limit' => null, 'scale' => null]],
+            ['TINYINTEGER(1)', ['name' => SqliteAdapter::PHINX_TYPE_BOOLEAN, 'limit' => null, 'scale' => null]],
+            ['SMALLINT', ['name' => SqliteAdapter::PHINX_TYPE_SMALL_INTEGER, 'limit' => null, 'scale' => null]],
+            ['SMALLINTEGER', ['name' => SqliteAdapter::PHINX_TYPE_SMALL_INTEGER, 'limit' => null, 'scale' => null]],
+            ['MEDIUMINT', ['name' => SqliteAdapter::PHINX_TYPE_INTEGER, 'limit' => null, 'scale' => null]],
+            ['MEDIUMINTEGER', ['name' => SqliteAdapter::PHINX_TYPE_INTEGER, 'limit' => null, 'scale' => null]],
+            ['BIGINT', ['name' => SqliteAdapter::PHINX_TYPE_BIG_INTEGER, 'limit' => null, 'scale' => null]],
+            ['BIGINTEGER', ['name' => SqliteAdapter::PHINX_TYPE_BIG_INTEGER, 'limit' => null, 'scale' => null]],
+            ['TEXT', ['name' => SqliteAdapter::PHINX_TYPE_TEXT, 'limit' => null, 'scale' => null]],
+            ['TINYTEXT', ['name' => SqliteAdapter::PHINX_TYPE_TEXT, 'limit' => null, 'scale' => null]],
+            ['MEDIUMTEXT', ['name' => SqliteAdapter::PHINX_TYPE_TEXT, 'limit' => null, 'scale' => null]],
+            ['LONGTEXT', ['name' => SqliteAdapter::PHINX_TYPE_TEXT, 'limit' => null, 'scale' => null]],
+            ['BLOB', ['name' => SqliteAdapter::PHINX_TYPE_BLOB, 'limit' => null, 'scale' => null]],
+            ['TINYBLOB', ['name' => SqliteAdapter::PHINX_TYPE_BLOB, 'limit' => null, 'scale' => null]],
+            ['MEDIUMBLOB', ['name' => SqliteAdapter::PHINX_TYPE_BLOB, 'limit' => null, 'scale' => null]],
+            ['LONGBLOB', ['name' => SqliteAdapter::PHINX_TYPE_BLOB, 'limit' => null, 'scale' => null]],
+            ['FLOAT', ['name' => SqliteAdapter::PHINX_TYPE_FLOAT, 'limit' => null, 'scale' => null]],
+            ['REAL', ['name' => SqliteAdapter::PHINX_TYPE_FLOAT, 'limit' => null, 'scale' => null]],
+            ['DOUBLE', ['name' => SqliteAdapter::PHINX_TYPE_DOUBLE, 'limit' => null, 'scale' => null]],
+            ['DATE', ['name' => SqliteAdapter::PHINX_TYPE_DATE, 'limit' => null, 'scale' => null]],
+            ['DATE_TEXT', ['name' => SqliteAdapter::PHINX_TYPE_DATE, 'limit' => null, 'scale' => null]],
+            ['DATETIME', ['name' => SqliteAdapter::PHINX_TYPE_DATETIME, 'limit' => null, 'scale' => null]],
+            ['DATETIME_TEXT', ['name' => SqliteAdapter::PHINX_TYPE_DATETIME, 'limit' => null, 'scale' => null]],
+            ['TIME', ['name' => SqliteAdapter::PHINX_TYPE_TIME, 'limit' => null, 'scale' => null]],
+            ['TIME_TEXT', ['name' => SqliteAdapter::PHINX_TYPE_TIME, 'limit' => null, 'scale' => null]],
+            ['TIMESTAMP', ['name' => SqliteAdapter::PHINX_TYPE_TIMESTAMP, 'limit' => null, 'scale' => null]],
+            ['TIMESTAMP_TEXT', ['name' => SqliteAdapter::PHINX_TYPE_TIMESTAMP, 'limit' => null, 'scale' => null]],
+            ['BINARY', ['name' => SqliteAdapter::PHINX_TYPE_BINARY, 'limit' => null, 'scale' => null]],
+            ['BINARY_BLOB', ['name' => SqliteAdapter::PHINX_TYPE_BINARY, 'limit' => null, 'scale' => null]],
+            ['VARBINARY', ['name' => SqliteAdapter::PHINX_TYPE_VARBINARY, 'limit' => null, 'scale' => null]],
+            ['VARBINARY_BLOB', ['name' => SqliteAdapter::PHINX_TYPE_VARBINARY, 'limit' => null, 'scale' => null]],
+            ['JSON', ['name' => SqliteAdapter::PHINX_TYPE_JSON, 'limit' => null, 'scale' => null]],
+            ['JSON_TEXT', ['name' => SqliteAdapter::PHINX_TYPE_JSON, 'limit' => null, 'scale' => null]],
+            ['JSONB', ['name' => SqliteAdapter::PHINX_TYPE_JSONB, 'limit' => null, 'scale' => null]],
+            ['JSONB_TEXT', ['name' => SqliteAdapter::PHINX_TYPE_JSONB, 'limit' => null, 'scale' => null]],
+            ['UUID', ['name' => SqliteAdapter::PHINX_TYPE_UUID, 'limit' => null, 'scale' => null]],
+            ['UUID_TEXT', ['name' => SqliteAdapter::PHINX_TYPE_UUID, 'limit' => null, 'scale' => null]],
+            ['DECIMAL', ['name' => Literal::from('decimal'), 'limit' => null, 'scale' => null]],
+            ['POINT', ['name' => Literal::from('point'), 'limit' => null, 'scale' => null]],
+            ['POLYGON', ['name' => Literal::from('polygon'), 'limit' => null, 'scale' => null]],
+            ['LINESTRING', ['name' => Literal::from('linestring'), 'limit' => null, 'scale' => null]],
+            ['GEOMETRY', ['name' => Literal::from('geometry'), 'limit' => null, 'scale' => null]],
+            ['BIT', ['name' => Literal::from('bit'), 'limit' => null, 'scale' => null]],
+            ['ENUM', ['name' => Literal::from('enum'), 'limit' => null, 'scale' => null]],
+            ['SET', ['name' => Literal::from('set'), 'limit' => null, 'scale' => null]],
+            ['CIDR', ['name' => Literal::from('cidr'), 'limit' => null, 'scale' => null]],
+            ['INET', ['name' => Literal::from('inet'), 'limit' => null, 'scale' => null]],
+            ['MACADDR', ['name' => Literal::from('macaddr'), 'limit' => null, 'scale' => null]],
+            ['INTERVAL', ['name' => Literal::from('interval'), 'limit' => null, 'scale' => null]],
+            ['FILESTREAM', ['name' => Literal::from('filestream'), 'limit' => null, 'scale' => null]],
+            ['DECIMAL_TEXT', ['name' => Literal::from('decimal'), 'limit' => null, 'scale' => null]],
+            ['POINT_TEXT', ['name' => Literal::from('point'), 'limit' => null, 'scale' => null]],
+            ['POLYGON_TEXT', ['name' => Literal::from('polygon'), 'limit' => null, 'scale' => null]],
+            ['LINESTRING_TEXT', ['name' => Literal::from('linestring'), 'limit' => null, 'scale' => null]],
+            ['GEOMETRY_TEXT', ['name' => Literal::from('geometry'), 'limit' => null, 'scale' => null]],
+            ['BIT_TEXT', ['name' => Literal::from('bit'), 'limit' => null, 'scale' => null]],
+            ['ENUM_TEXT', ['name' => Literal::from('enum'), 'limit' => null, 'scale' => null]],
+            ['SET_TEXT', ['name' => Literal::from('set'), 'limit' => null, 'scale' => null]],
+            ['CIDR_TEXT', ['name' => Literal::from('cidr'), 'limit' => null, 'scale' => null]],
+            ['INET_TEXT', ['name' => Literal::from('inet'), 'limit' => null, 'scale' => null]],
+            ['MACADDR_TEXT', ['name' => Literal::from('macaddr'), 'limit' => null, 'scale' => null]],
+            ['INTERVAL_TEXT', ['name' => Literal::from('interval'), 'limit' => null, 'scale' => null]],
+            ['FILESTREAM_TEXT', ['name' => Literal::from('filestream'), 'limit' => null, 'scale' => null]],
+            ['BIT_TEXT(2,12)', ['name' => Literal::from('bit'), 'limit' => 2, 'scale' => 12]],
+            ['not a type', ['name' => Literal::from('not a type'), 'limit' => null, 'scale' => null]],
+            ['NOT A TYPE', ['name' => Literal::from('NOT A TYPE'), 'limit' => null, 'scale' => null]],
+            ['not a type(2)', ['name' => Literal::from('not a type(2)'), 'limit' => null, 'scale' => null]],
+            ['NOT A TYPE(2)', ['name' => Literal::from('NOT A TYPE(2)'), 'limit' => null, 'scale' => null]],
+            ['ack', ['name' => Literal::from('ack'), 'limit' => null, 'scale' => null]],
+            ['ACK', ['name' => Literal::from('ACK'), 'limit' => null, 'scale' => null]],
+            ['ack_text', ['name' => Literal::from('ack_text'), 'limit' => null, 'scale' => null]],
+            ['ACK_TEXT', ['name' => Literal::from('ACK_TEXT'), 'limit' => null, 'scale' => null]],
+            ['ack_text(2,12)', ['name' => Literal::from('ack_text'), 'limit' => 2, 'scale' => 12]],
+            ['ACK_TEXT(12,2)', ['name' => Literal::from('ACK_TEXT'), 'limit' => 12, 'scale' => 2]],
+            [null, ['name' => null, 'limit' => null, 'scale' => null]],
+        ];
+    }
+
+    /** @covers \Migrations\Db\Adapter\SqliteAdapter::getColumnTypes */
+    public function testGetColumnTypes()
+    {
+        $columnTypes = $this->adapter->getColumnTypes();
+        $expected = [
+            SqliteAdapter::PHINX_TYPE_BIG_INTEGER,
+            SqliteAdapter::PHINX_TYPE_BINARY,
+            SqliteAdapter::PHINX_TYPE_BLOB,
+            SqliteAdapter::PHINX_TYPE_BOOLEAN,
+            SqliteAdapter::PHINX_TYPE_CHAR,
+            SqliteAdapter::PHINX_TYPE_DATE,
+            SqliteAdapter::PHINX_TYPE_DATETIME,
+            SqliteAdapter::PHINX_TYPE_DECIMAL,
+            SqliteAdapter::PHINX_TYPE_DOUBLE,
+            SqliteAdapter::PHINX_TYPE_FLOAT,
+            SqliteAdapter::PHINX_TYPE_INTEGER,
+            SqliteAdapter::PHINX_TYPE_JSON,
+            SqliteAdapter::PHINX_TYPE_JSONB,
+            SqliteAdapter::PHINX_TYPE_SMALL_INTEGER,
+            SqliteAdapter::PHINX_TYPE_STRING,
+            SqliteAdapter::PHINX_TYPE_TEXT,
+            SqliteAdapter::PHINX_TYPE_TIME,
+            SqliteAdapter::PHINX_TYPE_UUID,
+            SqliteAdapter::PHINX_TYPE_BINARYUUID,
+            SqliteAdapter::PHINX_TYPE_TIMESTAMP,
+            SqliteAdapter::PHINX_TYPE_TINY_INTEGER,
+            SqliteAdapter::PHINX_TYPE_VARBINARY,
+        ];
+        sort($columnTypes);
+        sort($expected);
+
+        $this->assertEquals($expected, $columnTypes);
+    }
+
+    /**
+     * @dataProvider provideColumnTypesForValidation
+     * @covers \Phinx\Db\Adapter\SqliteAdapter::isValidColumnType
+     */
+    public function testIsValidColumnType($phinxType, $exp)
+    {
+        $col = (new Column())->setType($phinxType);
+        $this->assertSame($exp, $this->adapter->isValidColumnType($col));
+    }
+
+    public static function provideColumnTypesForValidation()
+    {
+        return [
+            [SqliteAdapter::PHINX_TYPE_BIG_INTEGER, true],
+            [SqliteAdapter::PHINX_TYPE_BINARY, true],
+            [SqliteAdapter::PHINX_TYPE_BLOB, true],
+            [SqliteAdapter::PHINX_TYPE_BOOLEAN, true],
+            [SqliteAdapter::PHINX_TYPE_CHAR, true],
+            [SqliteAdapter::PHINX_TYPE_DATE, true],
+            [SqliteAdapter::PHINX_TYPE_DATETIME, true],
+            [SqliteAdapter::PHINX_TYPE_DOUBLE, true],
+            [SqliteAdapter::PHINX_TYPE_FLOAT, true],
+            [SqliteAdapter::PHINX_TYPE_INTEGER, true],
+            [SqliteAdapter::PHINX_TYPE_JSON, true],
+            [SqliteAdapter::PHINX_TYPE_JSONB, true],
+            [SqliteAdapter::PHINX_TYPE_SMALL_INTEGER, true],
+            [SqliteAdapter::PHINX_TYPE_STRING, true],
+            [SqliteAdapter::PHINX_TYPE_TEXT, true],
+            [SqliteAdapter::PHINX_TYPE_TIME, true],
+            [SqliteAdapter::PHINX_TYPE_UUID, true],
+            [SqliteAdapter::PHINX_TYPE_TIMESTAMP, true],
+            [SqliteAdapter::PHINX_TYPE_VARBINARY, true],
+            [SqliteAdapter::PHINX_TYPE_BIT, false],
+            [SqliteAdapter::PHINX_TYPE_CIDR, false],
+            [SqliteAdapter::PHINX_TYPE_DECIMAL, true],
+            [SqliteAdapter::PHINX_TYPE_ENUM, false],
+            [SqliteAdapter::PHINX_TYPE_FILESTREAM, false],
+            [SqliteAdapter::PHINX_TYPE_GEOMETRY, false],
+            [SqliteAdapter::PHINX_TYPE_INET, false],
+            [SqliteAdapter::PHINX_TYPE_INTERVAL, false],
+            [SqliteAdapter::PHINX_TYPE_LINESTRING, false],
+            [SqliteAdapter::PHINX_TYPE_MACADDR, false],
+            [SqliteAdapter::PHINX_TYPE_POINT, false],
+            [SqliteAdapter::PHINX_TYPE_POLYGON, false],
+            [SqliteAdapter::PHINX_TYPE_SET, false],
+            [Literal::from('someType'), true],
+            ['someType', false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDatabaseVersionStrings
+     * @covers \Phinx\Db\Adapter\SqliteAdapter::databaseVersionAtLeast
+     */
+    public function testDatabaseVersionAtLeast($ver, $exp)
+    {
+        $this->assertSame($exp, $this->adapter->databaseVersionAtLeast($ver));
+    }
+
+    public static function provideDatabaseVersionStrings()
+    {
+        return [
+            ['2', true],
+            ['3', true],
+            ['4', false],
+            ['3.0', true],
+            ['3.0.0.0.0.0', true],
+            ['3.0.0.0.0.99999', true],
+            ['3.9999', false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideColumnNamesToCheck
+     * @covers \Phinx\Db\Adapter\SqliteAdapter::getSchemaName
+     * @covers \Phinx\Db\Adapter\SqliteAdapter::getTableInfo
+     * @covers \Phinx\Db\Adapter\SqliteAdapter::hasColumn
+     */
+    public function testHasColumn($tableDef, $col, $exp)
+    {
+        $conn = $this->adapter->getConnection();
+        $conn->exec($tableDef);
+        $this->assertEquals($exp, $this->adapter->hasColumn('t', $col));
+    }
+
+    public static function provideColumnNamesToCheck()
+    {
+        return [
+            ['create table t(a text)', 'a', true],
+            ['create table t(A text)', 'a', true],
+            ['create table t("a" text)', 'a', true],
+            ['create table t([a] text)', 'a', true],
+            ['create table t(\'a\' text)', 'a', true],
+            ['create table t("A" text)', 'a', true],
+            ['create table t(a text)', 'A', true],
+            ['create table t(b text)', 'a', false],
+            ['create table t(b text, a text)', 'a', true],
+            ['create table t("0" text)', '0', true],
+            ['create table t("0" text)', '0e0', false],
+            ['create table t("0e0" text)', '0', false],
+            ['create table t(b text); create temp table t(a text)', 'a', true],
+            ['create table not_t(a text)', 'a', false],
+        ];
+    }
+
+    /** @covers \Phinx\Db\Adapter\SqliteAdapter::getSchemaName
+     * @covers \Phinx\Db\Adapter\SqliteAdapter::getTableInfo
+     * @covers \Phinx\Db\Adapter\SqliteAdapter::getColumns
+     */
+    public function testGetColumns()
+    {
+        $conn = $this->adapter->getConnection();
+        $conn->exec('create table t(a integer, b text, c char(5), d integer(12,6), e integer not null, f integer null)');
+        $exp = [
+            ['name' => 'a', 'type' => 'integer', 'null' => true, 'limit' => null, 'precision' => null, 'scale' => null],
+            ['name' => 'b', 'type' => 'text', 'null' => true, 'limit' => null, 'precision' => null, 'scale' => null],
+            ['name' => 'c', 'type' => 'char', 'null' => true, 'limit' => 5, 'precision' => 5, 'scale' => null],
+            ['name' => 'd', 'type' => 'integer', 'null' => true, 'limit' => 12, 'precision' => 12, 'scale' => 6],
+            ['name' => 'e', 'type' => 'integer', 'null' => false, 'limit' => null, 'precision' => null, 'scale' => null],
+            ['name' => 'f', 'type' => 'integer', 'null' => true, 'limit' => null, 'precision' => null, 'scale' => null],
+        ];
+        $act = $this->adapter->getColumns('t');
+        $this->assertCount(count($exp), $act);
+        foreach ($exp as $index => $data) {
+            $this->assertInstanceOf(Column::class, $act[$index]);
+            foreach ($data as $key => $value) {
+                $m = 'get' . ucfirst($key);
+                $this->assertEquals($value, $act[$index]->$m(), "Parameter '$key' of column at index $index did not match expectations.");
+            }
+        }
+    }
+
+    /**
+     * @dataProvider provideIdentityCandidates
+     * @covers \Phinx\Db\Adapter\SqliteAdapter::resolveIdentity
+     */
+    public function testGetColumnsForIdentity($tableDef, $exp)
+    {
+        $conn = $this->adapter->getConnection();
+        $conn->exec($tableDef);
+        $cols = $this->adapter->getColumns('t');
+        $act = [];
+        foreach ($cols as $col) {
+            if ($col->getIdentity()) {
+                $act[] = $col->getName();
+            }
+        }
+        $this->assertEquals((array)$exp, $act);
+    }
+
+    public static function provideIdentityCandidates()
+    {
+        return [
+            ['create table t(a text)', null],
+            ['create table t(a text primary key)', null],
+            ['create table t(a integer, b text, primary key(a,b))', null],
+            ['create table t(a integer primary key desc)', null],
+            ['create table t(a integer primary key) without rowid', null],
+            ['create table t(a integer primary key)', 'a'],
+            ['CREATE TABLE T(A INTEGER PRIMARY KEY)', 'A'],
+            ['create table t(a integer, primary key(a))', 'a'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDefaultValues
+     * @covers \Phinx\Db\Adapter\SqliteAdapter::parseDefaultValue
+     */
+    public function testGetColumnsForDefaults($tableDef, $exp)
+    {
+        $conn = $this->adapter->getConnection();
+        $conn->exec($tableDef);
+        $act = $this->adapter->getColumns('t')[0]->getDefault();
+        if (is_object($exp)) {
+            $this->assertEquals($exp, $act);
+        } else {
+            $this->assertSame($exp, $act);
+        }
+    }
+
+    public static function provideDefaultValues()
+    {
+        return [
+            'Implicit null' => ['create table t(a integer)', null],
+            'Explicit null LC' => ['create table t(a integer default null)', null],
+            'Explicit null UC' => ['create table t(a integer default NULL)', null],
+            'Explicit null MC' => ['create table t(a integer default nuLL)', null],
+            'Extra parentheses' => ['create table t(a integer default ( ( null ) ))', null],
+            'Comment 1' => ['create table t(a integer default ( /* this is perfectly fine */ null ))', null],
+            'Comment 2' => ["create table t(a integer default ( /* this\nis\nperfectly\nfine */ null ))", null],
+            'Line comment 1' => ["create table t(a integer default ( -- this is perfectly fine, too\n null ))", null],
+            'Line comment 2' => ["create table t(a integer default ( -- this is perfectly fine, too\r\n null ))", null],
+            'Current date LC' => ['create table t(a date default current_date)', 'CURRENT_DATE'],
+            'Current date UC' => ['create table t(a date default CURRENT_DATE)', 'CURRENT_DATE'],
+            'Current date MC' => ['create table t(a date default CURRENT_date)', 'CURRENT_DATE'],
+            'Current time LC' => ['create table t(a time default current_time)', 'CURRENT_TIME'],
+            'Current time UC' => ['create table t(a time default CURRENT_TIME)', 'CURRENT_TIME'],
+            'Current time MC' => ['create table t(a time default CURRENT_time)', 'CURRENT_TIME'],
+            'Current timestamp LC' => ['create table t(a datetime default current_timestamp)', 'CURRENT_TIMESTAMP'],
+            'Current timestamp UC' => ['create table t(a datetime default CURRENT_TIMESTAMP)', 'CURRENT_TIMESTAMP'],
+            'Current timestamp MC' => ['create table t(a datetime default CURRENT_timestamp)', 'CURRENT_TIMESTAMP'],
+            'String 1' => ['create table t(a text default \'\')', Literal::from('')],
+            'String 2' => ['create table t(a text default \'value!\')', Literal::from('value!')],
+            'String 3' => ['create table t(a text default \'O\'\'Brien\')', Literal::from('O\'Brien')],
+            'String 4' => ['create table t(a text default \'CURRENT_TIMESTAMP\')', Literal::from('CURRENT_TIMESTAMP')],
+            'String 5' => ['create table t(a text default \'current_timestamp\')', Literal::from('current_timestamp')],
+            'String 6' => ['create table t(a text default \'\' /* comment */)', Literal::from('')],
+            'Hexadecimal LC' => ['create table t(a integer default 0xff)', 255],
+            'Hexadecimal UC' => ['create table t(a integer default 0XFF)', 255],
+            'Hexadecimal MC' => ['create table t(a integer default 0x1F)', 31],
+            'Integer 1' => ['create table t(a integer default 1)', 1],
+            'Integer 2' => ['create table t(a integer default -1)', -1],
+            'Integer 3' => ['create table t(a integer default +1)', 1],
+            'Integer 4' => ['create table t(a integer default 2112)', 2112],
+            'Integer 5' => ['create table t(a integer default 002112)', 2112],
+            'Integer boolean 1' => ['create table t(a boolean default 1)', true],
+            'Integer boolean 2' => ['create table t(a boolean default 0)', false],
+            'Integer boolean 3' => ['create table t(a boolean default -1)', -1],
+            'Integer boolean 4' => ['create table t(a boolean default 2)', 2],
+            'Float 1' => ['create table t(a float default 1.0)', 1.0],
+            'Float 2' => ['create table t(a float default +1.0)', 1.0],
+            'Float 3' => ['create table t(a float default -1.0)', -1.0],
+            'Float 4' => ['create table t(a float default 1.)', 1.0],
+            'Float 5' => ['create table t(a float default 0.1)', 0.1],
+            'Float 6' => ['create table t(a float default .1)', 0.1],
+            'Float 7' => ['create table t(a float default 1e0)', 1.0],
+            'Float 8' => ['create table t(a float default 1e+0)', 1.0],
+            'Float 9' => ['create table t(a float default 1e+1)', 10.0],
+            'Float 10' => ['create table t(a float default 1e-1)', 0.1],
+            'Float 11' => ['create table t(a float default 1E-1)', 0.1],
+            'Blob literal 1' => ['create table t(a float default x\'ff\')', Expression::from('x\'ff\'')],
+            'Blob literal 2' => ['create table t(a float default X\'FF\')', Expression::from('X\'FF\'')],
+            'Arbitrary expression' => ['create table t(a float default ((2) + (2)))', Expression::from('(2) + (2)')],
+            'Pathological case 1' => ['create table t(a float default (\'/*\' || \'*/\'))', Expression::from('\'/*\' || \'*/\'')],
+            'Pathological case 2' => ['create table t(a float default (\'--\' || \'stuff\'))', Expression::from('\'--\' || \'stuff\'')],
+        ];
+    }
+
+    /**
+     * @dataProvider provideBooleanDefaultValues
+     * @covers \Phinx\Db\Adapter\SqliteAdapter::parseDefaultValue
+     */
+    public function testGetColumnsForBooleanDefaults($tableDef, $exp)
+    {
+        if (!$this->adapter->databaseVersionAtLeast('3.24')) {
+            $this->markTestSkipped('SQLite 3.24.0 or later is required for this test.');
+        }
+        $conn = $this->adapter->getConnection();
+        $conn->exec($tableDef);
+        $act = $this->adapter->getColumns('t')[0]->getDefault();
+        if (is_object($exp)) {
+            $this->assertEquals($exp, $act);
+        } else {
+            $this->assertSame($exp, $act);
+        }
+    }
+
+    public static function provideBooleanDefaultValues()
+    {
+        return [
+            'True LC' => ['create table t(a boolean default true)', true],
+            'True UC' => ['create table t(a boolean default TRUE)', true],
+            'True MC' => ['create table t(a boolean default TRue)', true],
+            'False LC' => ['create table t(a boolean default false)', false],
+            'False UC' => ['create table t(a boolean default FALSE)', false],
+            'False MC' => ['create table t(a boolean default FALse)', false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTablesForTruncation
+     * @covers \Phinx\Db\Adapter\SqliteAdapter::truncateTable
+     */
+    public function testTruncateTable($tableDef, $tableName, $tableId)
+    {
+        $conn = $this->adapter->getConnection();
+        $conn->exec($tableDef);
+        $conn->exec("INSERT INTO $tableId default values");
+        $conn->exec("INSERT INTO $tableId default values");
+        $conn->exec("INSERT INTO $tableId default values");
+        $this->assertEquals(3, $conn->query("select count(*) from $tableId")->fetchColumn(), 'Broken fixture: data were not inserted properly');
+        $this->assertEquals(3, $conn->query("select max(id) from $tableId")->fetchColumn(), 'Broken fixture: data were not inserted properly');
+        $this->adapter->truncateTable($tableName);
+        $this->assertEquals(0, $conn->query("select count(*) from $tableId")->fetchColumn(), 'Table was not truncated');
+        $conn->exec("INSERT INTO $tableId default values");
+        $this->assertEquals(1, $conn->query("select max(id) from $tableId")->fetchColumn(), 'Autoincrement was not reset');
+    }
+
+    /**
+     * @return array
+     */
+    public static function provideTablesForTruncation()
+    {
+        return [
+            ['create table t(id integer primary key)', 't', 't'],
+            ['create table t(id integer primary key autoincrement)', 't', 't'],
+            ['create temp table t(id integer primary key)', 't', 'temp.t'],
+            ['create temp table t(id integer primary key autoincrement)', 't', 'temp.t'],
+            ['create table t(id integer primary key)', 'main.t', 'main.t'],
+            ['create table t(id integer primary key autoincrement)', 'main.t', 'main.t'],
+            ['create temp table t(id integer primary key)', 'temp.t', 'temp.t'],
+            ['create temp table t(id integer primary key autoincrement)', 'temp.t', 'temp.t'],
+            ['create table ["](id integer primary key)', 'main."', 'main.""""'],
+            ['create table ["](id integer primary key autoincrement)', 'main."', 'main.""""'],
+            ['create table [\'](id integer primary key)', 'main.\'', 'main."\'"'],
+            ['create table [\'](id integer primary key autoincrement)', 'main.\'', 'main."\'"'],
+            ['create table T(id integer primary key)', 't', 't'],
+            ['create table T(id integer primary key autoincrement)', 't', 't'],
+            ['create table t(id integer primary key)', 'T', 't'],
+            ['create table t(id integer primary key autoincrement)', 'T', 't'],
+        ];
+    }
+
+    public function testForeignKeyReferenceCorrectAfterRenameColumn()
+    {
+        $refTableColumnId = 'ref_table_id';
+        $refTableColumnToRename = 'columnToRename';
+        $refTableRenamedColumn = 'renamedColumn';
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable->addColumn($refTableColumnToRename, 'string')->save();
+
+        $table = new Table('table', [], $this->adapter);
+        $table->addColumn($refTableColumnId, 'integer');
+        $table->addForeignKey($refTableColumnId, $refTable->getName(), 'id');
+        $table->save();
+
+        $refTable->renameColumn($refTableColumnToRename, $refTableRenamedColumn)->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [$refTableColumnId]));
+        $this->assertFalse($this->adapter->hasTable("tmp_{$refTable->getName()}"));
+        $this->assertTrue($this->adapter->hasColumn($refTable->getName(), $refTableRenamedColumn));
+
+        $rows = $this->adapter->fetchAll('select * from sqlite_master where `type` = \'table\'');
+        foreach ($rows as $row) {
+            if ($row['tbl_name'] === $table->getName()) {
+                $sql = $row['sql'];
+            }
+        }
+        $this->assertStringContainsString("REFERENCES `{$refTable->getName()}` (`id`)", $sql);
+    }
+
+    public function testForeignKeyReferenceCorrectAfterChangeColumn()
+    {
+        $refTableColumnId = 'ref_table_id';
+        $refTableColumnToChange = 'columnToChange';
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable->addColumn($refTableColumnToChange, 'string')->save();
+
+        $table = new Table('table', [], $this->adapter);
+        $table->addColumn($refTableColumnId, 'integer');
+        $table->addForeignKey($refTableColumnId, $refTable->getName(), 'id');
+        $table->save();
+
+        $refTable->changeColumn($refTableColumnToChange, 'text')->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [$refTableColumnId]));
+        $this->assertFalse($this->adapter->hasTable("tmp_{$refTable->getName()}"));
+        $this->assertEquals('text', $this->adapter->getColumns($refTable->getName())[1]->getType());
+
+        $rows = $this->adapter->fetchAll('select * from sqlite_master where `type` = \'table\'');
+        foreach ($rows as $row) {
+            if ($row['tbl_name'] === $table->getName()) {
+                $sql = $row['sql'];
+            }
+        }
+        $this->assertStringContainsString("REFERENCES `{$refTable->getName()}` (`id`)", $sql);
+    }
+
+    public function testForeignKeyReferenceCorrectAfterRemoveColumn()
+    {
+        $refTableColumnId = 'ref_table_id';
+        $refTableColumnToRemove = 'columnToRemove';
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable->addColumn($refTableColumnToRemove, 'string')->save();
+
+        $table = new Table('table', [], $this->adapter);
+        $table->addColumn($refTableColumnId, 'integer');
+        $table->addForeignKey($refTableColumnId, $refTable->getName(), 'id');
+        $table->save();
+
+        $refTable->removeColumn($refTableColumnToRemove)->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [$refTableColumnId]));
+        $this->assertFalse($this->adapter->hasTable("tmp_{$refTable->getName()}"));
+        $this->assertFalse($this->adapter->hasColumn($refTable->getName(), $refTableColumnToRemove));
+
+        $rows = $this->adapter->fetchAll('select * from sqlite_master where `type` = \'table\'');
+        foreach ($rows as $row) {
+            if ($row['tbl_name'] === $table->getName()) {
+                $sql = $row['sql'];
+            }
+        }
+        $this->assertStringContainsString("REFERENCES `{$refTable->getName()}` (`id`)", $sql);
+    }
+
+    public function testForeignKeyReferenceCorrectAfterChangePrimaryKey()
+    {
+        $refTableColumnAdditionalId = 'additional_id';
+        $refTableColumnId = 'ref_table_id';
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable->addColumn($refTableColumnAdditionalId, 'integer')->save();
+
+        $table = new Table('table', [], $this->adapter);
+        $table->addColumn($refTableColumnId, 'integer');
+        $table->addForeignKey($refTableColumnId, $refTable->getName(), 'id');
+        $table->save();
+
+        $refTable
+            ->addIndex('id', ['unique' => true])
+            ->changePrimaryKey($refTableColumnAdditionalId)
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [$refTableColumnId]));
+        $this->assertFalse($this->adapter->hasTable("tmp_{$refTable->getName()}"));
+        $this->assertTrue($this->adapter->getColumns($refTable->getName())[1]->getIdentity());
+
+        $rows = $this->adapter->fetchAll('select * from sqlite_master where `type` = \'table\'');
+        foreach ($rows as $row) {
+            if ($row['tbl_name'] === $table->getName()) {
+                $sql = $row['sql'];
+            }
+        }
+        $this->assertStringContainsString("REFERENCES `{$refTable->getName()}` (`id`)", $sql);
+    }
+
+    public function testForeignKeyReferenceCorrectAfterDropForeignKey()
+    {
+        $refTableAdditionalColumnId = 'ref_table_additional_id';
+        $refTableAdditional = new Table('ref_table_additional', [], $this->adapter);
+        $refTableAdditional->save();
+
+        $refTableColumnId = 'ref_table_id';
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable->addColumn($refTableAdditionalColumnId, 'integer');
+        $refTable->addForeignKey($refTableAdditionalColumnId, $refTableAdditional->getName(), 'id');
+        $refTable->save();
+
+        $table = new Table('table', [], $this->adapter);
+        $table->addColumn($refTableColumnId, 'integer');
+        $table->addForeignKey($refTableColumnId, $refTable->getName(), 'id');
+        $table->save();
+
+        $refTable->dropForeignKey($refTableAdditionalColumnId)->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [$refTableColumnId]));
+        $this->assertFalse($this->adapter->hasTable("tmp_{$refTable->getName()}"));
+        $this->assertFalse($this->adapter->hasForeignKey($refTable->getName(), [$refTableAdditionalColumnId]));
+
+        $rows = $this->adapter->fetchAll('select * from sqlite_master where `type` = \'table\'');
+        foreach ($rows as $row) {
+            if ($row['tbl_name'] === $table->getName()) {
+                $sql = $row['sql'];
+            }
+        }
+        $this->assertStringContainsString("REFERENCES `{$refTable->getName()}` (`id`)", $sql);
+    }
+
+    public function testInvalidPdoAttribute()
+    {
+        $adapter = new SqliteAdapter($this->config + ['attr_invalid' => true]);
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Invalid PDO attribute: attr_invalid (\PDO::ATTR_INVALID)');
+        $adapter->connect();
+    }
+
+    public function testPdoExceptionUpdateNonExistingTable()
+    {
+        $this->expectException(PDOException::class);
+        $table = new Table('non_existing_table', [], $this->adapter);
+        $table->addColumn('column', 'string')->update();
+    }
+
+    public function testPdoPersistentConnection()
+    {
+        $adapter = new SqliteAdapter($this->config + ['attr_persistent' => true]);
+        $this->assertTrue($adapter->getConnection()->getAttribute(PDO::ATTR_PERSISTENT));
+    }
+
+    public function testPdoNotPersistentConnection()
+    {
+        $adapter = new SqliteAdapter($this->config);
+        $this->assertFalse($adapter->getConnection()->getAttribute(PDO::ATTR_PERSISTENT));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -121,10 +121,11 @@ if (getenv('DB_URL_COMPARE') !== false) {
     ]);
 }
 
-Plugin::getCollection()->add(new MigrationsPlugin());
-Plugin::getCollection()->add(new BakePlugin());
-Plugin::getCollection()->add(new SimpleSnapshotPlugin());
-Plugin::getCollection()->add(new TestBlogPlugin());
+Plugin::getCollection()
+    ->add(new MigrationsPlugin())
+    ->add(new BakePlugin())
+    ->add(new SimpleSnapshotPlugin())
+    ->add(new TestBlogPlugin());
 
 if (!defined('PHINX_VERSION')) {
     define('PHINX_VERSION', strpos('@PHINX_VERSION@', '@PHINX_VERSION') === 0 ? 'UNKNOWN' : '@PHINX_VERSION@');


### PR DESCRIPTION
- Import sqlite driver code from phinx.
- Update config parsing to use ConnectionManager as that is the eventual end state.
- Fix strict errors caused by uninitialized properties.
- Fix configuration parsing to unskip mysql tests.