### PR TITLE
Don't pluralize table name when baking seeds

### DIFF
--- a/src/Command/BakeSeedCommand.php
+++ b/src/Command/BakeSeedCommand.php
@@ -101,7 +101,7 @@ class BakeSeedCommand extends SimpleBakeCommand
             $namespace = $this->_pluginNamespace($this->plugin);
         }
 
-        $table = Inflector::tableize((string)$arguments->getArgumentAt(0));
+        $table = Inflector::underscore((string)$arguments->getArgumentAt(0));
         if ($arguments->hasOption('table')) {
             /** @var string $table */
             $table = $arguments->getOption('table');


### PR DESCRIPTION
When baking a seed like this `bin/cake bake seed VeryImportantPeople`, the resulting code is broken:

```php
class VeryImportantPeopleSeed extends AbstractSeed {
  public function run(): void {
    $data = [];

    $table = $this->table('very_important_peoples'); //should not be "peoples"
    $table->insert($data)->save();
  }
}
```

This change finishes this one: https://github.com/cakephp/migrations/pull/282 :D