### PR TITLE
Get Environment tests passing with migrations engine 

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,11 +16,6 @@ parameters:
 			path: src/Command/BakeMigrationSnapshotCommand.php
 
 		-
-			message: "#^Method Migrations\\\\Db\\\\Adapter\\\\AdapterFactory\\:\\:getAdapter\\(\\) should return Migrations\\\\Db\\\\Adapter\\\\AdapterInterface but returns object\\.$#"
-			count: 1
-			path: src/Db/Adapter/AdapterFactory.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Db/Adapter/AdapterFactory.php
@@ -74,16 +69,6 @@ parameters:
 			message: "#^Ternary operator condition is always true\\.$#"
 			count: 2
 			path: src/Db/Adapter/SqlserverAdapter.php
-
-		-
-			message: "#^Parameter \\#1 \\$adapter of method Phinx\\\\Migration\\\\MigrationInterface\\:\\:setAdapter\\(\\) expects Phinx\\\\Db\\\\Adapter\\\\AdapterInterface, Migrations\\\\Db\\\\Adapter\\\\AdapterInterface given\\.$#"
-			count: 2
-			path: src/Migration/Environment.php
-
-		-
-			message: "#^Parameter \\#1 \\$adapter of method Phinx\\\\Seed\\\\SeedInterface\\:\\:setAdapter\\(\\) expects Phinx\\\\Db\\\\Adapter\\\\AdapterInterface, Migrations\\\\Db\\\\Adapter\\\\AdapterInterface given\\.$#"
-			count: 1
-			path: src/Migration/Environment.php
 
 		-
 			message: "#^Possibly invalid array key type Cake\\\\Database\\\\Schema\\\\TableSchemaInterface\\|string\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -15,6 +15,11 @@
       <code><![CDATA[isset($this->output)]]></code>
     </RedundantPropertyInitializationCheck>
   </file>
+  <file src="src/Db/Adapter/AdapterFactory.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->adapters]]></code>
+    </PropertyTypeCoercion>
+  </file>
   <file src="src/Db/Adapter/AdapterWrapper.php">
     <DeprecatedMethod>
       <code>getQueryBuilder</code>
@@ -69,11 +74,6 @@
     </MissingParamType>
   </file>
   <file src="src/Migration/Environment.php">
-    <InvalidArgument>
-      <code><![CDATA[$this->getAdapter()]]></code>
-      <code><![CDATA[$this->getAdapter()]]></code>
-      <code><![CDATA[$this->getAdapter()]]></code>
-    </InvalidArgument>
     <RedundantPropertyInitializationCheck>
       <code><![CDATA[isset($this->adapter)]]></code>
     </RedundantPropertyInitializationCheck>

--- a/tests/TestCase/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/TestCase/Db/Adapter/AdapterFactoryTest.php
@@ -33,7 +33,6 @@ class AdapterFactoryTest extends TestCase
 
     public function testRegisterAdapter()
     {
-
         $mock = $this->getMockForAbstractClass(PdoAdapter::class, [['foo' => 'bar']]);
         $this->factory->registerAdapter('test', function (array $options) use ($mock) {
             $this->assertEquals('value', $options['key']);

--- a/tests/TestCase/Migration/EnvironmentTest.php
+++ b/tests/TestCase/Migration/EnvironmentTest.php
@@ -3,15 +3,11 @@ declare(strict_types=1);
 
 namespace Test\Phinx\Migration;
 
-use Migrations\Db\Adapter\AdapterFactory;
 use Migrations\Db\Adapter\PdoAdapter;
-use Migrations\Db\Adapter\PhinxAdapter;
 use Migrations\Migration\Environment;
-use PDO;
 use Phinx\Migration\AbstractMigration;
 use Phinx\Migration\MigrationInterface;
 use Phinx\Seed\AbstractSeed;
-use Phinx\Seed\SeedInterface;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;


### PR DESCRIPTION
Using the PhinxAdapter we can maintain compatibility with existing Migrations, and have an API solution for both now as we transition onto the migrations engine and after phinx is removed, the API doesn't change much just the namespaces change.