### PR TITLE
Update Adapter classes to use Connection pt1

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,17 +26,12 @@ parameters:
 			path: src/Db/Adapter/MysqlAdapter.php
 
 		-
-			message: "#^Parameter \\#4 \\$options of method Migrations\\\\Db\\\\Adapter\\\\PdoAdapter\\:\\:createPdoConnection\\(\\) expects array\\<int, mixed\\>, array\\<int\\|string, mixed\\> given\\.$#"
-			count: 1
-			path: src/Db/Adapter/MysqlAdapter.php
-
-		-
 			message: "#^Right side of && is always true\\.$#"
 			count: 1
 			path: src/Db/Adapter/MysqlAdapter.php
 
 		-
-			message: "#^Access to an undefined property PDO\\:\\:\\$connection\\.$#"
+			message: "#^Access to an undefined property Cake\\\\Database\\\\Connection\\:\\:\\$connection\\.$#"
 			count: 1
 			path: src/Db/Adapter/PdoAdapter.php
 
@@ -57,11 +52,6 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @return with type Phinx\\\\Db\\\\Adapter\\\\AdapterInterface is not subtype of native type Migrations\\\\Db\\\\Adapter\\\\AdapterInterface\\.$#"
-			count: 1
-			path: src/Db/Adapter/SqlserverAdapter.php
-
-		-
-			message: "#^Parameter \\#4 \\$options of method Migrations\\\\Db\\\\Adapter\\\\PdoAdapter\\:\\:createPdoConnection\\(\\) expects array\\<int, mixed\\>, array\\<int\\|string, mixed\\> given\\.$#"
 			count: 1
 			path: src/Db/Adapter/SqlserverAdapter.php
 

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -132,12 +132,9 @@ class StatusCommand extends Command
         $adapter = $connectionConfig['scheme'] ?? null;
         $adapterConfig = [
             'adapter' => $adapter,
-            'user' => $connectionConfig['username'],
-            'pass' => $connectionConfig['password'],
-            'host' => $connectionConfig['host'],
-            'name' => $connectionConfig['database'],
-            'migration_table' => $table,
             'connection' => $connectionName,
+            'database' => $connectionConfig['database'],
+            'migration_table' => $table,
         ];
 
         $configData = [

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -199,15 +199,15 @@ class MysqlAdapter extends PdoAdapter
      */
     protected function hasTableWithSchema(string $schema, string $tableName): bool
     {
-        $result = $this->fetchRow(sprintf(
+        $connection = $this->getConnection();
+        $result = $connection->execute(
             "SELECT TABLE_NAME
             FROM INFORMATION_SCHEMA.TABLES
-            WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'",
-            $schema,
-            $tableName
-        ));
+            WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?",
+            [$schema, $tableName]
+        );
 
-        return !empty($result);
+        return $result->rowCount() === 1;
     }
 
     /**

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Migrations\Db\Adapter;
 
 use Cake\Database\Connection;
-use Cake\Database\Driver\Mysql as MysqlDriver;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
 use Migrations\Db\Literal;
@@ -17,10 +16,7 @@ use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use Migrations\Db\Table\Table;
-use PDO;
 use Phinx\Config\FeatureFlags;
-use RuntimeException;
-use UnexpectedValueException;
 
 /**
  * Phinx MySQL Adapter.
@@ -106,9 +102,12 @@ class MysqlAdapter extends PdoAdapter
         $this->setConnection($this->getConnection());
     }
 
+    /**
+     * @inheritDoc
+     */
     public function setConnection(Connection $connection): AdapterInterface
     {
-        $connection->execute(sprintf("USE %s", $this->getOption('database')));
+        $connection->execute(sprintf('USE %s', $this->getOption('database')));
 
         return parent::setConnection($connection);
     }
@@ -1250,7 +1249,7 @@ class MysqlAdapter extends PdoAdapter
         } else {
             $this->execute(sprintf('CREATE DATABASE `%s` DEFAULT CHARACTER SET `%s`', $name, $charset));
         }
-        $this->execute(sprintf("USE %s", $name));
+        $this->execute(sprintf('USE %s', $name));
     }
 
     /**

--- a/src/Db/Adapter/PdoAdapter.php
+++ b/src/Db/Adapter/PdoAdapter.php
@@ -210,22 +210,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     }
 
     /**
-     * Build connection instance.
-     *
-     * @param class-string<\Cake\Database\Driver> $driverClass Driver class name.
-     * @param array $options Options.
-     * @return \Cake\Database\Connection
-     */
-    protected function buildConnection(string $driverClass, array $options): Connection
-    {
-        $driver = new $driverClass($options);
-        $prop = new ReflectionProperty($driver, 'pdo');
-        $prop->setValue($driver, $this->connection);
-
-        return new Connection(['driver' => $driver] + $options);
-    }
-
-    /**
      * @inheritDoc
      */
     public function getQueryBuilder(string $type): Query
@@ -637,18 +621,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     public function castToBool($value): mixed
     {
         return (bool)$value ? 1 : 0;
-    }
-
-    /**
-     * Retrieve a database connection attribute
-     *
-     * @see https://php.net/manual/en/pdo.getattribute.php
-     * @param int $attribute One of the PDO::ATTR_* constants
-     * @return mixed
-     */
-    public function getAttribute(int $attribute): mixed
-    {
-        return $this->getConnection()->getAttribute($attribute);
     }
 
     /**

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -63,10 +63,11 @@ class PostgresAdapter extends PdoAdapter
     /**
      * {@inheritDoc}
      */
-    public function setConnection(PDO $connection): AdapterInterface
+    public function setConnection(Connection $connection): AdapterInterface
     {
         // always set here since connect() isn't always called
-        $this->useIdentity = (float)$connection->getAttribute(PDO::ATTR_SERVER_VERSION) >= 10;
+        $version = $connection->getDriver()->version();
+        $this->useIdentity = (float)$version >= 10;
 
         return parent::setConnection($connection);
     }
@@ -80,55 +81,8 @@ class PostgresAdapter extends PdoAdapter
      */
     public function connect(): void
     {
-        if ($this->connection === null) {
-            if (!class_exists('PDO') || !in_array('pgsql', PDO::getAvailableDrivers(), true)) {
-                // @codeCoverageIgnoreStart
-                throw new RuntimeException('You need to enable the PDO_Pgsql extension for Phinx to run properly.');
-                // @codeCoverageIgnoreEnd
-            }
-
-            $options = $this->getOptions();
-            $dsn = 'pgsql:dbname=' . $options['name'];
-
-            if (isset($options['host'])) {
-                $dsn .= ';host=' . $options['host'];
-            }
-
-            // if custom port is specified use it
-            if (isset($options['port'])) {
-                $dsn .= ';port=' . $options['port'];
-            }
-
-            $driverOptions = [];
-
-            // use custom data fetch mode
-            if (!empty($options['fetch_mode'])) {
-                $driverOptions[PDO::ATTR_DEFAULT_FETCH_MODE] =
-                    constant('\PDO::FETCH_' . strtoupper($options['fetch_mode']));
-            }
-
-            // pass \PDO::ATTR_PERSISTENT to driver options instead of useless setting it after instantiation
-            if (isset($options['attr_persistent'])) {
-                $driverOptions[PDO::ATTR_PERSISTENT] = $options['attr_persistent'];
-            }
-
-            $db = $this->createPdoConnection($dsn, $options['user'] ?? null, $options['pass'] ?? null, $driverOptions);
-
-            $schema = $options['schema'] ?? null;
-            if ($schema) {
-                try {
-                    $db->exec('SET search_path TO ' . $this->quoteSchemaName($schema));
-                } catch (PDOException $exception) {
-                    throw new InvalidArgumentException(
-                        sprintf('Schema does not exists: %s', $schema),
-                        0,
-                        $exception
-                    );
-                }
-            }
-
-            $this->setConnection($db);
-        }
+        $this->getConnection()->getDriver()->connect();
+        $this->setConnection($this->getConnection());
     }
 
     /**
@@ -136,7 +90,7 @@ class PostgresAdapter extends PdoAdapter
      */
     public function disconnect(): void
     {
-        $this->connection = null;
+        $this->getConnection()->getDriver()->disconnect();
     }
 
     /**
@@ -152,7 +106,7 @@ class PostgresAdapter extends PdoAdapter
      */
     public function beginTransaction(): void
     {
-        $this->execute('BEGIN');
+        $this->getConnection()->begin();
     }
 
     /**
@@ -160,7 +114,7 @@ class PostgresAdapter extends PdoAdapter
      */
     public function commitTransaction(): void
     {
-        $this->execute('COMMIT');
+        $this->getConnection()->commit();
     }
 
     /**
@@ -168,7 +122,7 @@ class PostgresAdapter extends PdoAdapter
      */
     public function rollbackTransaction(): void
     {
-        $this->execute('ROLLBACK');
+        $this->getConnection()->rollback();
     }
 
     /**
@@ -210,21 +164,18 @@ class PostgresAdapter extends PdoAdapter
         }
 
         $parts = $this->getSchemaName($tableName);
-        $result = $this->getConnection()->query(
-            sprintf(
-                'SELECT *
-                FROM information_schema.tables
-                WHERE table_schema = %s
-                AND table_name = %s',
-                $this->getConnection()->quote($parts['schema']),
-                $this->getConnection()->quote($parts['table'])
-            )
+        $connection = $this->getConnection();
+        $stmt = $connection->execute(
+            'SELECT *
+            FROM information_schema.tables
+            WHERE table_schema = ?
+            AND table_name = ?',
+            [$parts['schema'], $parts['table']]
         );
-        if (!$result) {
-            return false;
-        }
+        $count = $stmt->rowCount();
+        $stmt->closeCursor();
 
-        return $result->rowCount() === 1;
+        return $count === 1;
     }
 
     /**
@@ -310,7 +261,7 @@ class PostgresAdapter extends PdoAdapter
             $queries[] = sprintf(
                 'COMMENT ON TABLE %s IS %s',
                 $this->quoteTableName($table->getName()),
-                $this->getConnection()->quote($options['comment'])
+                $this->quoteString($options['comment'])
             );
         }
 
@@ -369,7 +320,7 @@ class PostgresAdapter extends PdoAdapter
 
         // passing 'null' is to remove table comment
         $newComment = $newComment !== null
-            ? $this->getConnection()->quote($newComment)
+            ? $this->quoteString($newComment)
             : 'NULL';
         $sql = sprintf(
             'COMMENT ON TABLE %s IS %s',
@@ -436,8 +387,8 @@ class PostgresAdapter extends PdoAdapter
              WHERE table_schema = %s AND table_name = %s
              ORDER BY ordinal_position',
             $this->useIdentity ? ', identity_generation' : '',
-            $this->getConnection()->quote($parts['schema']),
-            $this->getConnection()->quote($parts['table'])
+            $this->quoteString($parts['schema']),
+            $this->quoteString($parts['table'])
         );
         $columnsInfo = $this->fetchAll($sql);
         foreach ($columnsInfo as $columnInfo) {
@@ -504,21 +455,16 @@ class PostgresAdapter extends PdoAdapter
     public function hasColumn(string $tableName, string $columnName): bool
     {
         $parts = $this->getSchemaName($tableName);
-        $sql = sprintf(
-            'SELECT count(*)
+        $connection = $this->getConnection();
+        $sql = 'SELECT count(*)
             FROM information_schema.columns
-            WHERE table_schema = %s AND table_name = %s AND column_name = %s',
-            $this->getConnection()->quote($parts['schema']),
-            $this->getConnection()->quote($parts['table']),
-            $this->getConnection()->quote($columnName)
-        );
+            WHERE table_schema = ? AND table_name = ? AND column_name = ?';
 
-        $result = $this->fetchRow($sql);
-        if (!$result) {
-            return false;
-        }
+        $result = $connection->execute($sql, [$parts['schema'], $parts['table'], $columnName]);
+        $row = $result->fetch('assoc');
+        $result->closeCursor();
 
-        return $result['count'] > 0;
+        return $row['count'] > 0;
     }
 
     /**
@@ -557,9 +503,9 @@ class PostgresAdapter extends PdoAdapter
             'SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END AS column_exists
              FROM information_schema.columns
              WHERE table_schema = %s AND table_name = %s AND column_name = %s',
-            $this->getConnection()->quote($parts['schema']),
-            $this->getConnection()->quote($parts['table']),
-            $this->getConnection()->quote($columnName)
+            $this->quoteString($parts['schema']),
+            $this->quoteString($parts['table']),
+            $this->quoteString($columnName)
         );
 
         $result = $this->fetchRow($sql);
@@ -755,8 +701,8 @@ class PostgresAdapter extends PdoAdapter
             ORDER BY
                 t.relname,
                 i.relname",
-            $this->getConnection()->quote($parts['schema']),
-            $this->getConnection()->quote($parts['table'])
+            $this->quoteString($parts['schema']),
+            $this->quoteString($parts['table'])
         );
         $rows = $this->fetchAll($sql);
         foreach ($rows as $row) {
@@ -901,8 +847,8 @@ class PostgresAdapter extends PdoAdapter
                     AND tc.table_schema = %s
                     AND tc.table_name = %s
                 ORDER BY kcu.position_in_unique_constraint",
-            $this->getConnection()->quote($parts['schema']),
-            $this->getConnection()->quote($parts['table'])
+            $this->quoteString($parts['schema']),
+            $this->quoteString($parts['table'])
         ));
 
         $primaryKey = [
@@ -965,8 +911,8 @@ class PostgresAdapter extends PdoAdapter
                     JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name
                 WHERE constraint_type = 'FOREIGN KEY' AND tc.table_schema = %s AND tc.table_name = %s
                 ORDER BY kcu.ordinal_position",
-            $this->getConnection()->quote($parts['schema']),
-            $this->getConnection()->quote($parts['table'])
+            $this->quoteString($parts['schema']),
+            $this->quoteString($parts['table'])
         ));
         foreach ($rows as $row) {
             $foreignKeys[$row['constraint_name']]['table'] = $row['table_name'];
@@ -1298,7 +1244,7 @@ class PostgresAdapter extends PdoAdapter
         $comment = (string)$column->getComment();
         // passing 'null' is to remove column comment
         $comment = strcasecmp($comment, 'NULL') !== 0
-                 ? $this->getConnection()->quote($comment)
+                 ? $this->quoteString($comment)
                  : 'NULL';
 
         return sprintf(
@@ -1445,7 +1391,7 @@ class PostgresAdapter extends PdoAdapter
             'SELECT count(*)
              FROM pg_namespace
              WHERE nspname = %s',
-            $this->getConnection()->quote($schemaName)
+            $this->quoteString($schemaName)
         );
         $result = $this->fetchRow($sql);
         if (!$result) {
@@ -1577,26 +1523,6 @@ class PostgresAdapter extends PdoAdapter
     }
 
     /**
-     * @inheritDoc
-     */
-    public function getDecoratedConnection(): Connection
-    {
-        if (isset($this->decoratedConnection)) {
-            return $this->decoratedConnection;
-        }
-
-        $options = $this->getOptions();
-        $options = [
-            'username' => $options['user'] ?? null,
-            'password' => $options['pass'] ?? null,
-            'database' => $options['name'],
-            'quoteIdentifiers' => true,
-        ] + $options;
-
-        return $this->decoratedConnection = $this->buildConnection(PostgresDriver::class, $options);
-    }
-
-    /**
      * Sets search path of schemas to look through for a table
      *
      * @return void
@@ -1639,8 +1565,7 @@ class PostgresAdapter extends PdoAdapter
             $this->output->writeln($sql);
         } else {
             $sql .= ' ' . $override . 'VALUES (' . implode(', ', array_fill(0, count($columns), '?')) . ')';
-            $stmt = $this->getConnection()->prepare($sql);
-            $stmt->execute(array_values($row));
+            $this->getConnection()->execute($sql, array_values($row));
         }
     }
 
@@ -1671,12 +1596,12 @@ class PostgresAdapter extends PdoAdapter
             $sql .= implode(', ', $values) . ';';
             $this->output->writeln($sql);
         } else {
+            $connection = $this->getConnection();
             $count_keys = count($keys);
             $query = '(' . implode(', ', array_fill(0, $count_keys, '?')) . ')';
             $count_vars = count($rows);
             $queries = array_fill(0, $count_vars, $query);
             $sql .= implode(',', $queries);
-            $stmt = $this->getConnection()->prepare($sql);
             $vals = [];
 
             foreach ($rows as $row) {
@@ -1689,7 +1614,7 @@ class PostgresAdapter extends PdoAdapter
                 }
             }
 
-            $stmt->execute($vals);
+            $connection->execute($sql, $vals);
         }
     }
 }

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Migrations\Db\Adapter;
 
 use Cake\Database\Connection;
-use Cake\Database\Driver\Postgres as PostgresDriver;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
 use Migrations\Db\Literal;
@@ -17,9 +16,6 @@ use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use Migrations\Db\Table\Table;
-use PDO;
-use PDOException;
-use RuntimeException;
 
 class PostgresAdapter extends PdoAdapter
 {

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 namespace Migrations\Db\Adapter;
 
 use BadMethodCallException;
-use Cake\Database\Connection;
-use Cake\Database\Driver\Sqlite as SqliteDriver;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
 use Migrations\Db\Expression;
@@ -19,7 +17,6 @@ use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use Migrations\Db\Table\Table;
-use PDO;
 use PDOException;
 use RuntimeException;
 use const FILTER_VALIDATE_BOOLEAN;

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 namespace Migrations\Db\Adapter;
 
 use BadMethodCallException;
-use Cake\Database\Connection;
-use Cake\Database\Driver\Sqlserver as SqlServerDriver;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
 use Migrations\Db\Literal;
@@ -18,11 +16,7 @@ use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use Migrations\Db\Table\Table;
-use PDO;
-use PDOException;
 use Phinx\Migration\MigrationInterface;
-use RuntimeException;
-use UnexpectedValueException;
 
 /**
  * Migrations SqlServer Adapter.
@@ -1256,25 +1250,5 @@ SQL;
         $endTime = str_replace(' ', 'T', $endTime);
 
         return parent::migrated($migration, $direction, $startTime, $endTime);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getDecoratedConnection(): Connection
-    {
-        if (isset($this->decoratedConnection)) {
-            return $this->decoratedConnection;
-        }
-
-        $options = $this->getOptions();
-        $options = [
-            'username' => $options['user'] ?? null,
-            'password' => $options['pass'] ?? null,
-            'database' => $options['name'],
-            'quoteIdentifiers' => true,
-        ] + $options;
-
-        return $this->decoratedConnection = $this->buildConnection(SqlServerDriver::class, $options);
     }
 }

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -60,102 +60,8 @@ class SqlserverAdapter extends PdoAdapter
      */
     public function connect(): void
     {
-        if ($this->connection === null) {
-            if (!class_exists('PDO') || !in_array('sqlsrv', PDO::getAvailableDrivers(), true)) {
-                // try our connection via freetds (Mac/Linux)
-                $this->connectDblib();
-
-                return;
-            }
-
-            $options = $this->getOptions();
-
-            $dsn = 'sqlsrv:server=' . $options['host'];
-            // if port is specified use it, otherwise use the SqlServer default
-            if (!empty($options['port'])) {
-                $dsn .= ',' . $options['port'];
-            }
-            $dsn .= ';database=' . $options['name'] . ';MultipleActiveResultSets=false';
-
-            // option to add additional connection options
-            // https://docs.microsoft.com/en-us/sql/connect/php/connection-options?view=sql-server-ver15
-            if (isset($options['dsn_options'])) {
-                foreach ($options['dsn_options'] as $key => $option) {
-                    $dsn .= ';' . $key . '=' . $option;
-                }
-            }
-
-            $driverOptions = [];
-
-            // charset support
-            if (isset($options['charset'])) {
-                $driverOptions[PDO::SQLSRV_ATTR_ENCODING] = $options['charset'];
-            }
-
-            // use custom data fetch mode
-            if (!empty($options['fetch_mode'])) {
-                $driverOptions[PDO::ATTR_DEFAULT_FETCH_MODE] = constant('\PDO::FETCH_' . strtoupper($options['fetch_mode']));
-            }
-
-            // Note, the PDO::ATTR_PERSISTENT attribute is not supported for sqlsrv and will throw an error when used
-            // See https://github.com/Microsoft/msphpsql/issues/65
-
-            // support arbitrary \PDO::SQLSRV_ATTR_* driver options and pass them to PDO
-            // https://php.net/manual/en/ref.pdo-sqlsrv.php#pdo-sqlsrv.constants
-            foreach ($options as $key => $option) {
-                if (strpos($key, 'sqlsrv_attr_') === 0) {
-                    $pdoConstant = '\PDO::' . strtoupper($key);
-                    if (!defined($pdoConstant)) {
-                        throw new UnexpectedValueException('Invalid PDO attribute: ' . $key . ' (' . $pdoConstant . ')');
-                    }
-                    $driverOptions[constant($pdoConstant)] = $option;
-                }
-            }
-
-            $db = $this->createPdoConnection($dsn, $options['user'] ?? null, $options['pass'] ?? null, $driverOptions);
-
-            $this->setConnection($db);
-        }
-    }
-
-    /**
-     * Connect to MSSQL using dblib/freetds.
-     *
-     * The "sqlsrv" driver is not available on Unix machines.
-     *
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
-     * @return void
-     */
-    protected function connectDblib(): void
-    {
-        if (!class_exists('PDO') || !in_array('dblib', PDO::getAvailableDrivers(), true)) {
-            // @codeCoverageIgnoreStart
-            throw new RuntimeException('You need to enable the PDO_Dblib extension for Migrations to run properly.');
-            // @codeCoverageIgnoreEnd
-        }
-
-        $options = $this->getOptions();
-
-        // if port is specified use it, otherwise use the SqlServer default
-        if (empty($options['port'])) {
-            $dsn = 'dblib:host=' . $options['host'] . ';dbname=' . $options['name'];
-        } else {
-            $dsn = 'dblib:host=' . $options['host'] . ':' . $options['port'] . ';dbname=' . $options['name'];
-        }
-
-        $driverOptions = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION];
-
-        try {
-            $db = new PDO($dsn, $options['user'], $options['pass'], $driverOptions);
-        } catch (PDOException $exception) {
-            throw new InvalidArgumentException(sprintf(
-                'There was a problem connecting to the database: %s',
-                $exception->getMessage()
-            ), 0, $exception);
-        }
-
-        $this->setConnection($db);
+        $this->getConnection()->getDriver()->connect();
+        $this->setConnection($this->getConnection());
     }
 
     /**
@@ -163,7 +69,7 @@ class SqlserverAdapter extends PdoAdapter
      */
     public function disconnect(): void
     {
-        $this->connection = null;
+        $this->getConnection()->getDriver()->disconnect();
     }
 
     /**
@@ -179,7 +85,7 @@ class SqlserverAdapter extends PdoAdapter
      */
     public function beginTransaction(): void
     {
-        $this->execute('BEGIN TRANSACTION');
+        $this->getConnection()->begin();
     }
 
     /**
@@ -187,7 +93,7 @@ class SqlserverAdapter extends PdoAdapter
      */
     public function commitTransaction(): void
     {
-        $this->execute('COMMIT TRANSACTION');
+        $this->getConnection()->commit();
     }
 
     /**
@@ -195,7 +101,7 @@ class SqlserverAdapter extends PdoAdapter
      */
     public function rollbackTransaction(): void
     {
-        $this->execute('ROLLBACK TRANSACTION');
+        $this->getConnection()->rollback();
     }
 
     /**
@@ -363,7 +269,7 @@ class SqlserverAdapter extends PdoAdapter
         // passing 'null' is to remove column comment
         $currentComment = $this->getColumnComment((string)$tableName, $column->getName());
 
-        $comment = strcasecmp((string)$column->getComment(), 'NULL') !== 0 ? $this->getConnection()->quote((string)$column->getComment()) : '\'\'';
+        $comment = strcasecmp((string)$column->getComment(), 'NULL') !== 0 ? $this->quoteString((string)$column->getComment()) : '\'\'';
         $command = $currentComment === null ? 'sp_addextendedproperty' : 'sp_updateextendedproperty';
 
         return sprintf(

--- a/src/Migration/Environment.php
+++ b/src/Migration/Environment.php
@@ -347,13 +347,13 @@ class Environment
         // AdapterFactory to choose the adapter.
         // Adapters should use Connection API instead of PDO.
         $connection = ConnectionManager::get($options['connection']);
+        $options['connection'] = $connection;
 
         // Get the driver classname as those are aligned with adapter names.
         $driver = $connection->getDriver();
         $driverClass = get_class($driver);
         $driverName = strtolower(substr($driverClass, (int)strrpos($driverClass, '\\') + 1));
-
-        $options['connection'] = $connection;
+        $options['adapter'] = $driverName;
 
         $factory = AdapterFactory::instance();
         $adapter = $factory

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -417,6 +417,7 @@ class MigrationHelper extends Helper
             unset($columnOptions['collate']);
         }
 
+        // TODO this can be cleaned up when we stop using phinx data structures for column definitions
         if ($columnOptions['precision'] === null) {
             unset($columnOptions['precision']);
         } else {

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Migrations\Test\Db\Adapter;
 
+use Cake\Database\Connection;
 use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
 use InvalidArgumentException;
@@ -43,18 +44,16 @@ class MysqlAdapterTest extends TestCase
         }
         // Emulate the results of Util::parseDsn()
         $this->config = [
-            'adapter' => $config['scheme'],
-            'user' => $config['username'],
-            'pass' => $config['password'],
-            'host' => $config['host'],
-            'name' => $config['database'],
+            'adapter' => 'mysql',
+            'connection' => ConnectionManager::get('test'),
+            'database' => $config['database'],
         ];
 
         $this->adapter = new MysqlAdapter($this->config, new ArrayInput([]), new NullOutput());
 
         // ensure the database is empty for each test
-        $this->adapter->dropDatabase($this->config['name']);
-        $this->adapter->createDatabase($this->config['name'], ['charset' => 'utf8mb4']);
+        $this->adapter->dropDatabase($this->config['database']);
+        $this->adapter->createDatabase($this->config['database'], ['charset' => 'utf8mb4']);
 
         // leave the adapter in a disconnected state for each test
         $this->adapter->disconnect();
@@ -67,61 +66,14 @@ class MysqlAdapterTest extends TestCase
 
     private function usingMysql8(): bool
     {
-        return version_compare($this->adapter->getAttribute(PDO::ATTR_SERVER_VERSION), '8.0.0', '>=');
+        $version = $this->adapter->getConnection()->getDriver()->version();
+
+        return version_compare($version, '8.0.0', '>=');
     }
 
     public function testConnection()
     {
-        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
-        $this->assertSame(PDO::ERRMODE_EXCEPTION, $this->adapter->getConnection()->getAttribute(PDO::ATTR_ERRMODE));
-    }
-
-    public function testConnectionWithFetchMode()
-    {
-        $options = $this->adapter->getOptions();
-        $options['fetch_mode'] = 'assoc';
-        $this->adapter->setOptions($options);
-        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
-        $this->assertSame(PDO::FETCH_ASSOC, $this->adapter->getConnection()->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE));
-    }
-
-    public function testConnectionWithoutPort()
-    {
-        $options = $this->adapter->getOptions();
-        unset($options['port']);
-        $this->adapter->setOptions($options);
-        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
-    }
-
-    public function testConnectionWithInvalidCredentials()
-    {
-        $options = ['user' => 'invalid', 'pass' => 'invalid'] + $this->config;
-
-        try {
-            $adapter = new MysqlAdapter($options, new ArrayInput([]), new NullOutput());
-            $adapter->connect();
-            $this->fail('Expected the adapter to throw an exception');
-        } catch (InvalidArgumentException $e) {
-            $this->assertInstanceOf(
-                'InvalidArgumentException',
-                $e,
-                'Expected exception of type InvalidArgumentException, got ' . get_class($e)
-            );
-            $this->assertStringContainsString('There was a problem connecting to the database', $e->getMessage());
-        }
-    }
-
-    public function testConnectionWithSocketConnection()
-    {
-        if (!getenv('MYSQL_UNIX_SOCKET')) {
-            $this->markTestSkipped('MySQL socket connection skipped.');
-        }
-
-        $options = ['unix_socket' => getenv('MYSQL_UNIX_SOCKET')] + $this->config;
-        $adapter = new MysqlAdapter($options, new ArrayInput([]), new NullOutput());
-        $adapter->connect();
-
-        $this->assertInstanceOf('\PDO', $this->adapter->getConnection());
+        $this->assertInstanceOf(Connection::class, $this->adapter->getConnection());
     }
 
     public function testCreatingTheSchemaTableOnConnect()
@@ -199,7 +151,7 @@ class MysqlAdapterTest extends TestCase
 
         $rows = $this->adapter->fetchAll(sprintf(
             "SELECT TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='ntable'",
-            $this->config['name']
+            $this->config['database']
         ));
         $comment = $rows[0];
 
@@ -227,7 +179,7 @@ class MysqlAdapterTest extends TestCase
             "SELECT TABLE_NAME, COLUMN_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME
              FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
              WHERE TABLE_SCHEMA='%s' AND REFERENCED_TABLE_NAME='ntable_tag'",
-            $this->config['name']
+            $this->config['database']
         ));
         $foreignKey = $rows[0];
 
@@ -403,11 +355,6 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasIndexByName('table1', 'myemailindex'));
     }
 
-    public function testCreateTableWithMultiplePKsAndUniqueIndexes()
-    {
-        $this->markTestIncomplete();
-    }
-
     public function testCreateTableWithMyISAMEngine()
     {
         $table = new Table('ntable', ['engine' => 'MyISAM'], $this->adapter);
@@ -425,11 +372,6 @@ class MysqlAdapterTest extends TestCase
             'collation' => 'utf8mb4_unicode_ci',
         ];
         $adapter = new MysqlAdapter($options, new ArrayInput([]), new NullOutput());
-
-        // Ensure the database is empty and the adapter is in a disconnected state
-        $adapter->dropDatabase($options['name']);
-        $adapter->createDatabase($options['name']);
-        $adapter->disconnect();
 
         $table = new Table('table_with_default_collation', [], $adapter);
         $table->addColumn('name', 'string')
@@ -536,7 +478,7 @@ class MysqlAdapterTest extends TestCase
 
     public function testCreateTableWithSchema()
     {
-        $table = new Table($this->config['name'] . '.ntable', [], $this->adapter);
+        $table = new Table($this->config['database'] . '.ntable', [], $this->adapter);
         $table->addColumn('realname', 'string')
             ->addColumn('email', 'integer')
             ->save();
@@ -603,7 +545,7 @@ class MysqlAdapterTest extends TestCase
                     FROM INFORMATION_SCHEMA.TABLES
                     WHERE TABLE_SCHEMA='%s'
                         AND TABLE_NAME='%s'",
-                $this->config['name'],
+                $this->config['database'],
                 'table1'
             )
         );
@@ -625,7 +567,7 @@ class MysqlAdapterTest extends TestCase
                     FROM INFORMATION_SCHEMA.TABLES
                     WHERE TABLE_SCHEMA='%s'
                         AND TABLE_NAME='%s'",
-                $this->config['name'],
+                $this->config['database'],
                 'table1'
             )
         );
@@ -647,7 +589,7 @@ class MysqlAdapterTest extends TestCase
                     FROM INFORMATION_SCHEMA.TABLES
                     WHERE TABLE_SCHEMA='%s'
                         AND TABLE_NAME='%s'",
-                $this->config['name'],
+                $this->config['database'],
                 'table1'
             )
         );
@@ -1173,7 +1115,8 @@ class MysqlAdapterTest extends TestCase
     public function testDatetimeColumn()
     {
         $this->adapter->connect();
-        if (version_compare($this->adapter->getAttribute(PDO::ATTR_SERVER_VERSION), '5.6.4') === -1) {
+        $version = $this->adapter->getConnection()->getDriver()->version();
+        if (version_compare($version, '5.6.4') === -1) {
             $this->markTestSkipped('Cannot test datetime limit on versions less than 5.6.4');
         }
         $table = new Table('t', [], $this->adapter);
@@ -1186,7 +1129,8 @@ class MysqlAdapterTest extends TestCase
     public function testDatetimeColumnLimit()
     {
         $this->adapter->connect();
-        if (version_compare($this->adapter->getAttribute(PDO::ATTR_SERVER_VERSION), '5.6.4') === -1) {
+        $version = $this->adapter->getConnection()->getDriver()->version();
+        if (version_compare($version, '5.6.4') === -1) {
             $this->markTestSkipped('Cannot test datetime limit on versions less than 5.6.4');
         }
         $limit = 6;
@@ -1200,7 +1144,8 @@ class MysqlAdapterTest extends TestCase
     public function testTimeColumnLimit()
     {
         $this->adapter->connect();
-        if (version_compare($this->adapter->getAttribute(PDO::ATTR_SERVER_VERSION), '5.6.4') === -1) {
+        $version = $this->adapter->getConnection()->getDriver()->version();
+        if (version_compare($version, '5.6.4') === -1) {
             $this->markTestSkipped('Cannot test datetime limit on versions less than 5.6.4');
         }
         $limit = 3;
@@ -1214,7 +1159,8 @@ class MysqlAdapterTest extends TestCase
     public function testTimestampColumnLimit()
     {
         $this->adapter->connect();
-        if (version_compare($this->adapter->getAttribute(PDO::ATTR_SERVER_VERSION), '5.6.4') === -1) {
+        $version = $this->adapter->getConnection()->getDriver()->version();
+        if (version_compare($version, '5.6.4') === -1) {
             $this->markTestSkipped('Cannot test datetime limit on versions less than 5.6.4');
         }
         $limit = 1;
@@ -1228,7 +1174,8 @@ class MysqlAdapterTest extends TestCase
     public function testTimestampInvalidLimit()
     {
         $this->adapter->connect();
-        if (version_compare($this->adapter->getAttribute(PDO::ATTR_SERVER_VERSION), '5.6.4') === -1) {
+        $version = $this->adapter->getConnection()->getDriver()->version();
+        if (version_compare($version, '5.6.4') === -1) {
             $this->markTestSkipped('Cannot test datetime limit on versions less than 5.6.4');
         }
         $table = new Table('t', [], $this->adapter);
@@ -1343,7 +1290,7 @@ class MysqlAdapterTest extends TestCase
 
         $this->assertContains($described['TABLE_TYPE'], ['VIEW', 'BASE TABLE']);
         $this->assertEquals($described['TABLE_NAME'], 't');
-        $this->assertEquals($described['TABLE_SCHEMA'], $this->config['name']);
+        $this->assertEquals($described['TABLE_SCHEMA'], $this->config['database']);
         $this->assertEquals($described['TABLE_ROWS'], 0);
     }
 
@@ -1421,7 +1368,7 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($table->hasIndex('email'));
         $index_data = $this->adapter->query(sprintf(
             'SELECT SUB_PART FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = "%s" AND TABLE_NAME = "table1" AND INDEX_NAME = "email"',
-            $this->config['name']
+            $this->config['database']
         ))->fetch(PDO::FETCH_ASSOC);
         $expected_limit = $index_data['SUB_PART'];
         $this->assertEquals($expected_limit, 50);
@@ -1439,13 +1386,13 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($table->hasIndex(['email', 'username']));
         $index_data = $this->adapter->query(sprintf(
             'SELECT SUB_PART FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = "%s" AND TABLE_NAME = "table1" AND INDEX_NAME = "email" AND COLUMN_NAME = "email"',
-            $this->config['name']
+            $this->config['database']
         ))->fetch(PDO::FETCH_ASSOC);
         $expected_limit = $index_data['SUB_PART'];
         $this->assertEquals($expected_limit, 3);
         $index_data = $this->adapter->query(sprintf(
             'SELECT SUB_PART FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = "%s" AND TABLE_NAME = "table1" AND INDEX_NAME = "email" AND COLUMN_NAME = "username"',
-            $this->config['name']
+            $this->config['database']
         ))->fetch(PDO::FETCH_ASSOC);
         $expected_limit = $index_data['SUB_PART'];
         $this->assertEquals($expected_limit, 2);
@@ -1463,7 +1410,7 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($table->hasIndex('email'));
         $index_data = $this->adapter->query(sprintf(
             'SELECT SUB_PART FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = "%s" AND TABLE_NAME = "table1" AND INDEX_NAME = "email" AND COLUMN_NAME = "email"',
-            $this->config['name']
+            $this->config['database']
         ))->fetch(PDO::FETCH_ASSOC);
         $expected_limit = $index_data['SUB_PART'];
         $this->assertEquals($expected_limit, 3);
@@ -1800,8 +1747,8 @@ class MysqlAdapterTest extends TestCase
     public function testHasForeignKey($tableDef, $key, $exp)
     {
         $conn = $this->adapter->getConnection();
-        $conn->exec('CREATE TABLE other(a int, b int, c int, key(a), key(b), key(a,b), key(a,b,c));');
-        $conn->exec($tableDef);
+        $conn->execute('CREATE TABLE other(a int, b int, c int, key(a), key(b), key(a,b), key(a,b,c));');
+        $conn->execute($tableDef);
         $this->assertSame($exp, $this->adapter->hasForeignKey('t', $key));
     }
 
@@ -1890,14 +1837,14 @@ class MysqlAdapterTest extends TestCase
             ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
             ->save();
 
-        $this->assertTrue($this->adapter->hasForeignKey($this->config['name'] . '.' . $table->getName(), ['ref_table_id']));
-        $this->assertFalse($this->adapter->hasForeignKey($this->config['name'] . '.' . $table->getName(), ['ref_table_id2']));
+        $this->assertTrue($this->adapter->hasForeignKey($this->config['database'] . '.' . $table->getName(), ['ref_table_id']));
+        $this->assertFalse($this->adapter->hasForeignKey($this->config['database'] . '.' . $table->getName(), ['ref_table_id2']));
     }
 
     public function testHasDatabase()
     {
         $this->assertFalse($this->adapter->hasDatabase('fake_database_name'));
-        $this->assertTrue($this->adapter->hasDatabase($this->config['name']));
+        $this->assertTrue($this->adapter->hasDatabase($this->config['database']));
     }
 
     public function testDropDatabase()
@@ -1919,7 +1866,7 @@ class MysqlAdapterTest extends TestCase
             FROM information_schema.columns
             WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='table1'
             ORDER BY ORDINAL_POSITION",
-            $this->config['name']
+            $this->config['database']
         ));
         $columnWithComment = $rows[1];
 
@@ -2140,7 +2087,7 @@ OUTPUT;
 
         $countQuery = $this->adapter->query('SELECT COUNT(*) FROM table1');
         $this->assertTrue($countQuery->execute());
-        $res = $countQuery->fetchAll();
+        $res = $countQuery->fetchAll('assoc');
         $this->assertEquals(0, $res[0]['COUNT(*)']);
     }
 
@@ -2181,7 +2128,7 @@ OUTPUT;
 
         $countQuery = $this->adapter->query('SELECT COUNT(*) FROM table1');
         $this->assertTrue($countQuery->execute());
-        $res = $countQuery->fetchAll();
+        $res = $countQuery->fetchAll('assoc');
         $this->assertEquals(0, $res[0]['COUNT(*)']);
     }
 
@@ -2214,31 +2161,6 @@ OUTPUT;
         $expectedOutput = preg_replace('~\R~u', '', $expectedOutput);
         $actualOutput = preg_replace('~\R~u', '', $actualOutput);
         $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
-    }
-
-    public function testDumpTransaction()
-    {
-        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
-        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
-
-        $consoleOutput = new BufferedOutput();
-        $this->adapter->setOutput($consoleOutput);
-
-        $this->adapter->beginTransaction();
-        $table = new Table('table1', [], $this->adapter);
-
-        $table->addColumn('column1', 'string')
-            ->addColumn('column2', 'integer')
-            ->addColumn('column3', 'string', ['default' => 'test'])
-            ->save();
-        $this->adapter->commitTransaction();
-        $this->adapter->rollbackTransaction();
-
-        $actualOutput = $consoleOutput->fetch();
-        // Add this to be LF - CR/LF systems independent
-        $actualOutput = preg_replace('~\R~u', '', $actualOutput);
-        $this->assertStringStartsWith('START TRANSACTION;', $actualOutput, 'Passing the --dry-run doesn\'t dump the transaction to the output');
-        $this->assertStringEndsWith('COMMIT;ROLLBACK;', $actualOutput, 'Passing the --dry-run doesn\'t dump the transaction to the output');
     }
 
     /**
@@ -2304,13 +2226,13 @@ OUTPUT;
         ]);
 
         $countQuery = $this->adapter->query('SELECT COUNT(*) AS c FROM table1 WHERE int_col > ?', [5]);
-        $res = $countQuery->fetchAll();
+        $res = $countQuery->fetchAll('assoc');
         $this->assertEquals(2, $res[0]['c']);
 
         $this->adapter->execute('UPDATE table1 SET int_col = ? WHERE int_col IS NULL', [12]);
 
         $countQuery->execute([1]);
-        $res = $countQuery->fetchAll();
+        $res = $countQuery->fetchAll('assoc');
         $this->assertEquals(3, $res[0]['c']);
     }
 
@@ -2453,29 +2375,10 @@ INPUT;
 
         $rows = $this->adapter->fetchAll(sprintf(
             "SELECT COLUMN_DEFAULT FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='exampleCurrentTimestamp3'",
-            $this->config['name']
+            $this->config['database']
         ));
         $colDef = $rows[0];
         $this->assertEqualsIgnoringCase('CURRENT_TIMESTAMP(3)', $colDef['COLUMN_DEFAULT']);
-    }
-
-    public static function pdoAttributeProvider()
-    {
-        return [
-            ['mysql_attr_invalid'],
-            ['attr_invalid'],
-        ];
-    }
-
-    /**
-     * @dataProvider pdoAttributeProvider
-     */
-    public function testInvalidPdoAttribute($attribute)
-    {
-        $adapter = new MysqlAdapter($this->config + [$attribute => true]);
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('Invalid PDO attribute: ' . $attribute . ' (\PDO::' . strtoupper($attribute) . ')');
-        $adapter->connect();
     }
 
     public static function integerDataTypesSQLProvider()
@@ -2515,17 +2418,5 @@ INPUT;
 
         $this->assertSame($expectedResponse['name'], $result['name'], "Type mismatch - got '{$result['name']}' when expecting '{$expectedResponse['name']}'");
         $this->assertSame($expectedResponse['limit'], $result['limit'], "Field upper boundary mismatch - got '{$result['limit']}' when expecting '{$expectedResponse['limit']}'");
-    }
-
-    public function testPdoPersistentConnection()
-    {
-        $adapter = new MysqlAdapter($this->config + ['attr_persistent' => true]);
-        $this->assertTrue($adapter->getConnection()->getAttribute(PDO::ATTR_PERSISTENT));
-    }
-
-    public function testPdoNotPersistentConnection()
-    {
-        $adapter = new MysqlAdapter($this->config);
-        $this->assertFalse($adapter->getConnection()->getAttribute(PDO::ATTR_PERSISTENT));
     }
 }

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -22,7 +22,6 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
-use UnexpectedValueException;
 
 class MysqlAdapterTest extends TestCase
 {

--- a/tests/TestCase/Db/Adapter/PdoAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PdoAdapterTest.php
@@ -40,17 +40,6 @@ class PdoAdapterTest extends TestCase
         $this->assertEquals('schema_table_test', $this->adapter->getSchemaTableName());
     }
 
-    public function testOptionsSetDefaultMigrationTableThrowsDeprecation()
-    {
-        $this->markTestIncomplete('Deprecation assertions are not supported in PHPUnit anymore. We need to adopt the cakephp TestSuite class instead');
-        $this->assertEquals('phinxlog', $this->adapter->getSchemaTableName());
-
-        $this->expectDeprecation();
-        $this->expectExceptionMessage('The default_migration_table setting for adapter has been deprecated since 0.13.0. Use `migration_table` instead.');
-        $this->adapter->setOptions(['default_migration_table' => 'schema_table_test']);
-        $this->assertEquals('schema_table_test', $this->adapter->getSchemaTableName());
-    }
-
     public function testSchemaTableName()
     {
         $this->assertEquals('phinxlog', $this->adapter->getSchemaTableName());
@@ -168,43 +157,5 @@ class PdoAdapterTest extends TestCase
             ->will($this->throwException(new PDOException()));
 
         $this->assertEquals([], $adapter->getVersionLog());
-    }
-
-    /**
-     * Tests that execute() can be called on the adapter, and that the SQL is passed through to the PDO.
-     */
-    public function testExecuteCanBeCalled()
-    {
-        /** @var \PDO&\PHPUnit\Framework\MockObject\MockObject $pdo */
-        $pdo = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->onlyMethods(['exec'])->getMock();
-        $pdo->expects($this->once())->method('exec')->with('SELECT 1;')->will($this->returnValue(1));
-
-        $this->adapter->setConnection($pdo);
-        $this->adapter->execute('SELECT 1');
-    }
-
-    public function testExecuteRightTrimsSemiColons()
-    {
-        /** @var \PDO&\PHPUnit\Framework\MockObject\MockObject $pdo */
-        $pdo = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->onlyMethods(['exec'])->getMock();
-        $pdo->expects($this->once())->method('exec')->with('SELECT 1;')->will($this->returnValue(1));
-
-        $this->adapter->setConnection($pdo);
-        $this->adapter->execute('SELECT 1;;');
-    }
-
-    public function testQueryBuilderMethods()
-    {
-        $result = $this->adapter->getSelectBuilder();
-        $this->assertNotEmpty($result);
-
-        $result = $this->adapter->getUpdateBuilder();
-        $this->assertNotEmpty($result);
-
-        $result = $this->adapter->getDeleteBuilder();
-        $this->assertNotEmpty($result);
-
-        $result = $this->adapter->getInsertBuilder();
-        $this->assertNotEmpty($result);
     }
 }

--- a/tests/TestCase/Db/Adapter/PdoAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PdoAdapterTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Migrations\Test\Db\Adapter;
 
-use PDO;
 use PDOException;
 use Phinx\Config\Config;
 use PHPUnit\Framework\TestCase;

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -21,7 +21,6 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
-use UnexpectedValueException;
 
 class PostgresAdapterTest extends TestCase
 {

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -16,7 +16,6 @@ use Migrations\Db\Literal;
 use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
-use PDO;
 use PDOException;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
@@ -26,7 +25,6 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
-use UnexpectedValueException;
 
 class SqliteAdapterTest extends TestCase
 {

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Migrations\Test\Db\Adapter;
 
 use BadMethodCallException;
+use Cake\Database\Connection;
 use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
 use Exception;
@@ -29,34 +30,32 @@ use UnexpectedValueException;
 
 class SqliteAdapterTest extends TestCase
 {
+    private array $config;
+
     /**
      * @var \Migrations\Db\Adapter\SqliteAdapter
      */
     private $adapter;
 
-    /**
-     * @var array
-     */
-    private $config;
-
     protected function setUp(): void
     {
+        /** @var array<string, mixed> $config */
         $config = ConnectionManager::getConfig('test');
-        // Emulate the results of Util::parseDsn()
-        $this->config = [
-            'adapter' => $config['scheme'],
-            'host' => $config['host'],
-            'name' => $config['database'],
-        ];
-        if ($this->config['adapter'] !== 'sqlite') {
+        if ($config['scheme'] !== 'sqlite') {
             $this->markTestSkipped('SQLite tests disabled.');
         }
+        $this->config = [
+            'adapter' => 'sqlite',
+            'suffix' => '',
+            'connection' => ConnectionManager::get('test'),
+            'database' => $config['database'],
+        ];
         $this->adapter = new SqliteAdapter($this->config, new ArrayInput([]), new NullOutput());
 
-        if ($this->config['name'] !== ':memory:') {
+        if ($config['database'] !== ':memory:') {
             // ensure the database is empty for each test
-            $this->adapter->dropDatabase($this->config['name']);
-            $this->adapter->createDatabase($this->config['name']);
+            $this->adapter->dropDatabase($config['database']);
+            $this->adapter->createDatabase($config['database']);
         }
 
         // leave the adapter in a disconnected state for each test
@@ -70,17 +69,7 @@ class SqliteAdapterTest extends TestCase
 
     public function testConnection()
     {
-        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
-        $this->assertSame(PDO::ERRMODE_EXCEPTION, $this->adapter->getConnection()->getAttribute(PDO::ATTR_ERRMODE));
-    }
-
-    public function testConnectionWithFetchMode()
-    {
-        $options = $this->adapter->getOptions();
-        $options['fetch_mode'] = 'assoc';
-        $this->adapter->setOptions($options);
-        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
-        $this->assertSame(PDO::FETCH_ASSOC, $this->adapter->getConnection()->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE));
+        $this->assertInstanceOf(Connection::class, $this->adapter->getConnection());
     }
 
     public function testBeginTransaction()
@@ -95,8 +84,6 @@ class SqliteAdapterTest extends TestCase
 
     public function testRollbackTransaction()
     {
-        $this->adapter->getConnection()
-            ->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $this->adapter->beginTransaction();
         $this->adapter->rollbackTransaction();
 
@@ -108,8 +95,6 @@ class SqliteAdapterTest extends TestCase
 
     public function testCommitTransactionTransaction()
     {
-        $this->adapter->getConnection()
-            ->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $this->adapter->beginTransaction();
         $this->adapter->commitTransaction();
 
@@ -284,11 +269,6 @@ class SqliteAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasIndex('table1', ['email']));
         $this->assertFalse($this->adapter->hasIndex('table1', ['email', 'user_email']));
         $this->assertTrue($this->adapter->hasIndexByName('table1', 'myemailindex'));
-    }
-
-    public function testCreateTableWithMultiplePKsAndUniqueIndexes()
-    {
-        $this->markTestIncomplete();
     }
 
     public function testCreateTableWithForeignKey()
@@ -1583,11 +1563,11 @@ class SqliteAdapterTest extends TestCase
 
     public function testHasDatabase()
     {
-        if ($this->config['name'] === ':memory:') {
+        if ($this->config['database'] === ':memory:') {
             $this->markTestSkipped('Skipping hasDatabase() when testing in-memory db.');
         }
         $this->assertFalse($this->adapter->hasDatabase('fake_database_name'));
-        $this->assertTrue($this->adapter->hasDatabase($this->config['name']));
+        $this->assertTrue($this->adapter->hasDatabase($this->config['database']));
     }
 
     public function testDropDatabase()
@@ -1759,8 +1739,6 @@ class SqliteAdapterTest extends TestCase
 
     public function testNullWithoutDefaultValue()
     {
-        $this->markTestSkipped('Skipping for now. See Github Issue #265.');
-
         // construct table with default/null combinations
         $table = new Table('table1', [], $this->adapter);
         $table->addColumn('aa', 'string', ['null' => true]) // no default value
@@ -1860,7 +1838,7 @@ OUTPUT;
         $countQuery = $this->adapter->query('SELECT COUNT(*) FROM table1');
         $this->assertTrue($countQuery->execute());
         $res = $countQuery->fetchAll();
-        $this->assertEquals(0, $res[0]['COUNT(*)']);
+        $this->assertEquals(0, $res[0][0]);
     }
 
     /**
@@ -1901,7 +1879,7 @@ OUTPUT;
         $countQuery = $this->adapter->query('SELECT COUNT(*) FROM table1');
         $this->assertTrue($countQuery->execute());
         $res = $countQuery->fetchAll();
-        $this->assertEquals(0, $res[0]['COUNT(*)']);
+        $this->assertEquals(0, $res[0][0]);
     }
 
     public function testDumpCreateTableAndThenInsert()
@@ -1998,13 +1976,13 @@ OUTPUT;
         ]);
 
         $countQuery = $this->adapter->query('SELECT COUNT(*) AS c FROM table1 WHERE int_col > ?', [5]);
-        $res = $countQuery->fetchAll();
+        $res = $countQuery->fetchAll('assoc');
         $this->assertEquals(2, $res[0]['c']);
 
         $this->adapter->execute('UPDATE table1 SET int_col = ? WHERE int_col IS NULL', [12]);
 
         $countQuery->execute([1]);
-        $res = $countQuery->fetchAll();
+        $res = $countQuery->fetchAll('assoc');
         $this->assertEquals(3, $res[0]['c']);
     }
 
@@ -2306,11 +2284,11 @@ INPUT;
     {
         // Test case for issue #1535
         $conn = $this->adapter->getConnection();
-        $conn->exec('ATTACH DATABASE \':memory:\' as etc');
-        $conn->exec('ATTACH DATABASE \':memory:\' as "main.db"');
-        $conn->exec(sprintf('DROP TABLE IF EXISTS %s', $createName));
+        $conn->execute('ATTACH DATABASE \':memory:\' as etc');
+        $conn->execute('ATTACH DATABASE \':memory:\' as "main.db"');
+        $conn->execute(sprintf('DROP TABLE IF EXISTS %s', $createName));
         $this->assertFalse($this->adapter->hasTable($tableName), sprintf('Adapter claims table %s exists when it does not', $tableName));
-        $conn->exec(sprintf('CREATE TABLE %s (a text)', $createName));
+        $conn->execute(sprintf('CREATE TABLE %s (a text)', $createName));
         if ($exp == true) {
             $this->assertTrue($this->adapter->hasTable($tableName), sprintf('Adapter claims table %s does not exist when it does', $tableName));
         } else {
@@ -2358,7 +2336,17 @@ INPUT;
     public function testHasIndex($tableDef, $cols, $exp)
     {
         $conn = $this->adapter->getConnection();
-        $conn->exec($tableDef);
+        if (strpos($tableDef, ';') !== false) {
+            $queries = explode(';', $tableDef);
+            foreach ($queries as $query) {
+                $stmt = $conn->execute($query);
+                $stmt->closeCursor();
+            }
+        } else {
+            $stmt = $conn->execute($tableDef);
+            $stmt->closeCursor();
+        }
+
         $this->assertEquals($exp, $this->adapter->hasIndex('t', $cols));
     }
 
@@ -2366,7 +2354,7 @@ INPUT;
     {
         return [
             ['create table t(a text)', 'a', false],
-            ['create table t(a text); create index test on t(a);', 'a', true],
+            ['create table t(a text); create index test on t(a)', 'a', true],
             ['create table t(a text unique)', 'a', true],
             ['create table t(a text primary key)', 'a', true],
             ['create table t(a text unique, b text unique)', ['a', 'b'], false],
@@ -2393,7 +2381,16 @@ INPUT;
     public function testHasIndexByName($tableDef, $index, $exp)
     {
         $conn = $this->adapter->getConnection();
-        $conn->exec($tableDef);
+        if (strpos($tableDef, ';') !== false) {
+            $queries = explode(';', $tableDef);
+            foreach ($queries as $query) {
+                $stmt = $conn->execute($query);
+                $stmt->closeCursor();
+            }
+        } else {
+            $stmt = $conn->execute($tableDef);
+            $stmt->closeCursor();
+        }
         $this->assertEquals($exp, $this->adapter->hasIndexByName('t', $index));
     }
 
@@ -2401,12 +2398,12 @@ INPUT;
     {
         return [
             ['create table t(a text)', 'test', false],
-            ['create table t(a text); create index test on t(a);', 'test', true],
-            ['create table t(a text); create index test on t(a);', 'TEST', true],
-            ['create table t(a text); create index "TEST" on t(a);', 'test', true],
+            ['create table t(a text); create index test on t(a)', 'test', true],
+            ['create table t(a text); create index test on t(a)', 'TEST', true],
+            ['create table t(a text); create index "TEST" on t(a)', 'test', true],
             ['create table t(a text unique)', 'sqlite_autoindex_t_1', true],
             ['create table t(a text primary key)', 'sqlite_autoindex_t_1', true],
-            ['create table not_t(a text); create index test on not_t(a);', 'test', false], // test checks table t which does not exist
+            ['create table not_t(a text); create index test on not_t(a)', 'test', false], // test checks table t which does not exist
             ['create table t(a text unique); create temp table t(a text)', 'sqlite_autoindex_t_1', false],
         ];
     }
@@ -2422,7 +2419,16 @@ INPUT;
     {
         $this->assertFalse($this->adapter->hasTable('t'), 'Dirty test fixture');
         $conn = $this->adapter->getConnection();
-        $conn->exec($tableDef);
+        if (strpos($tableDef, ';') !== false) {
+            $queries = explode(';', $tableDef);
+            foreach ($queries as $query) {
+                $stmt = $conn->execute($query);
+                $stmt->closeCursor();
+            }
+        } else {
+            $stmt = $conn->execute($tableDef);
+            $stmt->closeCursor();
+        }
         $this->assertSame($exp, $this->adapter->hasPrimaryKey('t', $key));
     }
 
@@ -2488,8 +2494,18 @@ INPUT;
     public function testHasForeignKey($tableDef, $key, $exp)
     {
         $conn = $this->adapter->getConnection();
-        $conn->exec('CREATE TABLE other(a integer, b integer, c integer)');
-        $conn->exec($tableDef);
+        $conn->execute('CREATE TABLE other(a integer, b integer, c integer)');
+        if (strpos($tableDef, ';') !== false) {
+            $queries = explode(';', $tableDef);
+            foreach ($queries as $query) {
+                $stmt = $conn->execute($query);
+                $stmt->closeCursor();
+            }
+        } else {
+            $stmt = $conn->execute($tableDef);
+            $stmt->closeCursor();
+        }
+
         $this->assertSame($exp, $this->adapter->hasForeignKey('t', $key));
     }
 
@@ -2929,7 +2945,17 @@ INPUT;
     public function testHasColumn($tableDef, $col, $exp)
     {
         $conn = $this->adapter->getConnection();
-        $conn->exec($tableDef);
+        if (strpos($tableDef, ';') !== false) {
+            $queries = explode(';', $tableDef);
+            foreach ($queries as $query) {
+                $stmt = $conn->execute($query);
+                $stmt->closeCursor();
+            }
+        } else {
+            $stmt = $conn->execute($tableDef);
+            $stmt->closeCursor();
+        }
+
         $this->assertEquals($exp, $this->adapter->hasColumn('t', $col));
     }
 
@@ -2960,7 +2986,7 @@ INPUT;
     public function testGetColumns()
     {
         $conn = $this->adapter->getConnection();
-        $conn->exec('create table t(a integer, b text, c char(5), d integer(12,6), e integer not null, f integer null)');
+        $conn->execute('create table t(a integer, b text, c char(5), d integer(12,6), e integer not null, f integer null)');
         $exp = [
             ['name' => 'a', 'type' => 'integer', 'null' => true, 'limit' => null, 'precision' => null, 'scale' => null],
             ['name' => 'b', 'type' => 'text', 'null' => true, 'limit' => null, 'precision' => null, 'scale' => null],
@@ -2987,7 +3013,7 @@ INPUT;
     public function testGetColumnsForIdentity($tableDef, $exp)
     {
         $conn = $this->adapter->getConnection();
-        $conn->exec($tableDef);
+        $conn->execute($tableDef);
         $cols = $this->adapter->getColumns('t');
         $act = [];
         foreach ($cols as $col) {
@@ -3019,7 +3045,7 @@ INPUT;
     public function testGetColumnsForDefaults($tableDef, $exp)
     {
         $conn = $this->adapter->getConnection();
-        $conn->exec($tableDef);
+        $conn->execute($tableDef);
         $act = $this->adapter->getColumns('t')[0]->getDefault();
         if (is_object($exp)) {
             $this->assertEquals($exp, $act);
@@ -3096,7 +3122,7 @@ INPUT;
             $this->markTestSkipped('SQLite 3.24.0 or later is required for this test.');
         }
         $conn = $this->adapter->getConnection();
-        $conn->exec($tableDef);
+        $conn->execute($tableDef);
         $act = $this->adapter->getColumns('t')[0]->getDefault();
         if (is_object($exp)) {
             $this->assertEquals($exp, $act);
@@ -3124,16 +3150,17 @@ INPUT;
     public function testTruncateTable($tableDef, $tableName, $tableId)
     {
         $conn = $this->adapter->getConnection();
-        $conn->exec($tableDef);
-        $conn->exec("INSERT INTO $tableId default values");
-        $conn->exec("INSERT INTO $tableId default values");
-        $conn->exec("INSERT INTO $tableId default values");
-        $this->assertEquals(3, $conn->query("select count(*) from $tableId")->fetchColumn(), 'Broken fixture: data were not inserted properly');
-        $this->assertEquals(3, $conn->query("select max(id) from $tableId")->fetchColumn(), 'Broken fixture: data were not inserted properly');
+        $conn->execute($tableDef);
+        $conn->execute("INSERT INTO $tableId default values");
+        $conn->execute("INSERT INTO $tableId default values");
+        $conn->execute("INSERT INTO $tableId default values");
+        $this->assertEquals(3, $conn->execute("select count(*) from $tableId")->fetchColumn(0), 'Broken fixture: data were not inserted properly');
+        $this->assertEquals(3, $conn->execute("select max(id) from $tableId")->fetchColumn(0), 'Broken fixture: data were not inserted properly');
         $this->adapter->truncateTable($tableName);
-        $this->assertEquals(0, $conn->query("select count(*) from $tableId")->fetchColumn(), 'Table was not truncated');
-        $conn->exec("INSERT INTO $tableId default values");
-        $this->assertEquals(1, $conn->query("select max(id) from $tableId")->fetchColumn(), 'Autoincrement was not reset');
+        $this->assertEquals(0, $conn->execute("select count(*) from $tableId")->fetchColumn(0), 'Table was not truncated');
+        $conn->execute("INSERT INTO $tableId default values");
+        $this->assertEquals(1, $conn->execute("select max(id) from $tableId")->fetchColumn(0), 'Autoincrement was not reset');
+        $conn->execute("DROP TABLE $tableId");
     }
 
     /**
@@ -3305,30 +3332,10 @@ INPUT;
         $this->assertStringContainsString("REFERENCES `{$refTable->getName()}` (`id`)", $sql);
     }
 
-    public function testInvalidPdoAttribute()
-    {
-        $adapter = new SqliteAdapter($this->config + ['attr_invalid' => true]);
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('Invalid PDO attribute: attr_invalid (\PDO::ATTR_INVALID)');
-        $adapter->connect();
-    }
-
     public function testPdoExceptionUpdateNonExistingTable()
     {
         $this->expectException(PDOException::class);
         $table = new Table('non_existing_table', [], $this->adapter);
         $table->addColumn('column', 'string')->update();
-    }
-
-    public function testPdoPersistentConnection()
-    {
-        $adapter = new SqliteAdapter($this->config + ['attr_persistent' => true]);
-        $this->assertTrue($adapter->getConnection()->getAttribute(PDO::ATTR_PERSISTENT));
-    }
-
-    public function testPdoNotPersistentConnection()
-    {
-        $adapter = new SqliteAdapter($this->config);
-        $this->assertFalse($adapter->getConnection()->getAttribute(PDO::ATTR_PERSISTENT));
     }
 }

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Migrations\Test\Db\Adapter;
 
 use BadMethodCallException;
+use Cake\Database\Connection;
 use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
 use InvalidArgumentException;
@@ -42,18 +43,16 @@ class SqlserverAdapterTest extends TestCase
         }
         // Emulate the results of Util::parseDsn()
         $this->config = [
-            'adapter' => $config['scheme'],
-            'user' => $config['username'],
-            'pass' => $config['password'],
-            'host' => $config['host'],
-            'name' => $config['database'],
+            'adapter' => 'sqlserver',
+            'connection' => ConnectionManager::get('test'),
+            'database' => $config['database'],
         ];
 
         $this->adapter = new SqlserverAdapter($this->config, new ArrayInput([]), new NullOutput());
 
         // ensure the database is empty for each test
-        $this->adapter->dropDatabase($this->config['name']);
-        $this->adapter->createDatabase($this->config['name']);
+        $this->adapter->dropDatabase($this->config['database']);
+        $this->adapter->createDatabase($this->config['database']);
 
         // leave the adapter in a disconnected state for each test
         $this->adapter->disconnect();
@@ -69,56 +68,7 @@ class SqlserverAdapterTest extends TestCase
 
     public function testConnection()
     {
-        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
-        $this->assertSame(PDO::ERRMODE_EXCEPTION, $this->adapter->getConnection()->getAttribute(PDO::ATTR_ERRMODE));
-    }
-
-    public function testConnectionWithDsnOptions()
-    {
-        $options = $this->adapter->getOptions();
-        $options['dsn_options'] = ['TrustServerCertificate' => 'true'];
-        $this->adapter->setOptions($options);
-        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
-    }
-
-    public function testConnectionWithFetchMode()
-    {
-        $options = $this->adapter->getOptions();
-        $options['fetch_mode'] = 'assoc';
-        $this->adapter->setOptions($options);
-        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
-        $this->assertSame(PDO::FETCH_ASSOC, $this->adapter->getConnection()->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE));
-    }
-
-    public function testConnectionWithoutPort()
-    {
-        $options = $this->adapter->getOptions();
-        unset($options['port']);
-        $this->adapter->setOptions($options);
-        $this->assertInstanceOf('PDO', $this->adapter->getConnection());
-    }
-
-    public function testConnectionWithInvalidCredentials()
-    {
-        $options = ['user' => 'invalid', 'pass' => 'invalid'] + $this->config;
-
-        $adapter = null;
-        try {
-            $adapter = new SqlServerAdapter($options, new ArrayInput([]), new NullOutput());
-            $adapter->connect();
-            $this->fail('Expected the adapter to throw an exception');
-        } catch (InvalidArgumentException $e) {
-            $this->assertInstanceOf(
-                'InvalidArgumentException',
-                $e,
-                'Expected exception of type InvalidArgumentException, got ' . get_class($e)
-            );
-            $this->assertStringContainsString('There was a problem connecting to the database', $e->getMessage());
-        } finally {
-            if (!empty($adapter)) {
-                $adapter->disconnect();
-            }
-        }
+        $this->assertInstanceOf(Connection::class, $this->adapter->getConnection());
     }
 
     public function testCreatingTheSchemaTableOnConnect()
@@ -1047,8 +997,8 @@ WHERE t.name='ntable'");
     public function testHasForeignKey($tableDef, $key, $exp)
     {
         $conn = $this->adapter->getConnection();
-        $conn->exec('CREATE TABLE other(a int, b int, c int, unique(a), unique(b), unique(a,b), unique(a,b,c));');
-        $conn->exec($tableDef);
+        $conn->execute('CREATE TABLE other(a int, b int, c int, unique(a), unique(b), unique(a,b), unique(a,b,c));');
+        $conn->execute($tableDef);
         $this->assertSame($exp, $this->adapter->hasForeignKey('t', $key));
     }
 
@@ -1099,7 +1049,7 @@ WHERE t.name='ntable'");
     public function testHasDatabase()
     {
         $this->assertFalse($this->adapter->hasDatabase('fake_database_name'));
-        $this->assertTrue($this->adapter->hasDatabase($this->config['name']));
+        $this->assertTrue($this->adapter->hasDatabase($this->config['database']));
     }
 
     public function testDropDatabase()
@@ -1334,29 +1284,6 @@ OUTPUT;
         $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
     }
 
-    public function testDumpTransaction()
-    {
-        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
-        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
-
-        $consoleOutput = new BufferedOutput();
-        $this->adapter->setOutput($consoleOutput);
-
-        $this->adapter->beginTransaction();
-        $table = new Table('schema1.table1', [], $this->adapter);
-
-        $table->addColumn('column1', 'string')
-            ->addColumn('column2', 'integer')
-            ->addColumn('column3', 'string', ['default' => 'test'])
-            ->save();
-        $this->adapter->commitTransaction();
-        $this->adapter->rollbackTransaction();
-
-        $actualOutput = str_replace("\r\n", "\n", $consoleOutput->fetch());
-        $this->assertStringStartsWith("BEGIN TRANSACTION;\n", $actualOutput, 'Passing the --dry-run doesn\'t dump the transaction to the output');
-        $this->assertStringEndsWith("COMMIT TRANSACTION;\nROLLBACK TRANSACTION;\n", $actualOutput, 'Passing the --dry-run doesn\'t dump the transaction to the output');
-    }
-
     /**
      * Tests interaction with the query builder
      */
@@ -1422,13 +1349,13 @@ OUTPUT;
         ]);
 
         $countQuery = $this->adapter->query('SELECT COUNT(*) AS c FROM table1 WHERE int_col > ?', [5]);
-        $res = $countQuery->fetchAll();
+        $res = $countQuery->fetchAll('assoc');
         $this->assertEquals(2, $res[0]['c']);
 
         $this->adapter->execute('UPDATE table1 SET int_col = ? WHERE int_col IS NULL', [12]);
 
         $countQuery->execute([1]);
-        $res = $countQuery->fetchAll();
+        $res = $countQuery->fetchAll('assoc');
         $this->assertEquals(3, $res[0]['c']);
     }
 
@@ -1442,24 +1369,5 @@ INPUT;
         $columns = $table->getColumns();
         $this->assertCount(1, $columns);
         $this->assertEquals(Literal::from('smallmoney'), array_pop($columns)->getType());
-    }
-
-    public static function pdoAttributeProvider()
-    {
-        return [
-            ['sqlsrv_attr_invalid'],
-            ['attr_invalid'],
-        ];
-    }
-
-    /**
-     * @dataProvider pdoAttributeProvider
-     */
-    public function testInvalidPdoAttribute($attribute)
-    {
-        $adapter = new SqlServerAdapter($this->config + [$attribute => true]);
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('Invalid PDO attribute: ' . $attribute . ' (\PDO::' . strtoupper($attribute) . ')');
-        $adapter->connect();
     }
 }

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -13,7 +13,6 @@ use Migrations\Db\Literal;
 use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
-use PDO;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -21,7 +20,6 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
-use UnexpectedValueException;
 
 class SqlserverAdapterTest extends TestCase
 {

--- a/tests/TestCase/Migration/EnvironmentTest.php
+++ b/tests/TestCase/Migration/EnvironmentTest.php
@@ -77,7 +77,7 @@ class EnvironmentTest extends TestCase
         $config = ConnectionManager::getConfig('test');
         $environment = new Environment('default', [
             'connection' => 'test',
-            'name' => $config['database'],
+            'database' => $config['database'],
             'migration_table' => 'phinxlog',
         ]);
         $adapter = $environment->getAdapter();

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -2592,6 +2592,7 @@ class ManagerTest extends TestCase
         $adapter = $this->prepareEnvironment([
             'migrations' => ROOT . '/config/Postgres',
         ]);
+        $adapter->connect();
         // migrate to the latest version
         $this->manager->migrate();
 

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -78,13 +78,8 @@ class ManagerTest extends TestCase
         $dbConfig = ConnectionManager::getConfig('test');
         $config = [
             'connection' => 'test',
+            'database' => $dbConfig['database'],
             'migration_table' => 'phinxlog',
-            // TODO all of these should go away.
-            'adapter' => $dbConfig['scheme'],
-            'user' => $dbConfig['username'] ?? null,
-            'pass' => $dbConfig['password'] ?? null,
-            'host' => $dbConfig['host'],
-            'name' => $dbConfig['database'],
         ];
 
         return [
@@ -2639,6 +2634,7 @@ class ManagerTest extends TestCase
         $adapter->dropDatabase($dbName);
         $adapter->createDatabase($dbName);
         $adapter->disconnect();
+        $adapter->connect();
 
         $this->manager->setConfig($config);
         $this->manager->migrate(20190928205056);

--- a/tests/TestCase/TestSuite/MigratorTest.php
+++ b/tests/TestCase/TestSuite/MigratorTest.php
@@ -32,8 +32,10 @@ class MigratorTest extends TestCase
     {
         parent::setUp();
 
-        $this->restore = $GLOBALS['__PHPUNIT_BOOTSTRAP'];
-        unset($GLOBALS['__PHPUNIT_BOOTSTRAP']);
+        if (isset($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
+            $this->restore = $GLOBALS['__PHPUNIT_BOOTSTRAP'];
+            unset($GLOBALS['__PHPUNIT_BOOTSTRAP']);
+        }
 
         (new ConnectionHelper())->dropTables('test');
     }
@@ -41,7 +43,10 @@ class MigratorTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        $GLOBALS['__PHPUNIT_BOOTSTRAP'] = $this->restore;
+        if ($this->restore) {
+            $GLOBALS['__PHPUNIT_BOOTSTRAP'] = $this->restore;
+            unset($this->restore);
+        }
 
         (new ConnectionHelper())->dropTables('test');
     }


### PR DESCRIPTION
Remove usage of `PDO` within `Adapter` classes. We can use the `Connection` abstractions provided by `Cake\Database` instead. There is a potentially significant change around `adapter->query()` as it now returns Cake statement wrappers which default to numeric field fetching instead of 'assoc' fetching like phinx did.

There is more that could be done around using `Connection` better as there is still a lot of string interpolation in query building instead of using prepared statements and lots of duplication between what phinx was doing and what cake's database layer does.

Part of #647 