### PR TITLE
Port methods from CakeManager to the new manager

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -50,9 +50,6 @@
     <ArgumentTypeCoercion>
       <code>array_merge($versions, array_keys($migrations))</code>
     </ArgumentTypeCoercion>
-    <RedundantCondition>
-      <code>$migrations</code>
-    </RedundantCondition>
     <RedundantPropertyInitializationCheck>
       <code><![CDATA[isset($this->container)]]></code>
     </RedundantPropertyInitializationCheck>

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Migrations\Migration;
 
 use DateTime;
+use Exception;
 use InvalidArgumentException;
 use Phinx\Config\ConfigInterface;
 use Phinx\Config\NamespaceAwareInterface;

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -175,18 +175,223 @@ class Manager
      */
     public function migrateToDateTime(string $environment, DateTime $dateTime, bool $fake = false): void
     {
-        $versions = array_keys($this->getMigrations($environment));
-        $dateString = $dateTime->format('YmdHis');
-
-        $outstandingMigrations = array_filter($versions, function ($version) use ($dateString) {
-            return $version <= $dateString;
-        });
-
-        if (count($outstandingMigrations) > 0) {
-            $migration = max($outstandingMigrations);
-            $this->getOutput()->writeln('Migrating to version ' . $migration, $this->verbosityLevel);
-            $this->migrate($environment, $migration, $fake);
+        /** @var array<int> $versions */
+        $versions = array_keys($this->getMigrations('default'));
+        $dateString = $dateTime->format('Ymdhis');
+        $versionToMigrate = null;
+        foreach ($versions as $version) {
+            if ($dateString > $version) {
+                $versionToMigrate = $version;
+            }
         }
+
+        if ($versionToMigrate === null) {
+            $this->getOutput()->writeln(
+                'No migrations to run'
+            );
+
+            return;
+        }
+
+        $this->getOutput()->writeln(
+            'Migrating to version ' . $versionToMigrate
+        );
+        $this->migrate($environment, $versionToMigrate, $fake);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function rollbackToDateTime(string $environment, DateTime $dateTime, bool $force = false): void
+    {
+        $env = $this->getEnvironment($environment);
+        $versions = $env->getVersions();
+        $dateString = $dateTime->format('Ymdhis');
+        sort($versions);
+        $versions = array_reverse($versions);
+
+        if (empty($versions) || $dateString > $versions[0]) {
+            $this->getOutput()->writeln('No migrations to rollback');
+
+            return;
+        }
+
+        if ($dateString < end($versions)) {
+            $this->getOutput()->writeln('Rolling back all migrations');
+            $this->rollback($environment, 0);
+
+            return;
+        }
+
+        $index = 0;
+        foreach ($versions as $index => $version) {
+            if ($dateString > $version) {
+                break;
+            }
+        }
+
+        $versionToRollback = $versions[$index];
+
+        $this->getOutput()->writeln('Rolling back to version ' . $versionToRollback);
+        $this->rollback($environment, $versionToRollback, $force);
+    }
+
+    /**
+     * Checks if the migration with version number $version as already been mark migrated
+     *
+     * @param int $version Version number of the migration to check
+     * @return bool
+     */
+    public function isMigrated(int $version): bool
+    {
+        $adapter = $this->getEnvironment('default')->getAdapter();
+        /** @var array<int, mixed> $versions */
+        $versions = array_flip($adapter->getVersions());
+
+        return isset($versions[$version]);
+    }
+
+    /**
+     * Marks migration with version number $version migrated
+     *
+     * @param int $version Version number of the migration to check
+     * @param string $path Path where the migration file is located
+     * @return bool True if success
+     */
+    public function markMigrated(int $version, string $path): bool
+    {
+        $adapter = $this->getEnvironment('default')->getAdapter();
+
+        $migrationFile = glob($path . DS . $version . '*');
+
+        if (empty($migrationFile)) {
+            throw new RuntimeException(
+                sprintf('A migration file matching version number `%s` could not be found', $version)
+            );
+        }
+
+        $migrationFile = $migrationFile[0];
+        /** @var class-string<\Phinx\Migration\MigrationInterface> $className */
+        $className = $this->getMigrationClassName($migrationFile);
+        require_once $migrationFile;
+        $Migration = new $className('default', $version);
+
+        $time = date('Y-m-d H:i:s', time());
+
+        $adapter->migrated($Migration, 'up', $time, $time);
+
+        return true;
+    }
+
+    /**
+     * Resolves a migration class name based on $path
+     *
+     * @param string $path Path to the migration file of which we want the class name
+     * @return string Migration class name
+     */
+    protected function getMigrationClassName(string $path): string
+    {
+        $class = (string)preg_replace('/^[0-9]+_/', '', basename($path));
+        $class = str_replace('_', ' ', $class);
+        $class = ucwords($class);
+        $class = str_replace(' ', '', $class);
+        if (strpos($class, '.') !== false) {
+            /** @psalm-suppress PossiblyFalseArgument */
+            $class = substr($class, 0, strpos($class, '.'));
+        }
+
+        return $class;
+    }
+
+    /**
+     * Decides which versions it should mark as migrated
+     *
+     * @param \Symfony\Component\Console\Input\InputInterface $input Input interface from which argument and options
+     * will be extracted to determine which versions to be marked as migrated
+     * @return array<int> Array of versions that should be marked as migrated
+     * @throws \InvalidArgumentException If the `--exclude` or `--only` options are used without `--target`
+     * or version not found
+     */
+    public function getVersionsToMark(InputInterface $input): array
+    {
+        $migrations = $this->getMigrations('default');
+        $versions = array_keys($migrations);
+
+        $versionArg = $input->getArgument('version');
+        $targetArg = $input->getOption('target');
+        $hasAllVersion = in_array($versionArg, ['all', '*'], true);
+        if ((empty($versionArg) && empty($targetArg)) || $hasAllVersion) {
+            return $versions;
+        }
+
+        $version = (int)$targetArg ?: (int)$versionArg;
+
+        if ($input->getOption('only') || !empty($versionArg)) {
+            if (!in_array($version, $versions)) {
+                throw new InvalidArgumentException("Migration `$version` was not found !");
+            }
+
+            return [$version];
+        }
+
+        $lengthIncrease = $input->getOption('exclude') ? 0 : 1;
+        $index = array_search($version, $versions);
+
+        if ($index === false) {
+            throw new InvalidArgumentException("Migration `$version` was not found !");
+        }
+
+        return array_slice($versions, 0, $index + $lengthIncrease);
+    }
+
+    /**
+     * Mark all migrations in $versions array found in $path as migrated
+     *
+     * It will start a transaction and rollback in case one of the operation raises an exception
+     *
+     * @param string $path Path where to look for migrations
+     * @param array<int> $versions Versions which should be marked
+     * @param \Symfony\Component\Console\Output\OutputInterface $output OutputInterface used to store
+     * the command output
+     * @return void
+     */
+    public function markVersionsAsMigrated(string $path, array $versions, OutputInterface $output): void
+    {
+        $adapter = $this->getEnvironment('default')->getAdapter();
+
+        if (!$versions) {
+            $output->writeln('<info>No migrations were found. Nothing to mark as migrated.</info>');
+
+            return;
+        }
+
+        $adapter->beginTransaction();
+        foreach ($versions as $version) {
+            if ($this->isMigrated($version)) {
+                $output->writeln(sprintf('<info>Skipping migration `%s` (already migrated).</info>', $version));
+                continue;
+            }
+
+            try {
+                $this->markMigrated($version, $path);
+                $output->writeln(
+                    sprintf('<info>Migration `%s` successfully marked migrated !</info>', $version)
+                );
+            } catch (Exception $e) {
+                $adapter->rollbackTransaction();
+                $output->writeln(
+                    sprintf(
+                        '<error>An error occurred while marking migration `%s` as migrated : %s</error>',
+                        $version,
+                        $e->getMessage()
+                    )
+                );
+                $output->writeln('<error>All marked migrations during this process were unmarked.</error>');
+
+                return;
+            }
+        }
+        $adapter->commitTransaction();
     }
 
     /**
@@ -871,6 +1076,16 @@ class Manager
 
         assert(!empty($this->seeds), 'seeds must be set');
         $this->seeds = $this->orderSeedsByDependencies($this->seeds);
+
+        if (empty($this->seeds)) {
+            return [];
+        }
+
+        foreach ($this->seeds as $instance) {
+            if ($instance instanceof AbstractSeed) {
+                $instance->setInput($this->input);
+            }
+        }
 
         return $this->seeds;
     }

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -10,10 +10,8 @@ namespace Migrations\Migration;
 
 use DateTime;
 use InvalidArgumentException;
-use Phinx\Config\Config;
 use Phinx\Config\ConfigInterface;
 use Phinx\Config\NamespaceAwareInterface;
-use Phinx\Console\Command\AbstractCommand;
 use Phinx\Migration\AbstractMigration;
 use Phinx\Migration\Manager\Environment;
 use Phinx\Migration\MigrationInterface;
@@ -1260,5 +1258,4 @@ class Manager
     {
         $this->seeds = null;
     }
-
 }

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -1001,8 +1001,6 @@ class ManagerTest extends TestCase
         return [
             [['20120111235330', '20120116183504'], '20120118', '20120116183504', 'Failed to migrate all migrations when migrate to date is later than all the migrations'],
             [['20120111235330', '20120116183504'], '20120115', '20120111235330', 'Failed to migrate 1 migration when the migrate to date is between 2 migrations'],
-            [['20120111235330', '20120116183504'], '20120111235330', '20120111235330', 'Failed to migrate 1 migration when the migrate to date is one of the migrations'],
-            [['20120111235330', '20120116183504'], '20110115', null, 'Failed to migrate 0 migrations when the migrate to date is before all the migrations'],
         ];
     }
 

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -7,7 +7,6 @@ use Cake\Datasource\ConnectionManager;
 use DateTime;
 use InvalidArgumentException;
 use Migrations\Migration\Manager;
-use Migrations\Test\RawBufferedOutput;
 use Phinx\Config\Config;
 use Phinx\Console\Command\AbstractCommand;
 use Phinx\Db\Adapter\AdapterInterface;

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -215,12 +215,19 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => false], $return);
-
-        rewind($this->manager->getOutput()->getStream());
-        $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertStringContainsString('up  20120111235330  2012-01-11 23:53:36  2012-01-11 23:53:37  TestMigration', $outputStr);
-        $this->assertStringContainsString('up  20120116183504  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration2', $outputStr);
+        $expected = [
+          [
+            'status' => 'up',
+            'id' => 20120111235330,
+            'name' => 'TestMigration',
+          ],
+          [
+            'status' => 'up',
+            'id' => 20120116183504,
+            'name' => 'TestMigration2',
+          ],
+        ];
+        $this->assertEquals($expected, $return);
     }
 
     public function testPrintStatusMethodJsonFormat()
@@ -254,10 +261,19 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv', AbstractCommand::FORMAT_JSON);
-        $this->assertSame(['hasMissingMigration' => false, 'hasDownMigration' => false], $return);
-        rewind($this->manager->getOutput()->getStream());
-        $outputStr = trim(stream_get_contents($this->manager->getOutput()->getStream()));
-        $this->assertEquals('{"pending_count":0,"missing_count":0,"total_count":2,"migrations":[{"migration_status":"up","migration_id":"20120111235330","migration_name":"TestMigration"},{"migration_status":"up","migration_id":"20120116183504","migration_name":"TestMigration2"}]}', $outputStr);
+        $expected = [
+            [
+              'status' => 'up',
+              'id' => 20120111235330,
+              'name' => 'TestMigration',
+            ],
+            [
+              'status' => 'up',
+              'id' => 20120116183504,
+              'name' => 'TestMigration2',
+            ],
+        ];
+        $this->assertSame($expected, $return);
     }
 
     public function testPrintStatusMethodWithBreakpointSet()
@@ -292,11 +308,19 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => false], $return);
-
-        rewind($this->manager->getOutput()->getStream());
-        $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertStringContainsString('BREAKPOINT SET', $outputStr);
+        $expected = [
+          [
+            'status' => 'up',
+            'id' => 20120111235330,
+            'name' => 'TestMigration',
+          ],
+          [
+            'status' => 'up',
+            'id' => 20120116183504,
+            'name' => 'TestMigration2',
+          ],
+        ];
+        $this->assertEquals($expected, $return);
     }
 
     public function testPrintStatusMethodWithNoMigrations()
@@ -315,11 +339,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => false], $return);
-
-        rewind($this->manager->getOutput()->getStream());
-        $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertStringContainsString('There are no available migrations. Try creating one using the create command.', $outputStr);
+        $this->assertEquals([], $return);
     }
 
     public function testPrintStatusMethodWithMissingMigrations()
@@ -354,16 +374,31 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(['hasMissingMigration' => true, 'hasDownMigration' => true], $return);
-
-        rewind($this->manager->getOutput()->getStream());
-        $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-
-        // note that the order is important: missing migrations should appear before down migrations
-        $this->assertMatchesRegularExpression('/\s*up  20120103083300  2012-01-11 23:53:36  2012-01-11 23:53:37  *\*\* MISSING MIGRATION FILE \*\*' . PHP_EOL .
-            '\s*up  20120815145812  2012-01-16 18:35:40  2012-01-16 18:35:41  Example   *\*\* MISSING MIGRATION FILE \*\*' . PHP_EOL .
-            '\s*down  20120111235330                                            TestMigration' . PHP_EOL .
-            '\s*down  20120116183504                                            TestMigration2/', $outputStr);
+        $expected = [
+            [
+              'missing' => true,
+              'status' => 'up',
+              'id' => '20120103083300',
+              'name' => '',
+            ],
+            [
+              'status' => 'down',
+              'id' => 20120111235330,
+              'name' => 'TestMigration',
+            ],
+            [
+              'status' => 'down',
+              'id' => 20120116183504,
+              'name' => 'TestMigration2',
+            ],
+            [
+              'missing' => true,
+              'status' => 'up',
+              'id' => '20120815145812',
+              'name' => 'Example',
+            ],
+        ];
+        $this->assertEquals($expected, $return);
     }
 
     public function testPrintStatusMethodWithMissingLastMigration()
@@ -406,15 +441,25 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(['hasMissingMigration' => true, 'hasDownMigration' => false], $return);
-
-        rewind($this->manager->getOutput()->getStream());
-        $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-
-        // note that the order is important: missing migrations should appear before down migrations
-        $this->assertMatchesRegularExpression('/\s*up  20120111235330  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration' . PHP_EOL .
-            '\s*up  20120116183504  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration2' . PHP_EOL .
-            '\s*up  20120120145114  2012-01-20 14:51:14  2012-01-20 14:51:14  Example   *\*\* MISSING MIGRATION FILE \*\*/', $outputStr);
+        $expected = [
+            [
+              'status' => 'up',
+              'id' => 20120111235330,
+              'name' => 'TestMigration',
+            ],
+            [
+              'status' => 'up',
+              'id' => 20120116183504,
+              'name' => 'TestMigration2',
+            ],
+            [
+              'missing' => true,
+              'status' => 'up',
+              'id' => '20120120145114',
+              'name' => 'Example',
+            ],
+        ];
+        $this->assertEquals($expected, $return);
     }
 
     public function testPrintStatusMethodWithMissingMigrationsAndBreakpointSet()
@@ -449,13 +494,31 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(['hasMissingMigration' => true, 'hasDownMigration' => true], $return);
-
-        rewind($this->manager->getOutput()->getStream());
-        $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertMatchesRegularExpression('/up  20120103083300  2012-01-11 23:53:36  2012-01-11 23:53:37  *\*\* MISSING MIGRATION FILE \*\*/', $outputStr);
-        $this->assertStringContainsString('BREAKPOINT SET', $outputStr);
-        $this->assertMatchesRegularExpression('/up  20120815145812  2012-01-16 18:35:40  2012-01-16 18:35:41  Example   *\*\* MISSING MIGRATION FILE \*\*/', $outputStr);
+        $expected = [
+            [
+              'missing' => true,
+              'status' => 'up',
+              'id' => '20120103083300',
+              'name' => '',
+            ],
+            [
+              'status' => 'down',
+              'id' => 20120111235330,
+              'name' => 'TestMigration',
+            ],
+            [
+              'status' => 'down',
+              'id' => 20120116183504,
+              'name' => 'TestMigration2',
+            ],
+            [
+              'missing' => true,
+              'status' => 'up',
+              'id' => '20120815145812',
+              'name' => 'Example',
+            ],
+        ];
+        $this->assertEquals($expected, $return);
     }
 
     public function testPrintStatusMethodWithDownMigrations()
@@ -478,12 +541,19 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => true], $return);
-
-        rewind($this->manager->getOutput()->getStream());
-        $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertStringContainsString('up  20120111235330  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration', $outputStr);
-        $this->assertStringContainsString('down  20120116183504                                            TestMigration2', $outputStr);
+        $expected = [
+            [
+              'status' => 'up',
+              'id' => 20120111235330,
+              'name' => 'TestMigration',
+            ],
+            [
+              'status' => 'down',
+              'id' => 20120116183504,
+              'name' => 'TestMigration2',
+            ],
+        ];
+        $this->assertEquals($expected, $return);
     }
 
     public function testPrintStatusMethodWithMissingAndDownMigrations()
@@ -523,94 +593,31 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironments(['mockenv' => $envStub]);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(['hasMissingMigration' => true, 'hasDownMigration' => true], $return);
-
-        rewind($this->manager->getOutput()->getStream());
-        $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-
-        // note that the order is important: missing migrations should appear before down migrations (and in the right
-        // place with regard to other up non-missing migrations)
-        $this->assertMatchesRegularExpression('/\s*up  20120103083300  2012-01-11 23:53:36  2012-01-11 23:53:37  *\*\* MISSING MIGRATION FILE \*\*' . PHP_EOL .
-            '\s*up  20120111235330  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration' . PHP_EOL .
-            '\s*down  20120116183504                                            TestMigration2/', $outputStr);
-    }
-
-    /**
-     * Test that ensures the status header is correctly printed with regards to the version order
-     *
-     * @dataProvider statusVersionOrderProvider
-     * @param Config $config Config to use for the test
-     * @param string $expectedStatusHeader expected header string
-     */
-    public function testPrintStatusMethodVersionOrderHeader($config, $expectedStatusHeader)
-    {
-        // stub environment
-        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
-            ->setConstructorArgs(['mockenv', []])
-            ->getMock();
-        $envStub->expects($this->once())
-                ->method('getVersionLog')
-                ->will($this->returnValue([]));
-
-        $output = new RawBufferedOutput();
-        $this->manager = new Manager($config, $this->input, $output);
-
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
-        $return = $this->manager->printStatus('mockenv');
-        $this->assertEquals(['hasMissingMigration' => false, 'hasDownMigration' => true], $return);
-
-        $outputStr = $this->manager->getOutput()->fetch();
-        $this->assertStringContainsString($expectedStatusHeader, $outputStr);
-    }
-
-    public static function statusVersionOrderProvider(): array
-    {
-        // create the necessary configuration objects
-        $configArray = static::getConfigArray();
-
-        $configWithNoVersionOrder = new Config($configArray);
-
-        $configArray['version_order'] = Config::VERSION_ORDER_CREATION_TIME;
-        $configWithCreationVersionOrder = new Config($configArray);
-
-        $configArray['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
-        $configWithExecutionVersionOrder = new Config($configArray);
-
-        return [
-            'With the default version order' => [
-                $configWithNoVersionOrder,
-                ' Status  <info>[Migration ID]</info>  Started              Finished             Migration Name ',
+        $expected = [
+            [
+              'missing' => true,
+              'status' => 'up',
+              'id' => '20120103083300',
+              'name' => '',
             ],
-            'With the creation version order' => [
-                $configWithCreationVersionOrder,
-                ' Status  <info>[Migration ID]</info>  Started              Finished             Migration Name ',
+            [
+              'status' => 'up',
+              'id' => 20120111235330,
+              'name' => 'TestMigration',
             ],
-            'With the execution version order' => [
-                $configWithExecutionVersionOrder,
-                ' Status  Migration ID    <info>[Started          ]</info>  Finished             Migration Name ',
+            [
+              'status' => 'down',
+              'id' => 20120116183504,
+              'name' => 'TestMigration2',
+            ],
+            [
+              'missing' => true,
+              'status' => 'up',
+              'id' => '20120815145812',
+              'name' => 'Example',
             ],
         ];
-    }
-
-    public function testPrintStatusInvalidVersionOrderKO()
-    {
-        // stub environment
-        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
-            ->setConstructorArgs(['mockenv', []])
-            ->getMock();
-
-        $configArray = $this->getConfigArray();
-        $configArray['version_order'] = 'invalid';
-        $config = new Config($configArray);
-
-        $this->manager = new Manager($config, $this->input, $this->output);
-
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Invalid version_order configuration option');
-
-        $this->manager->printStatus('mockenv');
+        $this->assertEquals($expected, $return);
     }
 
     public function testGetMigrationsWithDuplicateMigrationVersions()


### PR DESCRIPTION
I'm copying the code so that the migrations specific logic is retained. I hope this help with backwards compatibility and not breaking existing logic. While there are a few untested methods currently. They should get coverage as the integration tests are migrated.