### PR TITLE
Add config switch for backend selection.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
+  <file src="src/Command/MigrationsCommand.php">
+    <DeprecatedClass>
+      <code>MigrationsDispatcher</code>
+      <code>MigrationsDispatcher::getCommands()</code>
+      <code>MigrationsDispatcher::getCommands()</code>
+      <code>\Migrations\MigrationsDispatcher</code>
+      <code>new MigrationsDispatcher(PHINX_VERSION)</code>
+    </DeprecatedClass>
+  </file>
   <file src="src/Command/Phinx/Create.php">
     <PossiblyUndefinedArrayOffset>
       <code>$phinxName</code>

--- a/src/Command/MigrationsCommand.php
+++ b/src/Command/MigrationsCommand.php
@@ -51,9 +51,9 @@ class MigrationsCommand extends Command
         if (parent::defaultName() === 'migrations') {
             return 'migrations';
         }
-        // TODO this will need to be patched.
-        $command = new MigrationsDispatcher::$phinxCommands[static::$commandName]();
-        $name = $command->getName();
+        $className = MigrationsDispatcher::getCommands()[static::$commandName];
+        $command = new $className();
+        $name = (string)$command->getName();
 
         return 'migrations ' . $name;
     }
@@ -78,8 +78,8 @@ class MigrationsCommand extends Command
             return parent::getOptionParser();
         }
         $parser = parent::getOptionParser();
-        // Use new methods
-        $command = new MigrationsDispatcher::$phinxCommands[static::$commandName]();
+        $className = MigrationsDispatcher::getCommands()[static::$commandName];
+        $command = new $className();
 
         // Skip conversions for new commands.
         $parser->setDescription($command->getDescription());

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -29,6 +29,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * The Migrations class is responsible for handling migrations command
  * within an none-shell application.
+ *
+ * TODO(mark) This needs to be adapted to use the configure backend selection.
  */
 class Migrations
 {

--- a/src/MigrationsDispatcher.php
+++ b/src/MigrationsDispatcher.php
@@ -19,26 +19,31 @@ use Symfony\Component\Console\Application;
 /**
  * Used to register all supported subcommand in order to make
  * them executable by the Symfony Console component
+ *
+ * @deprecated 4.2.0 Will be removed alongsize phinx
  */
 class MigrationsDispatcher extends Application
 {
     /**
-     * TODO convert this to a method so that config can be used.
+     * Get the map of command names to phinx commands.
      *
-     * @var array<string, string>
-     * @psalm-var array<string, class-string<\Phinx\Console\Command\AbstractCommand>|class-string<\Migrations\Command\Phinx\BaseCommand>>
+     * @return array<string, string>
+     * @psalm-return array<string, class-string<\Phinx\Console\Command\AbstractCommand>|class-string<\Migrations\Command\Phinx\BaseCommand>>
      */
-    public static array $phinxCommands = [
-        'Create' => Phinx\Create::class,
-        'Dump' => Phinx\Dump::class,
-        'MarkMigrated' => Phinx\MarkMigrated::class,
-        'Migrate' => Phinx\Migrate::class,
-        'Rollback' => Phinx\Rollback::class,
-        'Seed' => Phinx\Seed::class,
-        'Status' => Phinx\Status::class,
-        'CacheBuild' => Phinx\CacheBuild::class,
-        'CacheClear' => Phinx\CacheClear::class,
-    ];
+    public static function getCommands(): array
+    {
+        return [
+            'Create' => Phinx\Create::class,
+            'Dump' => Phinx\Dump::class,
+            'MarkMigrated' => Phinx\MarkMigrated::class,
+            'Migrate' => Phinx\Migrate::class,
+            'Rollback' => Phinx\Rollback::class,
+            'Seed' => Phinx\Seed::class,
+            'Status' => Phinx\Status::class,
+            'CacheBuild' => Phinx\CacheBuild::class,
+            'CacheClear' => Phinx\CacheClear::class,
+        ];
+    }
 
     /**
      * Initialize the Phinx console application.
@@ -49,7 +54,7 @@ class MigrationsDispatcher extends Application
     {
         parent::__construct('Migrations plugin, based on Phinx by Rob Morgan.', $version);
         // Update this to use the methods
-        foreach (static::$phinxCommands as $value) {
+        foreach ($this->getCommands() as $value) {
             $this->add(new $value());
         }
         $this->setCatchExceptions(false);

--- a/src/MigrationsPlugin.php
+++ b/src/MigrationsPlugin.php
@@ -16,6 +16,8 @@ namespace Migrations;
 use Bake\Command\SimpleBakeCommand;
 use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
+use Cake\Core\Configure;
+use Cake\Core\PluginApplicationInterface;
 use Migrations\Command\MigrationsCacheBuildCommand;
 use Migrations\Command\MigrationsCacheClearCommand;
 use Migrations\Command\MigrationsCommand;
@@ -58,6 +60,21 @@ class MigrationsPlugin extends BasePlugin
         MigrationsSeedCommand::class,
         MigrationsStatusCommand::class,
     ];
+
+    /**
+     * Initialize configuration with defaults.
+     *
+     * @param \Cake\Core\PluginApplicationInterface $app The application.
+     * @return void
+     */
+    public function bootstrap(PluginApplicationInterface $app): void
+    {
+        parent::bootstrap($app);
+
+        if (!Configure::check('Migrations.backend')) {
+            Configure::write('Migrations.backend', 'phinx');
+        }
+    }
 
     /**
      * Add migrations commands.


### PR DESCRIPTION
Replace a clunky static variable with a method and deprecate the class. I was considering using this to splice in the new commands, but after thinking some more, it would be easier to replace the commands entirely.

Refs #647 