### PR TITLE
Trim down Config and Manager classes to remove unused behavior

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
          colors="true"
          cacheDirectory=".phpunit.cache"
          bootstrap="tests/bootstrap.php"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
 >
     <testsuites>
         <testsuite name="migrations">
@@ -34,7 +34,6 @@
     <php>
         <env name="FIXTURE_SCHEMA_METADATA" value="./tests/schema.php"/>
         <ini name="memory_limit" value="-1"/>
-        <ini name="apc.enable_cli" value="1"/>
 
         <!-- SQLite
         <env name="DB" value="sqlite"/>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -50,22 +50,6 @@
       <code>ConfigurationTrait</code>
     </DeprecatedTrait>
   </file>
-  <file src="src/Config/Config.php">
-    <DeprecatedMethod>
-      <code>getEnvironments</code>
-      <code>getEnvironments</code>
-      <code>hasEnvironment</code>
-      <code>hasEnvironment</code>
-      <code>searchNamespace</code>
-      <code>searchNamespace</code>
-    </DeprecatedMethod>
-    <LessSpecificImplementedReturnType>
-      <code>array</code>
-      <code>array</code>
-      <code>array</code>
-      <code>array</code>
-    </LessSpecificImplementedReturnType>
-  </file>
   <file src="src/Config/ConfigInterface.php">
     <MissingTemplateParam>
       <code>ArrayAccess</code>
@@ -143,12 +127,6 @@
     <ArgumentTypeCoercion>
       <code>array_merge($versions, array_keys($migrations))</code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod>
-      <code>getDataDomain</code>
-      <code>getMigrationNamespaceByPath</code>
-      <code>getSeedNamespaceByPath</code>
-      <code>hasEnvironment</code>
-    </DeprecatedMethod>
     <RedundantPropertyInitializationCheck>
       <code><![CDATA[isset($this->container)]]></code>
     </RedundantPropertyInitializationCheck>

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -136,6 +136,7 @@ class StatusCommand extends Command
             'pass' => $connectionConfig['password'],
             'host' => $connectionConfig['host'],
             'name' => $connectionConfig['database'],
+            'migration_table' => $table,
         ];
 
         $configData = [
@@ -146,10 +147,8 @@ class StatusCommand extends Command
                 'file' => $templatePath . 'Phinx/create.php.template',
             ],
             'migration_base_class' => 'Migrations\AbstractMigration',
-            'environments' => [
-                'default_migration_table' => $table,
-                'default' => $adapterConfig,
-            ],
+            'connection' => ConnectionManager::get($connectionName),
+            'environment' => $adapterConfig,
             // TODO do we want to support the DI container in migrations?
         ];
 
@@ -180,7 +179,7 @@ class StatusCommand extends Command
     {
         /** @var string|null $format */
         $format = $args->getOption('format');
-        $migrations = $this->getManager($args)->printStatus('default', $format);
+        $migrations = $this->getManager($args)->printStatus($format);
 
         switch ($format) {
             case 'json':

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -10,19 +10,16 @@ namespace Migrations\Config;
 
 use Closure;
 use InvalidArgumentException;
-use Phinx\Config\ConfigInterface as PhinxConfigInterface;
 use Phinx\Db\Adapter\SQLiteAdapter;
-use Phinx\Util\Util;
 use Psr\Container\ContainerInterface;
 use ReturnTypeWillChange;
 use RuntimeException;
-use Symfony\Component\Yaml\Yaml;
 use UnexpectedValueException;
 
 /**
- * Phinx configuration class.
+ * Migrations configuration class.
  */
-class Config implements ConfigInterface, PhinxConfigInterface
+class Config implements ConfigInterface
 {
     /**
      * The value that identifies a version order by creation time.
@@ -54,90 +51,7 @@ class Config implements ConfigInterface, PhinxConfigInterface
     public function __construct(array $configArray, ?string $configFilePath = null)
     {
         $this->configFilePath = $configFilePath;
-        $this->values = $this->replaceTokens($configArray);
-    }
-
-    /**
-     * Create a new instance of the config class using a Yaml file path.
-     *
-     * @param string $configFilePath Path to the Yaml File
-     * @throws \RuntimeException
-     * @return \Migrations\Config\ConfigInterface
-     * @deprecated 4.2 To be removed in 5.x
-     */
-    public static function fromYaml(string $configFilePath): ConfigInterface
-    {
-        if (!class_exists('Symfony\\Component\\Yaml\\Yaml', true)) {
-            // @codeCoverageIgnoreStart
-            throw new RuntimeException('Missing yaml parser, symfony/yaml package is not installed.');
-            // @codeCoverageIgnoreEnd
-        }
-
-        $configFile = file_get_contents($configFilePath);
-        $configArray = Yaml::parse($configFile);
-
-        if (!is_array($configArray)) {
-            throw new RuntimeException(sprintf(
-                'File \'%s\' must be valid YAML',
-                $configFilePath
-            ));
-        }
-
-        return new Config($configArray, $configFilePath);
-    }
-
-    /**
-     * Create a new instance of the config class using a JSON file path.
-     *
-     * @param string $configFilePath Path to the JSON File
-     * @throws \RuntimeException
-     * @return \Migrations\Config\ConfigInterface
-     * @deprecated 4.2 To be removed in 5.x
-     */
-    public static function fromJson(string $configFilePath): ConfigInterface
-    {
-        if (!function_exists('json_decode')) {
-            // @codeCoverageIgnoreStart
-            throw new RuntimeException('Need to install JSON PHP extension to use JSON config');
-            // @codeCoverageIgnoreEnd
-        }
-
-        $configArray = json_decode((string)file_get_contents($configFilePath), true);
-        if (!is_array($configArray)) {
-            throw new RuntimeException(sprintf(
-                'File \'%s\' must be valid JSON',
-                $configFilePath
-            ));
-        }
-
-        return new Config($configArray, $configFilePath);
-    }
-
-    /**
-     * Create a new instance of the config class using a PHP file path.
-     *
-     * @param string $configFilePath Path to the PHP File
-     * @throws \RuntimeException
-     * @return \Migrations\Config\ConfigInterface
-     * @deprecated 4.2 To be removed in 5.x
-     */
-    public static function fromPhp(string $configFilePath): ConfigInterface
-    {
-        ob_start();
-        /** @noinspection PhpIncludeInspection */
-        $configArray = include $configFilePath;
-
-        // Hide console output
-        ob_end_clean();
-
-        if (!is_array($configArray)) {
-            throw new RuntimeException(sprintf(
-                'PHP file \'%s\' must return an array',
-                $configFilePath
-            ));
-        }
-
-        return new Config($configArray, $configFilePath);
+        $this->values = $configArray;
     }
 
     /**
@@ -184,7 +98,7 @@ class Config implements ConfigInterface, PhinxConfigInterface
                 $environments[$name]['name'] = SQLiteAdapter::MEMORY;
             }
 
-            return $this->parseAgnosticDsn($environments[$name]);
+            return $environments[$name];
         }
 
         return null;
@@ -359,19 +273,6 @@ class Config implements ConfigInterface, PhinxConfigInterface
     }
 
     /**
-     * @inheritdoc
-     * @deprecated 4.2 To be removed in 5.x
-     */
-    public function getDataDomain(): array
-    {
-        if (!isset($this->values['data_domain'])) {
-            return [];
-        }
-
-        return $this->values['data_domain'];
-    }
-
-    /**
      * @inheritDoc
      */
     public function getContainer(): ?ContainerInterface
@@ -403,95 +304,6 @@ class Config implements ConfigInterface, PhinxConfigInterface
         $versionOrder = $this->getVersionOrder();
 
         return $versionOrder == self::VERSION_ORDER_CREATION_TIME;
-    }
-
-    /**
-     * @inheritdoc
-     * @deprecated 4.2 To be removed in 5.x
-     */
-    public function getBootstrapFile(): string|false
-    {
-        if (!isset($this->values['paths']['bootstrap'])) {
-            return false;
-        }
-
-        return $this->values['paths']['bootstrap'];
-    }
-
-    /**
-     * Replace tokens in the specified array.
-     *
-     * @param array<string, mixed> $arr Array to replace
-     * @return array<string, mixed>
-     */
-    protected function replaceTokens(array $arr): array
-    {
-        // Get environment variables
-        // Depending on configuration of server / OS and variables_order directive,
-        // environment variables either end up in $_SERVER (most likely) or $_ENV,
-        // so we search through both
-
-        /** @var array<string, string|null> $tokens */
-        $tokens = [];
-        foreach (array_merge($_ENV, $_SERVER) as $varname => $varvalue) {
-            if (strpos($varname, 'PHINX_') === 0) {
-                $tokens['%%' . $varname . '%%'] = $varvalue;
-            }
-        }
-
-        // Phinx defined tokens (override env tokens)
-        $tokens['%%PHINX_CONFIG_PATH%%'] = $this->getConfigFilePath();
-        $tokens['%%PHINX_CONFIG_DIR%%'] = $this->getConfigFilePath() !== null ? dirname((string)$this->getConfigFilePath()) : '';
-
-        // Recurse the array and replace tokens
-        return $this->recurseArrayForTokens($arr, $tokens);
-    }
-
-    /**
-     * Recurse an array for the specified tokens and replace them.
-     *
-     * @param array $arr Array to recurse
-     * @param array<string, string|null> $tokens Array of tokens to search for
-     * @return array<string, mixed>
-     */
-    protected function recurseArrayForTokens(array $arr, array $tokens): array
-    {
-        /** @var array<string, mixed> $out */
-        $out = [];
-        foreach ($arr as $name => $value) {
-            if (is_array($value)) {
-                $out[$name] = $this->recurseArrayForTokens($value, $tokens);
-                continue;
-            }
-            if (is_string($value)) {
-                foreach ($tokens as $token => $tval) {
-                    $value = str_replace($token, $tval ?? '', $value);
-                }
-                $out[$name] = $value;
-                continue;
-            }
-            $out[$name] = $value;
-        }
-
-        return $out;
-    }
-
-    /**
-     * Parse a database-agnostic DSN into individual options.
-     *
-     * @param array<string, mixed> $options Options
-     * @return array<string, mixed>
-     */
-    protected function parseAgnosticDsn(array $options): array
-    {
-        $parsed = Util::parseDsn($options['dsn'] ?? '');
-        if ($parsed) {
-            unset($options['dsn']);
-        }
-
-        $options += $parsed;
-
-        return $options;
     }
 
     /**
@@ -551,51 +363,5 @@ class Config implements ConfigInterface, PhinxConfigInterface
     public function getSeedTemplateFile(): ?string
     {
         return $this->values['templates']['seedFile'] ?? null;
-    }
-
-    /**
-     * Search $needle in $haystack and return key associate with him.
-     *
-     * @param string $needle Needle
-     * @param string[] $haystack Haystack
-     * @return string|null
-     * @deprecated 4.2 To be removed in 5.x
-     */
-    protected function searchNamespace(string $needle, array $haystack): ?string
-    {
-        $needle = realpath($needle);
-        $haystack = array_map('realpath', $haystack);
-
-        $key = array_search($needle, $haystack, true);
-
-        return is_string($key) ? trim($key, '\\') : null;
-    }
-
-    /**
-     * Get Migration Namespace associated with path.
-     *
-     * @param string $path Path
-     * @return string|null
-     * @deprecated 4.2 To be removed in 5.x
-     */
-    public function getMigrationNamespaceByPath(string $path): ?string
-    {
-        $paths = $this->getMigrationPaths();
-
-        return $this->searchNamespace($path, $paths);
-    }
-
-    /**
-     * Get Seed Namespace associated with path.
-     *
-     * @param string $path Path
-     * @return string|null
-     * @deprecated 4.2 To be removed in 5.x
-     */
-    public function getSeedNamespaceByPath(string $path): ?string
-    {
-        $paths = $this->getSeedPaths();
-
-        return $this->searchNamespace($path, $paths);
     }
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -10,10 +10,8 @@ namespace Migrations\Config;
 
 use Closure;
 use InvalidArgumentException;
-use Phinx\Db\Adapter\SQLiteAdapter;
 use Psr\Container\ContainerInterface;
 use ReturnTypeWillChange;
-use RuntimeException;
 use UnexpectedValueException;
 
 /**
@@ -40,146 +38,20 @@ class Config implements ConfigInterface
     protected array $values = [];
 
     /**
-     * @var string|null
-     */
-    protected ?string $configFilePath = null;
-
-    /**
      * @param array $configArray Config array
-     * @param string|null $configFilePath Config file path
      */
-    public function __construct(array $configArray, ?string $configFilePath = null)
+    public function __construct(array $configArray)
     {
-        $this->configFilePath = $configFilePath;
         $this->values = $configArray;
     }
 
     /**
      * @inheritDoc
-     * @deprecated 4.2 To be removed in 5.x
      */
-    public function getEnvironments(): ?array
+    public function getEnvironment(): ?array
     {
-        if (isset($this->values['environments'])) {
-            $environments = [];
-            foreach ($this->values['environments'] as $key => $value) {
-                if (is_array($value)) {
-                    $environments[$key] = $value;
-                }
-            }
-
-            return $environments;
-        }
-
-        return null;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getEnvironment(string $name): ?array
-    {
-        $environments = $this->getEnvironments();
-
-        if (isset($environments[$name])) {
-            if (
-                isset($this->values['environments']['default_migration_table'])
-                && !isset($environments[$name]['migration_table'])
-            ) {
-                $environments[$name]['migration_table'] =
-                    $this->values['environments']['default_migration_table'];
-            }
-
-            if (
-                isset($environments[$name]['adapter'])
-                && $environments[$name]['adapter'] === 'sqlite'
-                && !empty($environments[$name]['memory'])
-            ) {
-                $environments[$name]['name'] = SQLiteAdapter::MEMORY;
-            }
-
-            return $environments[$name];
-        }
-
-        return null;
-    }
-
-    /**
-     * @inheritDoc
-     * @deprecated 4.2 To be removed in 5.x
-     */
-    public function hasEnvironment(string $name): bool
-    {
-        return $this->getEnvironment($name) !== null;
-    }
-
-    /**
-     * @inheritDoc
-     * @deprecated 4.2 To be removed in 5.x
-     */
-    public function getDefaultEnvironment(): string
-    {
-        // The $PHINX_ENVIRONMENT variable overrides all other default settings
-        $env = getenv('PHINX_ENVIRONMENT');
-        if (!empty($env)) {
-            if ($this->hasEnvironment($env)) {
-                return $env;
-            }
-
-            throw new RuntimeException(sprintf(
-                'The environment configuration (read from $PHINX_ENVIRONMENT) for \'%s\' is missing',
-                $env
-            ));
-        }
-
-        // if the user has configured a default environment then use it,
-        // providing it actually exists!
-        if (isset($this->values['environments']['default_environment'])) {
-            if ($this->hasEnvironment($this->values['environments']['default_environment'])) {
-                return $this->values['environments']['default_environment'];
-            }
-
-            throw new RuntimeException(sprintf(
-                'The environment configuration for \'%s\' is missing',
-                (string)$this->values['environments']['default_environment']
-            ));
-        }
-
-        // else default to the first available one
-        $environments = $this->getEnvironments();
-        if (is_array($environments) && count($environments) > 0) {
-            $names = array_keys($environments);
-
-            return $names[0];
-        }
-
-        throw new RuntimeException('Could not find a default environment');
-    }
-
-    /**
-     * @inheritDoc
-     * @deprecated 4.2 To be removed in 5.x
-     */
-    public function getAlias($alias): ?string
-    {
-        return !empty($this->values['aliases'][$alias]) ? $this->values['aliases'][$alias] : null;
-    }
-
-    /**
-     * @inheritDoc
-     * @deprecated 4.2 To be removed in 5.x
-     */
-    public function getAliases(): array
-    {
-        return !empty($this->values['aliases']) ? $this->values['aliases'] : [];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getConfigFilePath(): ?string
-    {
-        return $this->configFilePath;
+        // TODO evolve this into connection only.
+        return $this->values['environment'] ?? null;
     }
 
     /**

--- a/src/Config/ConfigInterface.php
+++ b/src/Config/ConfigInterface.php
@@ -19,22 +19,14 @@ use Psr\Container\ContainerInterface;
 interface ConfigInterface extends ArrayAccess
 {
     /**
-     * Returns the configuration for a given environment.
+     * Returns the configuration for the current environment.
      *
      * This method returns <code>null</code> if the specified environment
      * doesn't exist.
      *
-     * @param string $name Environment Name
      * @return array|null
      */
-    public function getEnvironment(string $name): ?array;
-
-    /**
-     * Gets the config file path.
-     *
-     * @return string|null
-     */
-    public function getConfigFilePath(): ?string;
+    public function getEnvironment(): ?array;
 
     /**
      * Gets the paths to search for migration files.

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -11,7 +11,6 @@ namespace Migrations\Migration;
 use DateTime;
 use Exception;
 use InvalidArgumentException;
-use Migrations\Config\Config;
 use Migrations\Config\ConfigInterface;
 use Phinx\Migration\AbstractMigration;
 use Phinx\Migration\MigrationInterface;
@@ -45,9 +44,9 @@ class Manager
     protected OutputInterface $output;
 
     /**
-     * @var \Migrations\Migration\Environment[]
+     * @var \Migrations\Migration\Environment|null
      */
-    protected array $environments = [];
+    protected ?Environment $environment;
 
     /**
      * @var \Phinx\Migration\MigrationInterface[]|null
@@ -91,6 +90,7 @@ class Manager
      */
     public function printStatus(string $environment, ?string $format = null): array
     {
+        // TODO remove the environment parameter. There is only one environment with builtin
         $migrations = [];
         $isJson = $format === 'json';
         $defaultMigrations = $this->getMigrations('default');
@@ -173,6 +173,7 @@ class Manager
      */
     public function migrateToDateTime(string $environment, DateTime $dateTime, bool $fake = false): void
     {
+        // TODO remove the environment parameter. There is only one environment with builtin
         /** @var array<int> $versions */
         $versions = array_keys($this->getMigrations('default'));
         $dateString = $dateTime->format('Ymdhis');
@@ -202,6 +203,7 @@ class Manager
      */
     public function rollbackToDateTime(string $environment, DateTime $dateTime, bool $force = false): void
     {
+        // TODO remove the environment parameter. There is only one environment with builtin
         $env = $this->getEnvironment($environment);
         $versions = $env->getVersions();
         $dateString = $dateTime->format('Ymdhis');
@@ -242,6 +244,7 @@ class Manager
      */
     public function isMigrated(int $version): bool
     {
+        // TODO remove the environment parameter. There is only one environment with builtin
         $adapter = $this->getEnvironment('default')->getAdapter();
         /** @var array<int, mixed> $versions */
         $versions = array_flip($adapter->getVersions());
@@ -258,6 +261,7 @@ class Manager
      */
     public function markMigrated(int $version, string $path): bool
     {
+        // TODO remove the environment parameter. There is only one environment with builtin
         $adapter = $this->getEnvironment('default')->getAdapter();
 
         $migrationFile = glob($path . DS . $version . '*');
@@ -402,6 +406,7 @@ class Manager
      */
     public function migrate(string $environment, ?int $version = null, bool $fake = false): void
     {
+        // TODO remove the environment parameter. There is only one environment with builtin
         $migrations = $this->getMigrations($environment);
         $env = $this->getEnvironment($environment);
         $versions = $env->getVersions();
@@ -464,6 +469,7 @@ class Manager
      */
     public function executeMigration(string $name, MigrationInterface $migration, string $direction = MigrationInterface::UP, bool $fake = false): void
     {
+        // TODO remove the environment parameter. There is only one environment with builtin
         $this->getOutput()->writeln('', $this->verbosityLevel);
 
         // Skip the migration if it should not be executed
@@ -583,6 +589,8 @@ class Manager
      */
     public function rollback(string $environment, int|string|null $target = null, bool $force = false, bool $targetMustMatchVersion = true, bool $fake = false): void
     {
+        // TODO remove the environment parameter. There is only one environment with builtin
+
         // note that the migrations are indexed by name (aka creation time) in ascending order
         $migrations = $this->getMigrations($environment);
 
@@ -695,6 +703,7 @@ class Manager
      */
     public function seed(string $environment, ?string $seed = null): void
     {
+        // TODO remove the environment parameter. There is only one environment with builtin
         $seeds = $this->getSeeds($environment);
 
         if ($seed === null) {
@@ -715,50 +724,41 @@ class Manager
     }
 
     /**
-     * Sets the environments.
-     *
-     * @param \Migrations\Migration\Environment[] $environments Environments
-     * @return $this
-     */
-    public function setEnvironments(array $environments = [])
-    {
-        $this->environments = $environments;
-
-        return $this;
-    }
-
-    /**
      * Gets the manager class for the given environment.
      *
-     * @param string $name Environment Name
      * @throws \InvalidArgumentException
      * @return \Migrations\Migration\Environment
      */
-    public function getEnvironment(string $name): Environment
+    public function getEnvironment(): Environment
     {
-        if (isset($this->environments[$name])) {
-            return $this->environments[$name];
+        if (isset($this->environment)) {
+            return $this->environment;
         }
 
         $config = $this->getConfig();
-        // check the environment exists
-        if ($config instanceof Config && !$config->hasEnvironment($name)) {
-            throw new InvalidArgumentException(sprintf(
-                'The environment "%s" does not exist',
-                $name
-            ));
-        }
-
         // create an environment instance and cache it
-        $envOptions = $config->getEnvironment($name);
+        $envOptions = $config->getEnvironment();
         $envOptions['version_order'] = $config->getVersionOrder();
 
-        $environment = new Environment($name, $envOptions);
-        $this->environments[$name] = $environment;
+        $environment = new Environment('default', $envOptions);
         $environment->setInput($this->getInput());
         $environment->setOutput($this->getOutput());
+        $this->environment = $environment;
 
         return $environment;
+    }
+
+    /**
+     * Replace the environment
+     *
+     * @param \Migrations\Migration\Environment $environment
+     * @return $this
+     */
+    public function setEnvironment(Environment $environment)
+    {
+        $this->environment = $environment;
+
+        return $this;
     }
 
     /**
@@ -843,6 +843,7 @@ class Manager
      */
     public function getMigrations(string $environment): array
     {
+        // TODO remove the environment parameter. There is only one environment with builtin
         if ($this->migrations === null) {
             $phpFiles = $this->getMigrationFiles();
 
@@ -1127,6 +1128,7 @@ class Manager
      */
     public function toggleBreakpoint(string $environment, ?int $version): void
     {
+        // TODO remove the environment parameter. There is only one environment with builtin
         $this->markBreakpoint($environment, $version, self::BREAKPOINT_TOGGLE);
     }
 
@@ -1140,6 +1142,7 @@ class Manager
      */
     protected function markBreakpoint(string $environment, ?int $version, int $mark): void
     {
+        // TODO remove the environment parameter. There is only one environment with builtin
         $migrations = $this->getMigrations($environment);
         $env = $this->getEnvironment($environment);
         $versions = $env->getVersionLog();

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -1005,8 +1005,6 @@ class Manager
 
             foreach ($phpFiles as $filePath) {
                 if (Util::isValidSeedFileName(basename($filePath))) {
-                    $config = $this->getConfig();
-
                     // convert the filename to a class name
                     $class = pathinfo($filePath, PATHINFO_FILENAME);
                     $fileNames[$class] = basename($filePath);

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -837,13 +837,11 @@ class Manager
      * Gets an array of the database migrations, indexed by migration name (aka creation time) and sorted in ascending
      * order
      *
-     * @param string $environment Environment
      * @throws \InvalidArgumentException
      * @return \Phinx\Migration\MigrationInterface[]
      */
-    public function getMigrations(string $environment): array
+    public function getMigrations(): array
     {
-        // TODO remove the environment parameter. There is only one environment with builtin
         if ($this->migrations === null) {
             $phpFiles = $this->getMigrationFiles();
 
@@ -912,7 +910,7 @@ class Manager
                     }
 
                     // instantiate it
-                    $migration = new $class($environment, $version, $this->getInput(), $this->getOutput());
+                    $migration = new $class('default', $version, $this->getInput(), $this->getOutput());
 
                     if (!($migration instanceof AbstractMigration)) {
                         throw new InvalidArgumentException(sprintf(

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -164,7 +164,6 @@ class Manager
     /**
      * Migrate to the version of the database on a given date.
      *
-     * @param string $environment Environment
      * @param \DateTime $dateTime Date to migrate to
      * @param bool $fake flag that if true, we just record running the migration, but not actually do the
      *                               migration
@@ -312,7 +311,7 @@ class Manager
      */
     public function getVersionsToMark(InputInterface $input): array
     {
-        $migrations = $this->getMigrations('default');
+        $migrations = $this->getMigrations();
         $versions = array_keys($migrations);
 
         $versionArg = $input->getArgument('version');
@@ -1116,7 +1115,6 @@ class Manager
     /**
      * Updates the breakpoint for a specific version.
      *
-     * @param string $environment The required environment
      * @param int|null $version The version of the target migration
      * @param int $mark The state of the breakpoint as defined by self::BREAKPOINT_xxxx constants.
      * @return void

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -752,9 +752,6 @@ class Manager
         // create an environment instance and cache it
         $envOptions = $config->getEnvironment($name);
         $envOptions['version_order'] = $config->getVersionOrder();
-        if ($config instanceof Config) {
-            $envOptions['data_domain'] = $config->getDataDomain();
-        }
 
         $environment = new Environment($name, $envOptions);
         $this->environments[$name] = $environment;
@@ -878,14 +875,8 @@ class Manager
                         throw new InvalidArgumentException(sprintf('Duplicate migration - "%s" has the same version as "%s"', $filePath, $versions[$version]->getVersion()));
                     }
 
-                    $config = $this->getConfig();
-                    $namespace = null;
-                    if ($config instanceof Config) {
-                        $namespace = $config->getMigrationNamespaceByPath(dirname($filePath));
-                    }
-
                     // convert the filename to a class name
-                    $class = ($namespace === null ? '' : $namespace . '\\') . Util::mapFileNameToClassName(basename($filePath));
+                    $class = Util::mapFileNameToClassName(basename($filePath));
 
                     if (isset($fileNames[$class])) {
                         throw new InvalidArgumentException(sprintf(
@@ -1031,13 +1022,9 @@ class Manager
             foreach ($phpFiles as $filePath) {
                 if (Util::isValidSeedFileName(basename($filePath))) {
                     $config = $this->getConfig();
-                    $namespace = null;
-                    if ($config instanceof Config) {
-                        $namespace = $config->getSeedNamespaceByPath(dirname($filePath));
-                    }
 
                     // convert the filename to a class name
-                    $class = ($namespace === null ? '' : $namespace . '\\') . pathinfo($filePath, PATHINFO_FILENAME);
+                    $class = pathinfo($filePath, PATHINFO_FILENAME);
                     $fileNames[$class] = basename($filePath);
 
                     // load the seed file
@@ -1058,6 +1045,7 @@ class Manager
                     } else {
                         $seed = new $class();
                     }
+                    // TODO might need a migrations -> phinx shim here for Environment
                     $seed->setEnvironment($environment);
                     $input = $this->getInput();
                     $seed->setInput($input);

--- a/tests/TestCase/Config/AbstractConfigTestCase.php
+++ b/tests/TestCase/Config/AbstractConfigTestCase.php
@@ -29,6 +29,17 @@ abstract class AbstractConfigTestCase extends TestCase
      */
     public function getConfigArray()
     {
+        /** @var array<string, string> $connectionConfig */
+        $connectionConfig = ConnectionManager::getConfig('test');
+        $adapter = [
+            'migration_table' => 'phinxlog',
+            'adapter' => $connectionConfig['scheme'],
+            'user' => $connectionConfig['username'],
+            'pass' => $connectionConfig['password'],
+            'host' => $connectionConfig['host'],
+            'name' => $connectionConfig['database'],
+        ];
+
         return [
             'default' => [
                 'paths' => [
@@ -44,39 +55,30 @@ abstract class AbstractConfigTestCase extends TestCase
                 'file' => '%%PHINX_CONFIG_PATH%%/tpl/testtemplate.txt',
                 'class' => '%%PHINX_CONFIG_PATH%%/tpl/testtemplate.php',
             ],
-            'environments' => [
-                'default_migration_table' => 'phinxlog',
-                'default_environment' => 'testing',
-                'testing' => [
-                    'adapter' => 'sqllite',
-                    'wrapper' => 'testwrapper',
-                    'path' => '%%PHINX_CONFIG_PATH%%/testdb/test.db',
-                ],
-                'production' => [
-                    'adapter' => 'mysql',
-                ],
-            ],
-            'data_domain' => [
-                'phone_number' => [
-                    'type' => 'string',
-                    'null' => true,
-                    'length' => 15,
-                ],
-            ],
+            // TODO ideally we only need the connection and migration table name.
+            'environment' => $adapter,
         ];
     }
 
     public function getMigrationsConfigArray(): array
     {
+        /** @var array<string, string> $connectionConfig */
+        $connectionConfig = ConnectionManager::getConfig('test');
+        $adapter = [
+            'migration_table' => 'phinxlog',
+            'adapter' => $connectionConfig['scheme'],
+            'user' => $connectionConfig['username'],
+            'pass' => $connectionConfig['password'],
+            'host' => $connectionConfig['host'],
+            'name' => $connectionConfig['database'],
+        ];
+
         return [
             'paths' => [
                 'migrations' => $this->getMigrationPaths(),
                 'seeds' => $this->getSeedPaths(),
             ],
-            'environment' => [
-                'migration_table' => 'phinxlog',
-                'connection' => ConnectionManager::get('test'),
-            ],
+            'environment' => $adapter,
         ];
     }
 

--- a/tests/TestCase/Config/ConfigTest.php
+++ b/tests/TestCase/Config/ConfigTest.php
@@ -74,25 +74,6 @@ class ConfigTest extends AbstractConfigTestCase
     }
 
     /**
-     * @covers \Phinx\Config\Config::getDataDomain
-     */
-    public function testGetDataDomainMethod()
-    {
-        $config = new Config($this->getConfigArray());
-        $this->assertIsArray($config->getDataDomain());
-    }
-
-    /**
-     * @covers \Phinx\Config\Config::getDataDomain
-     */
-    public function testReturnsEmptyArrayWithEmptyDataDomain()
-    {
-        $config = new Config([]);
-        $this->assertIsArray($config->getDataDomain());
-        $this->assertCount(0, $config->getDataDomain());
-    }
-
-    /**
      * @covers \Phinx\Config\Config::getDefaultEnvironment
      */
     public function testGetDefaultEnvironmentUsingDatabaseKey()
@@ -303,36 +284,6 @@ class ConfigTest extends AbstractConfigTestCase
                 Config::VERSION_ORDER_EXECUTION_TIME, false,
             ],
         ];
-    }
-
-    public function testConfigReplacesEnvironmentTokens()
-    {
-        $_SERVER['PHINX_TEST_CONFIG_ADAPTER'] = 'sqlite';
-        $_SERVER['PHINX_TEST_CONFIG_SUFFIX'] = 'sqlite3';
-        $_ENV['PHINX_TEST_CONFIG_NAME'] = 'phinx_testing';
-        $_ENV['PHINX_TEST_CONFIG_SUFFIX'] = 'foo';
-
-        try {
-            $config = new Config([
-                'environments' => [
-                    'production' => [
-                        'adapter' => '%%PHINX_TEST_CONFIG_ADAPTER%%',
-                        'name' => '%%PHINX_TEST_CONFIG_NAME%%',
-                        'suffix' => '%%PHINX_TEST_CONFIG_SUFFIX%%',
-                    ],
-                ],
-            ]);
-
-            $this->assertSame(
-                ['adapter' => 'sqlite', 'name' => 'phinx_testing', 'suffix' => 'sqlite3'],
-                $config->getEnvironment('production')
-            );
-        } finally {
-            unset($_SERVER['PHINX_TEST_CONFIG_ADAPTER']);
-            unset($_SERVER['PHINX_TEST_CONFIG_SUFFIX']);
-            unset($_ENV['PHINX_TEST_CONFIG_NAME']);
-            unset($_ENV['PHINX_TEST_CONFIG_SUFFIX']);
-        }
     }
 
     public function testSqliteMemorySetsName()

--- a/tests/TestCase/Config/ConfigTest.php
+++ b/tests/TestCase/Config/ConfigTest.php
@@ -15,83 +15,22 @@ use UnexpectedValueException;
 class ConfigTest extends AbstractConfigTestCase
 {
     /**
-     * @covers \Phinx\Config\Config::getEnvironments
-     */
-    public function testGetEnvironmentsMethod()
-    {
-        $config = new Config($this->getConfigArray());
-        $this->assertCount(2, $config->getEnvironments());
-        $this->assertArrayHasKey('testing', $config->getEnvironments());
-        $this->assertArrayHasKey('production', $config->getEnvironments());
-    }
-
-    /**
-     * @covers \Phinx\Config\Config::hasEnvironment
-     */
-    public function testHasEnvironmentDoesntHave()
-    {
-        $config = new Config([]);
-        $this->assertFalse($config->hasEnvironment('dummy'));
-    }
-
-    /**
-     * @covers \Phinx\Config\Config::hasEnvironment
-     */
-    public function testHasEnvironmentHasOne()
-    {
-        $config = new Config($this->getConfigArray());
-        $this->assertTrue($config->hasEnvironment('testing'));
-    }
-
-    /**
-     * @covers \Phinx\Config\Config::getEnvironments
-     */
-    public function testGetEnvironmentsNotSet()
-    {
-        $config = new Config([]);
-        $this->assertNull($config->getEnvironments());
-    }
-
-    /**
      * @covers \Phinx\Config\Config::getEnvironment
      */
     public function testGetEnvironmentMethod()
     {
         $config = new Config($this->getConfigArray());
-        $db = $config->getEnvironment('testing');
-        $this->assertEquals('sqllite', $db['adapter']);
-    }
-
-    /**
-     * @covers \Phinx\Config\Config::getEnvironment
-     */
-    public function testHasEnvironmentMethod()
-    {
-        $configArray = $this->getConfigArray();
-        $config = new Config($configArray);
-        $this->assertTrue($config->hasEnvironment('testing'));
-        $this->assertFalse($config->hasEnvironment('fakeenvironment'));
-    }
-
-    /**
-     * @covers \Phinx\Config\Config::getDefaultEnvironment
-     */
-    public function testGetDefaultEnvironmentUsingDatabaseKey()
-    {
-        $configArray = $this->getConfigArray();
-        $configArray['environments']['default_environment'] = 'production';
-        $config = new Config($configArray);
-        $this->assertEquals('production', $config->getDefaultEnvironment());
+        $db = $config->getEnvironment();
+        $this->assertArrayHasKey('adapter', $db);
     }
 
     public function testEnvironmentHasMigrationTable()
     {
         $configArray = $this->getConfigArray();
-        $configArray['environments']['production']['migration_table'] = 'test_table';
+        $configArray['environment']['migration_table'] = 'test_table';
         $config = new Config($configArray);
 
-        $this->assertSame('phinxlog', $config->getEnvironment('testing')['migration_table']);
-        $this->assertSame('test_table', $config->getEnvironment('production')['migration_table']);
+        $this->assertSame('test_table', $config->getEnvironment()['migration_table']);
     }
 
     /**
@@ -168,30 +107,6 @@ class ConfigTest extends AbstractConfigTestCase
         $config = new Config([]);
         $this->assertFalse($config->getTemplateFile());
         $this->assertFalse($config->getTemplateClass());
-    }
-
-    public function testGetAliasNoAliasesEntry()
-    {
-        $config = new Config([]);
-        $this->assertNull($config->getAlias('Short'));
-    }
-
-    public function testGetAliasEmptyAliasesEntry()
-    {
-        $config = new Config(['aliases' => []]);
-        $this->assertNull($config->getAlias('Short'));
-    }
-
-    public function testGetAliasInvalidAliasRequest()
-    {
-        $config = new Config(['aliases' => ['Medium' => 'Some\Long\Classname']]);
-        $this->assertNull($config->getAlias('Short'));
-    }
-
-    public function testGetAliasValidAliasRequest()
-    {
-        $config = new Config(['aliases' => ['Short' => 'Some\Long\Classname']]);
-        $this->assertEquals('Some\Long\Classname', $config->getAlias('Short'));
     }
 
     public function testGetSeedPath()
@@ -284,55 +199,6 @@ class ConfigTest extends AbstractConfigTestCase
                 Config::VERSION_ORDER_EXECUTION_TIME, false,
             ],
         ];
-    }
-
-    public function testSqliteMemorySetsName()
-    {
-        $config = new Config([
-            'environments' => [
-                'production' => [
-                    'adapter' => 'sqlite',
-                    'memory' => true,
-                ],
-            ],
-        ]);
-        $this->assertSame(
-            ['adapter' => 'sqlite', 'memory' => true, 'name' => ':memory:'],
-            $config->getEnvironment('production')
-        );
-    }
-
-    public function testSqliteMemoryOverridesName()
-    {
-        $config = new Config([
-            'environments' => [
-                'production' => [
-                    'adapter' => 'sqlite',
-                    'memory' => true,
-                    'name' => 'blah',
-                ],
-            ],
-        ]);
-        $this->assertSame(
-            ['adapter' => 'sqlite', 'memory' => true, 'name' => ':memory:'],
-            $config->getEnvironment('production')
-        );
-    }
-
-    public function testSqliteNonBooleanMemory()
-    {
-        $config = new Config([
-            'environments' => [
-                'production' => [
-                    'adapter' => 'sqlite',
-                    'memory' => 'yes',
-                ],
-            ],
-        ]);
-        $this->assertSame(
-            ['adapter' => 'sqlite', 'memory' => 'yes', 'name' => ':memory:'],
-            $config->getEnvironment('production')
-        );
     }
 
     public function testDefaultTemplateStyle(): void

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -2158,7 +2158,7 @@ class ManagerTest extends TestCase
             ];
     }
 
-    public function testExecuteSeedWorksAsExpected():void
+    public function testExecuteSeedWorksAsExpected(): void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -2173,7 +2173,7 @@ class ManagerTest extends TestCase
         $this->assertStringContainsString('UserSeeder', $output);
     }
 
-    public function testExecuteASingleSeedWorksAsExpected():void
+    public function testExecuteASingleSeedWorksAsExpected(): void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -2186,7 +2186,7 @@ class ManagerTest extends TestCase
         $this->assertStringContainsString('UserSeeder', $output);
     }
 
-    public function testExecuteANonExistentSeedWorksAsExpected():void
+    public function testExecuteANonExistentSeedWorksAsExpected(): void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -2200,7 +2200,7 @@ class ManagerTest extends TestCase
         $this->manager->seed('NonExistentSeeder');
     }
 
-    public function testOrderSeeds():void
+    public function testOrderSeeds(): void
     {
         $seeds = array_values($this->manager->getSeeds());
         $this->assertInstanceOf('UserSeeder', $seeds[0]);
@@ -2208,7 +2208,7 @@ class ManagerTest extends TestCase
         $this->assertInstanceOf('PostSeeder', $seeds[2]);
     }
 
-    public function testSeedWillNotBeExecuted():void
+    public function testSeedWillNotBeExecuted(): void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -2221,7 +2221,7 @@ class ManagerTest extends TestCase
         $this->assertStringContainsString('skipped', $output);
     }
 
-    public function testGettingInputObject():void
+    public function testGettingInputObject(): void
     {
         $migrations = $this->manager->getMigrations();
         $seeds = $this->manager->getSeeds();
@@ -2236,7 +2236,7 @@ class ManagerTest extends TestCase
         }
     }
 
-    public function testGettingOutputObject():void
+    public function testGettingOutputObject(): void
     {
         $migrations = $this->manager->getMigrations();
         $seeds = $this->manager->getSeeds();
@@ -2251,7 +2251,7 @@ class ManagerTest extends TestCase
         }
     }
 
-    public function testReversibleMigrationsWorkAsExpected():void
+    public function testReversibleMigrationsWorkAsExpected(): void
     {
         $adapter = $this->prepareEnvironment([
             'migrations' => ROOT . '/config/Reversiblemigrations',
@@ -2294,7 +2294,7 @@ class ManagerTest extends TestCase
         $this->assertFalse($adapter->hasTable('users'));
     }
 
-    public function testReversibleMigrationWithIndexConflict():void
+    public function testReversibleMigrationWithIndexConflict(): void
     {
         if ($this->getDriverType() !== 'mysql') {
             $this->markTestSkipped('Test requires mysql connection');
@@ -2334,7 +2334,7 @@ class ManagerTest extends TestCase
         $this->assertFalse($adapter->hasIndex('my_table', ['entity_id']));
     }
 
-    public function testReversibleMigrationWithFKConflictOnTableDrop():void
+    public function testReversibleMigrationWithFKConflictOnTableDrop(): void
     {
         if ($this->getDriverType() !== 'mysql') {
             $this->markTestSkipped('Test requires mysql');
@@ -2548,7 +2548,7 @@ class ManagerTest extends TestCase
         }
     }
 
-    public function testBreakpointWithInvalidVersion():void
+    public function testBreakpointWithInvalidVersion(): void
     {
         if ($this->getDriverType() !== 'mysql') {
             $this->markTestSkipped('test requires mysql');

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -62,7 +62,7 @@ class ManagerTest extends TestCase
         $this->manager = null;
     }
 
-    private static function getCorrectedPath($path)
+    private static function getCorrectedPath(string $path): string
     {
         return str_replace('/', DIRECTORY_SEPARATOR, $path);
     }
@@ -72,7 +72,7 @@ class ManagerTest extends TestCase
      *
      * @return array
      */
-    public static function getConfigArray()
+    public static function getConfigArray(): array
     {
         /** @var array<string, string> $dbConfig */
         $dbConfig = ConnectionManager::getConfig('test');
@@ -94,7 +94,7 @@ class ManagerTest extends TestCase
         ];
     }
 
-    protected function getConfigWithPlugin($paths = [])
+    protected function getConfigWithPlugin(array $paths = []): array
     {
         $paths = [
             'migrations' => ROOT . 'Plugin/Manager/config/Migrations',
@@ -149,7 +149,7 @@ class ManagerTest extends TestCase
         return $adapter;
     }
 
-    public function testInstantiation()
+    public function testInstantiation(): void
     {
         $this->assertInstanceOf(
             'Symfony\Component\Console\Output\StreamOutput',
@@ -157,7 +157,7 @@ class ManagerTest extends TestCase
         );
     }
 
-    public function testPrintStatusMethod()
+    public function testPrintStatusMethod(): void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -204,7 +204,7 @@ class ManagerTest extends TestCase
         $this->assertEquals($expected, $return);
     }
 
-    public function testPrintStatusMethodJsonFormat()
+    public function testPrintStatusMethodJsonFormat(): void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -250,7 +250,7 @@ class ManagerTest extends TestCase
         $this->assertSame($expected, $return);
     }
 
-    public function testPrintStatusMethodWithBreakpointSet()
+    public function testPrintStatusMethodWithBreakpointSet(): void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -866,7 +866,7 @@ class ManagerTest extends TestCase
         }
     }
 
-    public function testRollbackToVersionWithSingleMigrationDoesNotFail()
+    public function testRollbackToVersionWithSingleMigrationDoesNotFail(): void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -891,7 +891,7 @@ class ManagerTest extends TestCase
         $this->assertStringNotContainsString('Undefined offset: -1', $output);
     }
 
-    public function testRollbackToVersionWithTwoMigrations()
+    public function testRollbackToVersionWithTwoMigrations(): void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -930,7 +930,7 @@ class ManagerTest extends TestCase
      *
      * @dataProvider rollbackLastDataProvider
      */
-    public function testRollbackLast($availableRolbacks, $versionOrder, $expectedOutput)
+    public function testRollbackLast(array $availableRolbacks, string $versionOrder, string $expectedOutput): void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -970,7 +970,7 @@ class ManagerTest extends TestCase
      *
      * @return array
      */
-    public static function migrateDateDataProvider()
+    public static function migrateDateDataProvider(): array
     {
         return [
             [['20120111235330', '20120116183504'], '20120118', '20120116183504', 'Failed to migrate all migrations when migrate to date is later than all the migrations'],
@@ -983,7 +983,7 @@ class ManagerTest extends TestCase
      *
      * @return array
      */
-    public static function rollbackToDateDataProvider()
+    public static function rollbackToDateDataProvider(): array
     {
         return [
 
@@ -1186,7 +1186,7 @@ class ManagerTest extends TestCase
      *
      * @return array
      */
-    public static function rollbackToDateByExecutionTimeDataProvider()
+    public static function rollbackToDateByExecutionTimeDataProvider(): array
     {
         return [
 
@@ -1422,7 +1422,7 @@ class ManagerTest extends TestCase
      *
      * @return array
      */
-    public static function rollbackToVersionDataProvider()
+    public static function rollbackToVersionDataProvider(): array
     {
         return [
 
@@ -1562,6 +1562,7 @@ class ManagerTest extends TestCase
                     '20120116183504',
                     null,
                 ],
+            // Breakpoint set on all migrations
             'Rollback all versions (ie. rollback to version 0) - breakpoint set on last migration' =>
                 [
                     [
@@ -1599,68 +1600,10 @@ class ManagerTest extends TestCase
                     '20111225000000',
                     'Target version (20111225000000) not found',
                 ],
-
-            // Breakpoint set on all migrations
-
-            'Rollback to one of the versions - breakpoint set on last migration' =>
-                [
-                    [
-                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
-                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
-                    ],
-                    '20120111235330',
-                    'Breakpoint reached. Further rollbacks inhibited.',
-                ],
-            'Rollback to the latest version - breakpoint set on last migration' =>
-                [
-                    [
-                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
-                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
-                    ],
-                    '20120116183504',
-                    null,
-                ],
-            'Rollback all versions (ie. rollback to version 0) - breakpoint set on last migration' =>
-                [
-                    [
-                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
-                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
-                    ],
-                    '0',
-                    'Breakpoint reached. Further rollbacks inhibited.',
-                ],
-            'Rollback last version - breakpoint set on last migration' =>
-                [
-                    [
-                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
-                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
-                    ],
-                    null,
-                    'Breakpoint reached. Further rollbacks inhibited.',
-                ],
-            'Rollback to non-existing version - breakpoint set on last migration' =>
-                [
-                    [
-                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
-                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
-                    ],
-                    '20121225000000',
-                    'Target version (20121225000000) not found',
-                ],
-            'Rollback to missing version - breakpoint set on last migration' =>
-                [
-                    [
-                        '20111225000000' => ['version' => '20111225000000', 'migration_name' => '', 'breakpoint' => 1],
-                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
-                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
-                    ],
-                    '20111225000000',
-                    'Target version (20111225000000) not found',
-                ],
         ];
     }
 
-    public static function rollbackToVersionByExecutionTimeDataProvider()
+    public static function rollbackToVersionByExecutionTimeDataProvider(): array
     {
         return [
 
@@ -2065,7 +2008,7 @@ class ManagerTest extends TestCase
      *
      * @return array
      */
-    public static function rollbackLastDataProvider()
+    public static function rollbackLastDataProvider(): array
     {
         return [
 
@@ -2191,16 +2134,6 @@ class ManagerTest extends TestCase
                     'Breakpoint reached. Further rollbacks inhibited.',
                 ],
 
-            'Rollback to last migration with creation time version ordering - breakpoint set on all migrations' =>
-                [
-                    [
-                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
-                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 1],
-                    ],
-                    Config::VERSION_ORDER_CREATION_TIME,
-                    'Breakpoint reached. Further rollbacks inhibited.',
-                ],
-
             'Rollback to last migration with missing last migration and creation time version ordering - breakpoint set on all migrations' =>
                 [
                     [
@@ -2225,7 +2158,7 @@ class ManagerTest extends TestCase
             ];
     }
 
-    public function testExecuteSeedWorksAsExpected()
+    public function testExecuteSeedWorksAsExpected():void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -2240,7 +2173,7 @@ class ManagerTest extends TestCase
         $this->assertStringContainsString('UserSeeder', $output);
     }
 
-    public function testExecuteASingleSeedWorksAsExpected()
+    public function testExecuteASingleSeedWorksAsExpected():void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -2253,7 +2186,7 @@ class ManagerTest extends TestCase
         $this->assertStringContainsString('UserSeeder', $output);
     }
 
-    public function testExecuteANonExistentSeedWorksAsExpected()
+    public function testExecuteANonExistentSeedWorksAsExpected():void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -2267,7 +2200,7 @@ class ManagerTest extends TestCase
         $this->manager->seed('NonExistentSeeder');
     }
 
-    public function testOrderSeeds()
+    public function testOrderSeeds():void
     {
         $seeds = array_values($this->manager->getSeeds());
         $this->assertInstanceOf('UserSeeder', $seeds[0]);
@@ -2275,7 +2208,7 @@ class ManagerTest extends TestCase
         $this->assertInstanceOf('PostSeeder', $seeds[2]);
     }
 
-    public function testSeedWillNotBeExecuted()
+    public function testSeedWillNotBeExecuted():void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -2288,7 +2221,7 @@ class ManagerTest extends TestCase
         $this->assertStringContainsString('skipped', $output);
     }
 
-    public function testGettingInputObject()
+    public function testGettingInputObject():void
     {
         $migrations = $this->manager->getMigrations();
         $seeds = $this->manager->getSeeds();
@@ -2303,7 +2236,7 @@ class ManagerTest extends TestCase
         }
     }
 
-    public function testGettingOutputObject()
+    public function testGettingOutputObject():void
     {
         $migrations = $this->manager->getMigrations();
         $seeds = $this->manager->getSeeds();
@@ -2318,7 +2251,7 @@ class ManagerTest extends TestCase
         }
     }
 
-    public function testReversibleMigrationsWorkAsExpected()
+    public function testReversibleMigrationsWorkAsExpected():void
     {
         $adapter = $this->prepareEnvironment([
             'migrations' => ROOT . '/config/Reversiblemigrations',
@@ -2361,7 +2294,7 @@ class ManagerTest extends TestCase
         $this->assertFalse($adapter->hasTable('users'));
     }
 
-    public function testReversibleMigrationWithIndexConflict()
+    public function testReversibleMigrationWithIndexConflict():void
     {
         if ($this->getDriverType() !== 'mysql') {
             $this->markTestSkipped('Test requires mysql connection');
@@ -2401,7 +2334,7 @@ class ManagerTest extends TestCase
         $this->assertFalse($adapter->hasIndex('my_table', ['entity_id']));
     }
 
-    public function testReversibleMigrationWithFKConflictOnTableDrop()
+    public function testReversibleMigrationWithFKConflictOnTableDrop():void
     {
         if ($this->getDriverType() !== 'mysql') {
             $this->markTestSkipped('Test requires mysql');
@@ -2446,7 +2379,7 @@ class ManagerTest extends TestCase
         $this->assertFalse($adapter->hasTable('customers'));
     }
 
-    public function testBreakpointsTogglingOperateAsExpected()
+    public function testBreakpointsTogglingOperateAsExpected(): void
     {
         if ($this->getDriverType() !== 'mysql') {
             $this->markTestSkipped('Test requires mysql');
@@ -2615,7 +2548,7 @@ class ManagerTest extends TestCase
         }
     }
 
-    public function testBreakpointWithInvalidVersion()
+    public function testBreakpointWithInvalidVersion():void
     {
         if ($this->getDriverType() !== 'mysql') {
             $this->markTestSkipped('test requires mysql');
@@ -2646,7 +2579,7 @@ class ManagerTest extends TestCase
         $this->assertStringContainsString('is not a valid version', $output);
     }
 
-    public function testPostgresFullMigration()
+    public function testPostgresFullMigration(): void
     {
         if ($this->getDriverType() !== 'postgres') {
             $this->markTestSkipped('Test requires postgres');
@@ -2679,7 +2612,7 @@ class ManagerTest extends TestCase
         $this->assertFalse($adapter->hasTable('users'));
     }
 
-    public function testMigrationWithDropColumnAndForeignKeyAndIndex()
+    public function testMigrationWithDropColumnAndForeignKeyAndIndex(): void
     {
         if ($this->getDriverType() !== 'mysql') {
             $this->markTestSkipped('Test requires mysql');
@@ -2739,7 +2672,7 @@ class ManagerTest extends TestCase
         $this->assertFalse($adapter->hasIndexByName('table1', 'table1_table3_id'));
     }
 
-    public function testInvalidVersionBreakpoint()
+    public function testInvalidVersionBreakpoint(): void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -2769,7 +2702,7 @@ class ManagerTest extends TestCase
         $this->assertEquals('warning 20120133235330 is not a valid version', trim($outputStr));
     }
 
-    public function testMigrationWillNotBeExecuted()
+    public function testMigrationWillNotBeExecuted(): void
     {
         if ($this->getDriverType() !== 'mysql') {
             $this->markTestSkipped('Test requires mysql');

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -602,7 +602,7 @@ class ManagerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/Duplicate migration/');
         $this->expectExceptionMessageMatches('/20120111235330_duplicate_migration_2.php" has the same version as "20120111235330"/');
-        $manager->getMigrations('mockenv');
+        $manager->getMigrations();
     }
 
     public function testGetMigrationsWithDuplicateMigrationNames()
@@ -613,7 +613,7 @@ class ManagerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Migration "20120111235331_duplicate_migration_name.php" has the same name as "20120111235330_duplicate_migration_name.php"');
 
-        $manager->getMigrations('mockenv');
+        $manager->getMigrations();
     }
 
     public function testGetMigrationsWithInvalidMigrationClassName()
@@ -625,7 +625,7 @@ class ManagerTest extends TestCase
         $this->expectExceptionMessageMatches('/Could not find class "InvalidClass" in file/');
         $this->expectExceptionMessageMatches('/20120111235330_invalid_class.php/');
 
-        $manager->getMigrations('mockenv');
+        $manager->getMigrations();
     }
 
     public function testGettingAValidEnvironment()
@@ -2290,7 +2290,7 @@ class ManagerTest extends TestCase
 
     public function testGettingInputObject()
     {
-        $migrations = $this->manager->getMigrations('mockenv');
+        $migrations = $this->manager->getMigrations();
         $seeds = $this->manager->getSeeds('mockenv');
         $inputObject = $this->manager->getInput();
         $this->assertInstanceOf('\Symfony\Component\Console\Input\InputInterface', $inputObject);
@@ -2305,7 +2305,7 @@ class ManagerTest extends TestCase
 
     public function testGettingOutputObject()
     {
-        $migrations = $this->manager->getMigrations('mockenv');
+        $migrations = $this->manager->getMigrations();
         $seeds = $this->manager->getSeeds('mockenv');
         $outputObject = $this->manager->getOutput();
         $this->assertInstanceOf('\Symfony\Component\Console\Output\OutputInterface', $outputObject);

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -169,14 +169,6 @@ class ManagerTest extends TestCase
         );
     }
 
-    public function testEnvironmentInheritsDataDomainOptions()
-    {
-        foreach ($this->config->getEnvironments() as $name => $opts) {
-            $env = $this->manager->getEnvironment($name);
-            $this->assertArrayHasKey('data_domain', $env->getOptions());
-        }
-    }
-
     public function testPrintStatusMethod()
     {
         // stub environment

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -74,35 +74,23 @@ class ManagerTest extends TestCase
      */
     public static function getConfigArray()
     {
-        $config = [];
-        if (static::getDriverType() === 'mysql') {
-            $dbConfig = ConnectionManager::getConfig('test');
-            $config = [
-                'adapter' => $dbConfig['scheme'],
-                'user' => $dbConfig['username'],
-                'pass' => $dbConfig['password'],
-                'host' => $dbConfig['host'],
-                'name' => $dbConfig['database'],
-            ];
-        }
+        /** @var array<string, string> $dbConfig */
+        $dbConfig = ConnectionManager::getConfig('test');
+        $config = [
+            'adapter' => $dbConfig['scheme'],
+            'user' => $dbConfig['username'],
+            'pass' => $dbConfig['password'],
+            'host' => $dbConfig['host'],
+            'name' => $dbConfig['database'],
+            'migration_table' => 'phinxlog',
+        ];
 
         return [
             'paths' => [
                 'migrations' => ROOT . '/config/ManagerMigrations',
                 'seeds' => ROOT . '/config/ManagerSeeds',
             ],
-            'environments' => [
-                'default_migration_table' => 'phinxlog',
-                'default_environment' => 'production',
-                'production' => $config,
-            ],
-            'data_domain' => [
-                'phone_number' => [
-                    'type' => 'string',
-                    'null' => true,
-                    'length' => 15,
-                ],
-            ],
+            'environment' => $config,
         ];
     }
 
@@ -143,7 +131,7 @@ class ManagerTest extends TestCase
             'name' => $connectionConfig['database'],
         ];
 
-        $configArray['environments']['production'] = $adapterConfig;
+        $configArray['environment'] = $adapterConfig;
         $this->manager->setConfig(new Config($configArray));
 
         $adapter = $this->manager->getEnvironment('production')->getAdapter();
@@ -198,7 +186,7 @@ class ManagerTest extends TestCase
                     ]
                 ));
 
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
         $expected = [
@@ -244,7 +232,7 @@ class ManagerTest extends TestCase
                             ],
                     ]
                 ));
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv', AbstractCommand::FORMAT_JSON);
         $expected = [
@@ -291,7 +279,7 @@ class ManagerTest extends TestCase
                     ]
                 ));
 
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
         $expected = [
@@ -322,7 +310,7 @@ class ManagerTest extends TestCase
         $config = new Config($configArray);
 
         $this->manager->setConfig($config);
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
         $this->assertEquals([], $return);
@@ -357,7 +345,7 @@ class ManagerTest extends TestCase
                     ]
                 ));
 
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
         $expected = [
@@ -424,7 +412,7 @@ class ManagerTest extends TestCase
                     ]
                 ));
 
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
         $expected = [
@@ -477,7 +465,7 @@ class ManagerTest extends TestCase
                     ]
                 ));
 
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
         $expected = [
@@ -524,7 +512,7 @@ class ManagerTest extends TestCase
                         'breakpoint' => 0,
                     ]]));
 
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
         $expected = [
@@ -576,7 +564,7 @@ class ManagerTest extends TestCase
                             'breakpoint' => 0,
                         ]]));
 
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
         $return = $this->manager->printStatus('mockenv');
         $expected = [
@@ -672,7 +660,7 @@ class ManagerTest extends TestCase
                     ->method('getVersions')
                     ->will($this->returnValue($availableMigrations));
         }
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->migrateToDateTime('mockenv', new DateTime($dateString));
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -699,7 +687,7 @@ class ManagerTest extends TestCase
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
 
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->rollback('mockenv', $version);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -732,7 +720,7 @@ class ManagerTest extends TestCase
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
 
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->rollback('mockenv', $version, false, false);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -774,7 +762,7 @@ class ManagerTest extends TestCase
         $this->output->setDecorated(false);
 
         $this->manager = new Manager($config, $this->input, $this->output);
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->rollback('mockenv', $version);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -817,7 +805,7 @@ class ManagerTest extends TestCase
         $this->output->setDecorated(false);
 
         $this->manager = new Manager($config, $this->input, $this->output);
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->rollback('mockenv', $availableRollbacks[$version]['migration_name'] ?? $version);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -860,7 +848,7 @@ class ManagerTest extends TestCase
         $this->output->setDecorated(false);
 
         $this->manager = new Manager($config, $this->input, $this->output);
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->rollback('mockenv', $date, false, false);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -893,7 +881,7 @@ class ManagerTest extends TestCase
                 ->method('getVersions')
                 ->will($this->returnValue([20120111235330]));
 
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->rollback('mockenv');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -930,7 +918,7 @@ class ManagerTest extends TestCase
                     )
                 );
 
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->rollback('mockenv');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -960,7 +948,7 @@ class ManagerTest extends TestCase
         $this->output = new StreamOutput(fopen('php://memory', 'a', false));
         $this->output->setDecorated(false);
         $this->manager = new Manager($config, $this->input, $this->output);
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->rollback('mockenv', null);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -2243,7 +2231,7 @@ class ManagerTest extends TestCase
         $envStub = $this->getMockBuilder(Environment::class)
             ->setConstructorArgs(['mockenv', []])
             ->getMock();
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->seed('mockenv');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -2258,7 +2246,7 @@ class ManagerTest extends TestCase
         $envStub = $this->getMockBuilder(Environment::class)
             ->setConstructorArgs(['mockenv', []])
             ->getMock();
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->seed('mockenv', 'UserSeeder');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -2271,7 +2259,7 @@ class ManagerTest extends TestCase
         $envStub = $this->getMockBuilder(Environment::class)
             ->setConstructorArgs(['mockenv', []])
             ->getMock();
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The seed class "NonExistentSeeder" does not exist');
@@ -2293,7 +2281,7 @@ class ManagerTest extends TestCase
         $envStub = $this->getMockBuilder(Environment::class)
             ->setConstructorArgs(['mockenv', []])
             ->getMock();
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->seed('mockenv', 'UserSeederNotExecuted');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -2328,14 +2316,6 @@ class ManagerTest extends TestCase
         foreach ($seeds as $seed) {
             $this->assertEquals($outputObject, $seed->getOutput());
         }
-    }
-
-    public function testGettingAnInvalidEnvironment()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The environment "invalidenv" does not exist');
-
-        $this->manager->getEnvironment('invalidenv');
     }
 
     public function testReversibleMigrationsWorkAsExpected()
@@ -2780,7 +2760,7 @@ class ManagerTest extends TestCase
                     ]
                 ));
 
-        $this->manager->setEnvironments(['mockenv' => $envStub]);
+        $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
         $this->manager->setBreakpoint('mockenv', 20120133235330);
 

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -134,7 +134,7 @@ class ManagerTest extends TestCase
         $configArray['environment'] = $adapterConfig;
         $this->manager->setConfig(new Config($configArray));
 
-        $adapter = $this->manager->getEnvironment('production')->getAdapter();
+        $adapter = $this->manager->getEnvironment()->getAdapter();
 
         // ensure the database is empty
         if ($adapterConfig['adapter'] === 'postgres') {
@@ -188,7 +188,7 @@ class ManagerTest extends TestCase
 
         $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
-        $return = $this->manager->printStatus('mockenv');
+        $return = $this->manager->printStatus();
         $expected = [
           [
             'status' => 'up',
@@ -234,7 +234,7 @@ class ManagerTest extends TestCase
                 ));
         $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
-        $return = $this->manager->printStatus('mockenv', AbstractCommand::FORMAT_JSON);
+        $return = $this->manager->printStatus(AbstractCommand::FORMAT_JSON);
         $expected = [
             [
               'status' => 'up',
@@ -281,7 +281,7 @@ class ManagerTest extends TestCase
 
         $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
-        $return = $this->manager->printStatus('mockenv');
+        $return = $this->manager->printStatus();
         $expected = [
           [
             'status' => 'up',
@@ -312,7 +312,7 @@ class ManagerTest extends TestCase
         $this->manager->setConfig($config);
         $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
-        $return = $this->manager->printStatus('mockenv');
+        $return = $this->manager->printStatus();
         $this->assertEquals([], $return);
     }
 
@@ -347,7 +347,7 @@ class ManagerTest extends TestCase
 
         $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
-        $return = $this->manager->printStatus('mockenv');
+        $return = $this->manager->printStatus();
         $expected = [
             [
               'missing' => true,
@@ -414,7 +414,7 @@ class ManagerTest extends TestCase
 
         $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
-        $return = $this->manager->printStatus('mockenv');
+        $return = $this->manager->printStatus();
         $expected = [
             [
               'status' => 'up',
@@ -467,7 +467,7 @@ class ManagerTest extends TestCase
 
         $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
-        $return = $this->manager->printStatus('mockenv');
+        $return = $this->manager->printStatus();
         $expected = [
             [
               'missing' => true,
@@ -514,7 +514,7 @@ class ManagerTest extends TestCase
 
         $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
-        $return = $this->manager->printStatus('mockenv');
+        $return = $this->manager->printStatus();
         $expected = [
             [
               'status' => 'up',
@@ -566,7 +566,7 @@ class ManagerTest extends TestCase
 
         $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
-        $return = $this->manager->printStatus('mockenv');
+        $return = $this->manager->printStatus();
         $expected = [
             [
               'missing' => true,
@@ -632,7 +632,7 @@ class ManagerTest extends TestCase
     {
         $this->assertInstanceOf(
             Environment::class,
-            $this->manager->getEnvironment('production')
+            $this->manager->getEnvironment()
         );
     }
 
@@ -661,7 +661,7 @@ class ManagerTest extends TestCase
                     ->will($this->returnValue($availableMigrations));
         }
         $this->manager->setEnvironment($envStub);
-        $this->manager->migrateToDateTime('mockenv', new DateTime($dateString));
+        $this->manager->migrateToDateTime(new DateTime($dateString));
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedMigration)) {
@@ -688,7 +688,7 @@ class ManagerTest extends TestCase
             ->will($this->returnValue($availableRollbacks));
 
         $this->manager->setEnvironment($envStub);
-        $this->manager->rollback('mockenv', $version);
+        $this->manager->rollback($version);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedOutput)) {
@@ -721,7 +721,7 @@ class ManagerTest extends TestCase
             ->will($this->returnValue($availableRollbacks));
 
         $this->manager->setEnvironment($envStub);
-        $this->manager->rollback('mockenv', $version, false, false);
+        $this->manager->rollback($version, false, false);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedOutput)) {
@@ -763,7 +763,7 @@ class ManagerTest extends TestCase
 
         $this->manager = new Manager($config, $this->input, $this->output);
         $this->manager->setEnvironment($envStub);
-        $this->manager->rollback('mockenv', $version);
+        $this->manager->rollback($version);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
 
@@ -806,7 +806,7 @@ class ManagerTest extends TestCase
 
         $this->manager = new Manager($config, $this->input, $this->output);
         $this->manager->setEnvironment($envStub);
-        $this->manager->rollback('mockenv', $availableRollbacks[$version]['migration_name'] ?? $version);
+        $this->manager->rollback($availableRollbacks[$version]['migration_name'] ?? $version);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
 
@@ -849,7 +849,7 @@ class ManagerTest extends TestCase
 
         $this->manager = new Manager($config, $this->input, $this->output);
         $this->manager->setEnvironment($envStub);
-        $this->manager->rollback('mockenv', $date, false, false);
+        $this->manager->rollback($date, false, false);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
 
@@ -882,7 +882,7 @@ class ManagerTest extends TestCase
                 ->will($this->returnValue([20120111235330]));
 
         $this->manager->setEnvironment($envStub);
-        $this->manager->rollback('mockenv');
+        $this->manager->rollback();
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         $this->assertStringContainsString('== 20120111235330 TestMigration: reverting', $output);
@@ -919,7 +919,7 @@ class ManagerTest extends TestCase
                 );
 
         $this->manager->setEnvironment($envStub);
-        $this->manager->rollback('mockenv');
+        $this->manager->rollback();
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         $this->assertStringNotContainsString('== 20120111235330 TestMigration: reverting', $output);
@@ -949,7 +949,7 @@ class ManagerTest extends TestCase
         $this->output->setDecorated(false);
         $this->manager = new Manager($config, $this->input, $this->output);
         $this->manager->setEnvironment($envStub);
-        $this->manager->rollback('mockenv', null);
+        $this->manager->rollback(null);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedOutput)) {
@@ -2232,7 +2232,7 @@ class ManagerTest extends TestCase
             ->setConstructorArgs(['mockenv', []])
             ->getMock();
         $this->manager->setEnvironment($envStub);
-        $this->manager->seed('mockenv');
+        $this->manager->seed();
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         $this->assertStringContainsString('GSeeder', $output);
@@ -2247,7 +2247,7 @@ class ManagerTest extends TestCase
             ->setConstructorArgs(['mockenv', []])
             ->getMock();
         $this->manager->setEnvironment($envStub);
-        $this->manager->seed('mockenv', 'UserSeeder');
+        $this->manager->seed('UserSeeder');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         $this->assertStringContainsString('UserSeeder', $output);
@@ -2264,12 +2264,12 @@ class ManagerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The seed class "NonExistentSeeder" does not exist');
 
-        $this->manager->seed('mockenv', 'NonExistentSeeder');
+        $this->manager->seed('NonExistentSeeder');
     }
 
     public function testOrderSeeds()
     {
-        $seeds = array_values($this->manager->getSeeds('mockenv'));
+        $seeds = array_values($this->manager->getSeeds());
         $this->assertInstanceOf('UserSeeder', $seeds[0]);
         $this->assertInstanceOf('GSeeder', $seeds[1]);
         $this->assertInstanceOf('PostSeeder', $seeds[2]);
@@ -2282,7 +2282,7 @@ class ManagerTest extends TestCase
             ->setConstructorArgs(['mockenv', []])
             ->getMock();
         $this->manager->setEnvironment($envStub);
-        $this->manager->seed('mockenv', 'UserSeederNotExecuted');
+        $this->manager->seed('UserSeederNotExecuted');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         $this->assertStringContainsString('skipped', $output);
@@ -2291,7 +2291,7 @@ class ManagerTest extends TestCase
     public function testGettingInputObject()
     {
         $migrations = $this->manager->getMigrations();
-        $seeds = $this->manager->getSeeds('mockenv');
+        $seeds = $this->manager->getSeeds();
         $inputObject = $this->manager->getInput();
         $this->assertInstanceOf('\Symfony\Component\Console\Input\InputInterface', $inputObject);
 
@@ -2306,7 +2306,7 @@ class ManagerTest extends TestCase
     public function testGettingOutputObject()
     {
         $migrations = $this->manager->getMigrations();
-        $seeds = $this->manager->getSeeds('mockenv');
+        $seeds = $this->manager->getSeeds();
         $outputObject = $this->manager->getOutput();
         $this->assertInstanceOf('\Symfony\Component\Console\Output\OutputInterface', $outputObject);
 
@@ -2325,7 +2325,7 @@ class ManagerTest extends TestCase
         ]);
 
         // migrate to the latest version
-        $this->manager->migrate('production');
+        $this->manager->migrate();
 
         // ensure up migrations worked
         $this->assertFalse($adapter->hasTable('info'));
@@ -2343,7 +2343,7 @@ class ManagerTest extends TestCase
         );
 
         // revert all changes to the first
-        $this->manager->rollback('production', '20121213232502');
+        $this->manager->rollback('20121213232502');
 
         // ensure reversed migrations worked
         $this->assertTrue($adapter->hasTable('info'));
@@ -2355,7 +2355,7 @@ class ManagerTest extends TestCase
         $this->assertFalse($adapter->hasTable('change_direction_test'));
 
         // revert all changes
-        $this->manager->rollback('production', '0');
+        $this->manager->rollback('0');
 
         $this->assertFalse($adapter->hasTable('info'));
         $this->assertFalse($adapter->hasTable('users'));
@@ -2367,7 +2367,7 @@ class ManagerTest extends TestCase
             $this->markTestSkipped('Test requires mysql connection');
         }
         $configArray = $this->getConfigArray();
-        $adapter = $this->manager->getEnvironment('production')->getAdapter();
+        $adapter = $this->manager->getEnvironment()->getAdapter();
 
         // override the migrations directory to use the reversible migrations
         $configArray['paths']['migrations'] = ROOT . '/config/DropIndexRegression/';
@@ -2382,7 +2382,7 @@ class ManagerTest extends TestCase
 
         // migrate to the latest version
         $this->manager->setConfig($config);
-        $this->manager->migrate('production');
+        $this->manager->migrate();
 
         // ensure up migrations worked
         $this->assertTrue($adapter->hasTable('my_table'));
@@ -2391,7 +2391,7 @@ class ManagerTest extends TestCase
         $this->assertTrue($adapter->hasForeignKey('my_table', ['entity_id']));
 
         // revert all changes to the first
-        $this->manager->rollback('production', '20121213232502');
+        $this->manager->rollback('20121213232502');
 
         // ensure reversed migrations worked
         $this->assertTrue($adapter->hasTable('my_table'));
@@ -2407,7 +2407,7 @@ class ManagerTest extends TestCase
             $this->markTestSkipped('Test requires mysql');
         }
         $configArray = $this->getConfigArray();
-        $adapter = $this->manager->getEnvironment('production')->getAdapter();
+        $adapter = $this->manager->getEnvironment()->getAdapter();
 
         // override the migrations directory to use the reversible migrations
         $configArray['paths']['migrations'] = ROOT . '/config/DropTableWithFkRegression';
@@ -2422,7 +2422,7 @@ class ManagerTest extends TestCase
 
         // migrate to the latest version
         $this->manager->setConfig($config);
-        $this->manager->migrate('production');
+        $this->manager->migrate();
 
         // ensure up migrations worked
         $this->assertTrue($adapter->hasTable('orders'));
@@ -2432,7 +2432,7 @@ class ManagerTest extends TestCase
         $this->assertTrue($adapter->hasForeignKey('orders', ['customer_id']));
 
         // revert all changes to the first
-        $this->manager->rollback('production', '20190928205056');
+        $this->manager->rollback('20190928205056');
 
         // ensure reversed migrations worked
         $this->assertTrue($adapter->hasTable('orders'));
@@ -2441,7 +2441,7 @@ class ManagerTest extends TestCase
         $this->assertFalse($adapter->hasTable('customers'));
         $this->assertFalse($adapter->hasForeignKey('orders', ['customer_id']));
 
-        $this->manager->rollback('production');
+        $this->manager->rollback();
         $this->assertFalse($adapter->hasTable('orders'));
         $this->assertFalse($adapter->hasTable('customers'));
     }
@@ -2452,7 +2452,7 @@ class ManagerTest extends TestCase
             $this->markTestSkipped('Test requires mysql');
         }
         $configArray = $this->getConfigArray();
-        $adapter = $this->manager->getEnvironment('production')->getAdapter();
+        $adapter = $this->manager->getEnvironment()->getAdapter();
 
         $config = new Config($configArray);
 
@@ -2465,10 +2465,10 @@ class ManagerTest extends TestCase
 
         // migrate to the latest version
         $this->manager->setConfig($config);
-        $this->manager->migrate('production');
+        $this->manager->migrate();
 
         // Get the versions
-        $originalVersions = $this->manager->getEnvironment('production')->getVersionLog();
+        $originalVersions = $this->manager->getEnvironment()->getVersionLog();
         $this->assertEquals(0, reset($originalVersions)['breakpoint']);
         $this->assertEquals(0, end($originalVersions)['breakpoint']);
 
@@ -2476,10 +2476,10 @@ class ManagerTest extends TestCase
         sleep(1);
 
         // Toggle the breakpoint on most recent migration
-        $this->manager->toggleBreakpoint('production', null);
+        $this->manager->toggleBreakpoint(null);
 
         // ensure breakpoint is set
-        $firstToggle = $this->manager->getEnvironment('production')->getVersionLog();
+        $firstToggle = $this->manager->getEnvironment()->getVersionLog();
         $this->assertEquals(0, reset($firstToggle)['breakpoint']);
         $this->assertEquals(1, end($firstToggle)['breakpoint']);
 
@@ -2496,10 +2496,10 @@ class ManagerTest extends TestCase
         sleep(1);
 
         // Toggle the breakpoint on most recent migration
-        $this->manager->toggleBreakpoint('production', null);
+        $this->manager->toggleBreakpoint(null);
 
         // ensure breakpoint is set
-        $secondToggle = $this->manager->getEnvironment('production')->getVersionLog();
+        $secondToggle = $this->manager->getEnvironment()->getVersionLog();
         $this->assertEquals(0, reset($secondToggle)['breakpoint']);
         $this->assertEquals(0, end($secondToggle)['breakpoint']);
 
@@ -2516,12 +2516,12 @@ class ManagerTest extends TestCase
         sleep(1);
 
         // Reset all breakpoints and toggle the most recent migration twice
-        $this->manager->removeBreakpoints('production');
-        $this->manager->toggleBreakpoint('production', null);
-        $this->manager->toggleBreakpoint('production', null);
+        $this->manager->removeBreakpoints();
+        $this->manager->toggleBreakpoint(null);
+        $this->manager->toggleBreakpoint(null);
 
         // ensure breakpoint is not set
-        $resetVersions = $this->manager->getEnvironment('production')->getVersionLog();
+        $resetVersions = $this->manager->getEnvironment()->getVersionLog();
         $this->assertEquals(0, reset($resetVersions)['breakpoint']);
         $this->assertEquals(0, end($resetVersions)['breakpoint']);
 
@@ -2538,10 +2538,10 @@ class ManagerTest extends TestCase
         sleep(1);
 
         // Set the breakpoint on the latest migration
-        $this->manager->setBreakpoint('production', null);
+        $this->manager->setBreakpoint(null);
 
         // ensure breakpoint is set
-        $setLastVersions = $this->manager->getEnvironment('production')->getVersionLog();
+        $setLastVersions = $this->manager->getEnvironment()->getVersionLog();
         $this->assertEquals(0, reset($setLastVersions)['breakpoint']);
         $this->assertEquals(1, end($setLastVersions)['breakpoint']);
 
@@ -2558,10 +2558,10 @@ class ManagerTest extends TestCase
         sleep(1);
 
         // Set the breakpoint on the first migration
-        $this->manager->setBreakpoint('production', reset($originalVersions)['version']);
+        $this->manager->setBreakpoint(reset($originalVersions)['version']);
 
         // ensure breakpoint is set
-        $setFirstVersion = $this->manager->getEnvironment('production')->getVersionLog();
+        $setFirstVersion = $this->manager->getEnvironment()->getVersionLog();
         $this->assertEquals(1, reset($setFirstVersion)['breakpoint']);
         $this->assertEquals(1, end($setFirstVersion)['breakpoint']);
 
@@ -2578,10 +2578,10 @@ class ManagerTest extends TestCase
         sleep(1);
 
         // Unset the breakpoint on the latest migration
-        $this->manager->unsetBreakpoint('production', null);
+        $this->manager->unsetBreakpoint(null);
 
         // ensure breakpoint is set
-        $unsetLastVersions = $this->manager->getEnvironment('production')->getVersionLog();
+        $unsetLastVersions = $this->manager->getEnvironment()->getVersionLog();
         $this->assertEquals(1, reset($unsetLastVersions)['breakpoint']);
         $this->assertEquals(0, end($unsetLastVersions)['breakpoint']);
 
@@ -2598,10 +2598,10 @@ class ManagerTest extends TestCase
         sleep(1);
 
         // Unset the breakpoint on the first migration
-        $this->manager->unsetBreakpoint('production', reset($originalVersions)['version']);
+        $this->manager->unsetBreakpoint(reset($originalVersions)['version']);
 
         // ensure breakpoint is set
-        $unsetFirstVersion = $this->manager->getEnvironment('production')->getVersionLog();
+        $unsetFirstVersion = $this->manager->getEnvironment()->getVersionLog();
         $this->assertEquals(0, reset($unsetFirstVersion)['breakpoint']);
         $this->assertEquals(0, end($unsetFirstVersion)['breakpoint']);
 
@@ -2621,7 +2621,7 @@ class ManagerTest extends TestCase
             $this->markTestSkipped('test requires mysql');
         }
         $configArray = $this->getConfigArray();
-        $adapter = $this->manager->getEnvironment('production')->getAdapter();
+        $adapter = $this->manager->getEnvironment()->getAdapter();
 
         $config = new Config($configArray);
 
@@ -2634,11 +2634,11 @@ class ManagerTest extends TestCase
 
         // migrate to the latest version
         $this->manager->setConfig($config);
-        $this->manager->migrate('production');
+        $this->manager->migrate();
         $this->manager->getOutput()->setDecorated(false);
 
         // set breakpoint on most recent migration
-        $this->manager->toggleBreakpoint('production', 999);
+        $this->manager->toggleBreakpoint(999);
 
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
@@ -2656,7 +2656,7 @@ class ManagerTest extends TestCase
             'migrations' => ROOT . '/config/Postgres',
         ]);
         // migrate to the latest version
-        $this->manager->migrate('production');
+        $this->manager->migrate();
 
         $this->assertTrue($adapter->hasTable('articles'));
         $this->assertTrue($adapter->hasTable('categories'));
@@ -2667,7 +2667,7 @@ class ManagerTest extends TestCase
         $this->assertTrue($adapter->hasTable('special_tags'));
         $this->assertTrue($adapter->hasTable('users'));
 
-        $this->manager->rollback('production', 'all');
+        $this->manager->rollback('all');
 
         $this->assertFalse($adapter->hasTable('articles'));
         $this->assertFalse($adapter->hasTable('categories'));
@@ -2685,7 +2685,7 @@ class ManagerTest extends TestCase
             $this->markTestSkipped('Test requires mysql');
         }
         $configArray = $this->getConfigArray();
-        $adapter = $this->manager->getEnvironment('production')->getAdapter();
+        $adapter = $this->manager->getEnvironment()->getAdapter();
 
         // override the migrations directory to use the reversible migrations
         $configArray['paths']['migrations'] = ROOT . '/config/DropColumnFkIndexRegression';
@@ -2699,7 +2699,7 @@ class ManagerTest extends TestCase
         $adapter->disconnect();
 
         $this->manager->setConfig($config);
-        $this->manager->migrate('production', 20190928205056);
+        $this->manager->migrate(20190928205056);
 
         $this->assertTrue($adapter->hasTable('table1'));
         $this->assertTrue($adapter->hasTable('table2'));
@@ -2712,7 +2712,7 @@ class ManagerTest extends TestCase
         $this->assertTrue($adapter->hasIndexByName('table1', 'table1_table3_id'));
 
         // Run the next migration
-        $this->manager->migrate('production');
+        $this->manager->migrate();
         $this->assertTrue($adapter->hasTable('table1'));
         $this->assertTrue($adapter->hasTable('table2'));
         $this->assertTrue($adapter->hasTable('table3'));
@@ -2724,8 +2724,8 @@ class ManagerTest extends TestCase
         $this->assertFalse($adapter->hasIndexByName('table1', 'table1_table3_id'));
 
         // rollback
-        $this->manager->rollback('production');
-        $this->manager->rollback('production');
+        $this->manager->rollback();
+        $this->manager->rollback();
 
         // ensure reversed migrations worked
         $this->assertTrue($adapter->hasTable('table1'));
@@ -2762,7 +2762,7 @@ class ManagerTest extends TestCase
 
         $this->manager->setEnvironment($envStub);
         $this->manager->getOutput()->setDecorated(false);
-        $this->manager->setBreakpoint('mockenv', 20120133235330);
+        $this->manager->setBreakpoint(20120133235330);
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
@@ -2775,7 +2775,7 @@ class ManagerTest extends TestCase
             $this->markTestSkipped('Test requires mysql');
         }
         $configArray = $this->getConfigArray();
-        $adapter = $this->manager->getEnvironment('production')->getAdapter();
+        $adapter = $this->manager->getEnvironment()->getAdapter();
 
         // override the migrations directory to use the should execute migrations
         $configArray['paths']['migrations'] = ROOT . '/config/ShouldExecute/';
@@ -2790,12 +2790,12 @@ class ManagerTest extends TestCase
 
         // Run the migration with shouldExecute returning false: the table should not be created
         $this->manager->setConfig($config);
-        $this->manager->migrate('production', 20201207205056);
+        $this->manager->migrate(20201207205056);
 
         $this->assertFalse($adapter->hasTable('info'));
 
         // Run the migration with shouldExecute returning true: the table should be created
-        $this->manager->migrate('production', 20201207205057);
+        $this->manager->migrate(20201207205057);
 
         $this->assertTrue($adapter->hasTable('info'));
     }


### PR DESCRIPTION
Remove many methods from `Config` and `Manager` as migrations will only need to operate on a single connection at a time. We no longer need multiple environments or several other features like aliases. This allows for several parameters to be removed and tests to be simpler.

Part of #647