### PR TITLE
Remove Symfony/Console from Manager and Adapter

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,6 +61,11 @@ parameters:
 			path: src/Db/Adapter/SqlserverAdapter.php
 
 		-
+			message: "#^Method Migrations\\\\Shim\\\\OutputAdapter\\:\\:getVerbosity\\(\\) should return 16\\|32\\|64\\|128\\|256 but returns int\\.$#"
+			count: 1
+			path: src/Shim/OutputAdapter.php
+
+		-
 			message: "#^Possibly invalid array key type Cake\\\\Database\\\\Schema\\\\TableSchemaInterface\\|string\\.$#"
 			count: 2
 			path: src/View/Helper/MigrationHelper.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -70,12 +70,6 @@
     <DeprecatedMethod>
       <code>getQueryBuilder</code>
     </DeprecatedMethod>
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$this->getAdapter()->setIo($io)]]></code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType>
-      <code>setIo</code>
-    </MoreSpecificReturnType>
   </file>
   <file src="src/Db/Adapter/MysqlAdapter.php">
     <RedundantCondition>
@@ -150,10 +144,6 @@
     <MoreSpecificReturnType>
       <code>self::VERBOSITY_*</code>
     </MoreSpecificReturnType>
-    <PossiblyInvalidArgument>
-      <code>$messages</code>
-      <code>$messages</code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="src/TableFinderTrait.php">
     <PossiblyUndefinedArrayOffset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -57,7 +57,8 @@
   </file>
   <file src="src/Db/Adapter/AbstractAdapter.php">
     <RedundantPropertyInitializationCheck>
-      <code><![CDATA[isset($this->output)]]></code>
+      <code><![CDATA[$this->io]]></code>
+      <code>null</code>
     </RedundantPropertyInitializationCheck>
   </file>
   <file src="src/Db/Adapter/AdapterFactory.php">
@@ -69,12 +70,12 @@
     <DeprecatedMethod>
       <code>getQueryBuilder</code>
     </DeprecatedMethod>
-    <InvalidNullableReturnType>
-      <code>InputInterface</code>
-    </InvalidNullableReturnType>
-    <NullableReturnStatement>
-      <code><![CDATA[$this->adapter->getInput()]]></code>
-    </NullableReturnStatement>
+    <LessSpecificReturnStatement>
+      <code><![CDATA[$this->getAdapter()->setIo($io)]]></code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType>
+      <code>setIo</code>
+    </MoreSpecificReturnType>
   </file>
   <file src="src/Db/Adapter/MysqlAdapter.php">
     <RedundantCondition>
@@ -117,6 +118,9 @@
       <code>$columns</code>
       <code>$newColumns</code>
     </MissingParamType>
+    <PossiblyNullReference>
+      <code>verbose</code>
+    </PossiblyNullReference>
   </file>
   <file src="src/Migration/Environment.php">
     <RedundantPropertyInitializationCheck>
@@ -138,6 +142,18 @@
     <DeprecatedTrait>
       <code>ConfigurationTrait</code>
     </DeprecatedTrait>
+  </file>
+  <file src="src/Shim/OutputAdapter.php">
+    <LessSpecificReturnStatement>
+      <code><![CDATA[$this->io->level()]]></code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType>
+      <code>self::VERBOSITY_*</code>
+    </MoreSpecificReturnType>
+    <PossiblyInvalidArgument>
+      <code>$messages</code>
+      <code>$messages</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/TableFinderTrait.php">
     <PossiblyUndefinedArrayOffset>

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -23,8 +23,6 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Inflector;
 use Migrations\Config\Config;
 use Migrations\Migration\Manager;
-use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Output\StreamOutput;
 
 /**
  * Status command for built in backend
@@ -135,7 +133,7 @@ class StatusCommand extends Command
             'connection' => $connectionName,
             'database' => $connectionConfig['database'],
             'migration_table' => $table,
-            'dryrun' => $args->getOption('dry-run')
+            'dryrun' => $args->getOption('dry-run'),
         ];
 
         $configData = [

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -162,7 +162,7 @@ class StatusCommand extends Command
     {
         $config = $this->getConfig($args);
 
-        return new Manager($config, new ArgvInput(), new StreamOutput(STDOUT));
+        return new Manager($config, $io);
     }
 
     /**
@@ -176,7 +176,7 @@ class StatusCommand extends Command
     {
         /** @var string|null $format */
         $format = $args->getOption('format');
-        $migrations = $this->getManager($args)->printStatus($format);
+        $migrations = $this->getManager($args, $io)->printStatus($format);
 
         switch ($format) {
             case 'json':

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -135,6 +135,7 @@ class StatusCommand extends Command
             'connection' => $connectionName,
             'database' => $connectionConfig['database'],
             'migration_table' => $table,
+            'dryrun' => $args->getOption('dry-run')
         ];
 
         $configData = [
@@ -156,9 +157,10 @@ class StatusCommand extends Command
      * Get the migration manager for the current CLI options and application configuration.
      *
      * @param \Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\ConsoleIo $io The command io.
      * @return \Migrations\Migration\Manager
      */
-    protected function getManager(Arguments $args): Manager
+    protected function getManager(Arguments $args, ConsoleIo $io): Manager
     {
         $config = $this->getConfig($args);
 

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -8,14 +8,13 @@ declare(strict_types=1);
 
 namespace Migrations\Db\Adapter;
 
+use Cake\Console\ConsoleIo;
 use Exception;
 use InvalidArgumentException;
 use Migrations\Db\Literal;
 use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\NullOutput;
-use Symfony\Component\Console\Output\OutputInterface;
+use RuntimeException;
 
 /**
  * Base Abstract Database Adapter.
@@ -28,14 +27,9 @@ abstract class AbstractAdapter implements AdapterInterface
     protected array $options = [];
 
     /**
-     * @var \Symfony\Component\Console\Input\InputInterface|null
+     * @var \Cake\Console\ConsoleIo
      */
-    protected ?InputInterface $input = null;
-
-    /**
-     * @var \Symfony\Component\Console\Output\OutputInterface
-     */
-    protected OutputInterface $output;
+    protected ConsoleIo $io;
 
     /**
      * @var string[]
@@ -56,17 +50,13 @@ abstract class AbstractAdapter implements AdapterInterface
      * Class Constructor.
      *
      * @param array<string, mixed> $options Options
-     * @param \Symfony\Component\Console\Input\InputInterface|null $input Input Interface
-     * @param \Symfony\Component\Console\Output\OutputInterface|null $output Output Interface
+     * @param \Cake\Console\ConsoleIo|null $io Console input/output
      */
-    public function __construct(array $options, ?InputInterface $input = null, ?OutputInterface $output = null)
+    public function __construct(array $options, ?ConsoleIo $io = null)
     {
         $this->setOptions($options);
-        if ($input !== null) {
-            $this->setInput($input);
-        }
-        if ($output !== null) {
-            $this->setOutput($output);
+        if ($io !== null) {
+            $this->setIo($io);
         }
     }
 
@@ -117,9 +107,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function setInput(InputInterface $input): AdapterInterface
     {
-        $this->input = $input;
-
-        return $this;
+        throw new RuntimeException('Using setInput() interface is not supported.');
     }
 
     /**
@@ -127,7 +115,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function getInput(): ?InputInterface
     {
-        return $this->input;
+        throw new RuntimeException('Using getInput() interface is not supported.');
     }
 
     /**
@@ -243,6 +231,25 @@ abstract class AbstractAdapter implements AdapterInterface
     public function isValidColumnType(Column $column): bool
     {
         return $column->getType() instanceof Literal || in_array($column->getType(), $this->getColumnTypes(), true);
+    }
+
+
+    /**
+ * @inheritDoc
+     */
+    public function setIo(ConsoleIo $io)
+    {
+        $this->io = $io;
+
+        return $this;
+    }
+
+    /**
+ * @inheritDoc
+     */
+    public function getIo(): ?ConsoleIo
+    {
+        return $this->io;
     }
 
     /**

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -16,6 +16,7 @@ use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use Migrations\Shim\OutputAdapter;
 use RuntimeException;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -228,9 +229,8 @@ abstract class AbstractAdapter implements AdapterInterface
         return $column->getType() instanceof Literal || in_array($column->getType(), $this->getColumnTypes(), true);
     }
 
-
     /**
- * @inheritDoc
+     * @inheritDoc
      */
     public function setIo(ConsoleIo $io)
     {
@@ -240,7 +240,7 @@ abstract class AbstractAdapter implements AdapterInterface
     }
 
     /**
- * @inheritDoc
+     * @inheritDoc
      */
     public function getIo(): ?ConsoleIo
     {

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -254,7 +254,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function isDryRunEnabled(): bool
     {
-        return $this->getOption('dry-run') === true;
+        return $this->getOption('dryrun') === true;
     }
 
     /**

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -14,7 +14,9 @@ use InvalidArgumentException;
 use Migrations\Db\Literal;
 use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
+use Migrations\Shim\OutputAdapter;
 use RuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Base Abstract Database Adapter.
@@ -123,9 +125,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function setOutput(OutputInterface $output): AdapterInterface
     {
-        $this->output = $output;
-
-        return $this;
+        throw new RuntimeException('Using setInput() method is not supported');
     }
 
     /**
@@ -133,12 +133,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function getOutput(): OutputInterface
     {
-        if (!isset($this->output)) {
-            $output = new NullOutput();
-            $this->setOutput($output);
-        }
-
-        return $this->output;
+        return new OutputAdapter($this->io);
     }
 
     /**
@@ -249,7 +244,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function getIo(): ?ConsoleIo
     {
-        return $this->io;
+        return $this->io ?? null;
     }
 
     /**
@@ -259,10 +254,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function isDryRunEnabled(): bool
     {
-        /** @var \Symfony\Component\Console\Input\InputInterface|null $input */
-        $input = $this->getInput();
-
-        return $input && $input->hasOption('dry-run') ? (bool)$input->getOption('dry-run') : false;
+        return $this->getOption('dry-run') === true;
     }
 
     /**

--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Migrations\Db\Adapter;
 
+use Cake\Console\ConsoleIo;
 use Cake\Database\Query;
 use Cake\Database\Query\DeleteQuery;
 use Cake\Database\Query\InsertQuery;
@@ -17,8 +18,6 @@ use Migrations\Db\Literal;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\Table;
 use Phinx\Migration\MigrationInterface;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Adapter Interface.
@@ -126,36 +125,6 @@ interface AdapterInterface
      * @return mixed
      */
     public function getOption(string $name): mixed;
-
-    /**
-     * Sets the console input.
-     *
-     * @param \Symfony\Component\Console\Input\InputInterface $input Input
-     * @return $this
-     */
-    public function setInput(InputInterface $input);
-
-    /**
-     * Gets the console input.
-     *
-     * @return \Symfony\Component\Console\Input\InputInterface|null
-     */
-    public function getInput(): ?InputInterface;
-
-    /**
-     * Sets the console output.
-     *
-     * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     * @return $this
-     */
-    public function setOutput(OutputInterface $output);
-
-    /**
-     * Gets the console output.
-     *
-     * @return \Symfony\Component\Console\Output\OutputInterface
-     */
-    public function getOutput(): OutputInterface;
 
     /**
      * Returns a new Migrations\Db\Table\Column using the existent data domain.
@@ -536,4 +505,19 @@ interface AdapterInterface
      * @return mixed
      */
     public function castToBool(mixed $value): mixed;
+
+    /**
+     * Sets the consoleio.
+     *
+     * @param \Cake\Console\ConsoleIo $io ConsoleIo
+     * @return $this
+     */
+    public function setIo(ConsoleIo $io);
+
+    /**
+     * Get the io instance
+     *
+     * @return \Cake\Console\ConsoleIo $io The io instance to use
+     */
+    public function getIo(): ?ConsoleIo;
 }

--- a/src/Db/Adapter/AdapterWrapper.php
+++ b/src/Db/Adapter/AdapterWrapper.php
@@ -490,7 +490,9 @@ abstract class AdapterWrapper implements WrapperInterface
      */
     public function setIo(ConsoleIo $io)
     {
-        return $this->getAdapter()->setIo($io);
+        $this->getAdapter()->setIo($io);
+
+        return $this;
     }
 
     /**

--- a/src/Db/Adapter/AdapterWrapper.php
+++ b/src/Db/Adapter/AdapterWrapper.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Migrations\Db\Adapter;
 
+use Cake\Console\ConsoleIo;
 use Cake\Database\Query;
 use Cake\Database\Query\DeleteQuery;
 use Cake\Database\Query\InsertQuery;
@@ -18,8 +19,6 @@ use Migrations\Db\Table\Column;
 use Migrations\Db\Table\Table;
 use PDO;
 use Phinx\Migration\MigrationInterface;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Adapter Wrapper.
@@ -92,42 +91,6 @@ abstract class AdapterWrapper implements WrapperInterface
     public function getOption(string $name): mixed
     {
         return $this->adapter->getOption($name);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function setInput(InputInterface $input): AdapterInterface
-    {
-        $this->adapter->setInput($input);
-
-        return $this;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getInput(): InputInterface
-    {
-        return $this->adapter->getInput();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function setOutput(OutputInterface $output): AdapterInterface
-    {
-        $this->adapter->setOutput($output);
-
-        return $this;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getOutput(): OutputInterface
-    {
-        return $this->adapter->getOutput();
     }
 
     /**
@@ -520,5 +483,21 @@ abstract class AdapterWrapper implements WrapperInterface
     public function getDeleteBuilder(): DeleteQuery
     {
         return $this->getAdapter()->getDeleteBuilder();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setIo(ConsoleIo $io)
+    {
+        return $this->getAdapter()->setIo($io);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIo(): ?ConsoleIo
+    {
+        return $this->getAdapter()->getIo();
     }
 }

--- a/src/Db/Adapter/PhinxAdapter.php
+++ b/src/Db/Adapter/PhinxAdapter.php
@@ -371,9 +371,7 @@ class PhinxAdapter implements PhinxAdapterInterface
      */
     public function setInput(InputInterface $input): PhinxAdapterInterface
     {
-        $this->adapter->setInput($input);
-
-        return $this;
+        throw new RuntimeException('Using setInput() on Adapters is no longer supported');
     }
 
     /**
@@ -381,12 +379,7 @@ class PhinxAdapter implements PhinxAdapterInterface
      */
     public function getInput(): InputInterface
     {
-        $input = $this->adapter->getInput();
-        if (!$input) {
-            throw new RuntimeException('Cannot getInput it has not been set.');
-        }
-
-        return $input;
+        throw new RuntimeException('Using getInput() on Adapters is no longer supported');
     }
 
     /**
@@ -394,9 +387,7 @@ class PhinxAdapter implements PhinxAdapterInterface
      */
     public function setOutput(OutputInterface $output): PhinxAdapterInterface
     {
-        $this->adapter->setOutput($output);
-
-        return $this;
+        throw new RuntimeException('Using setOutput() on Adapters is no longer supported');
     }
 
     /**
@@ -404,7 +395,7 @@ class PhinxAdapter implements PhinxAdapterInterface
      */
     public function getOutput(): OutputInterface
     {
-        return $this->adapter->getOutput();
+        throw new RuntimeException('Using getOutput() on Adapters is no longer supported');
     }
 
     /**

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -1558,7 +1558,7 @@ class PostgresAdapter extends PdoAdapter
 
         if ($this->isDryRunEnabled()) {
             $sql .= ' ' . $override . 'VALUES (' . implode(', ', array_map([$this, 'quoteValue'], $row)) . ');';
-            $this->output->writeln($sql);
+            $this->io->out($sql);
         } else {
             $sql .= ' ' . $override . 'VALUES (' . implode(', ', array_fill(0, count($columns), '?')) . ')';
             $this->getConnection()->execute($sql, array_values($row));
@@ -1590,7 +1590,7 @@ class PostgresAdapter extends PdoAdapter
                 return '(' . implode(', ', array_map([$this, 'quoteValue'], $row)) . ')';
             }, $rows);
             $sql .= implode(', ', $values) . ';';
-            $this->output->writeln($sql);
+            $this->io->out($sql);
         } else {
             $connection = $this->getConnection();
             $count_keys = count($keys);

--- a/src/Db/Adapter/TimedOutputAdapter.php
+++ b/src/Db/Adapter/TimedOutputAdapter.php
@@ -39,7 +39,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
 
         return function () use ($started): void {
             $end = microtime(true);
-            $this->getIo()->out('    -> ' . sprintf('%.4fs', $end - $started));
+            $this->getIo()?->out('    -> ' . sprintf('%.4fs', $end - $started));
         };
     }
 
@@ -72,7 +72,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
 
                 $outArr[] = '\'' . $arg . '\'';
             }
-            $this->getIo()->verbose(' -- ' . $command . '(' . implode(', ', $outArr) . ')');
+            $this->getIo()?->verbose(' -- ' . $command . '(' . implode(', ', $outArr) . ')');
 
             return;
         }

--- a/src/Db/Adapter/TimedOutputAdapter.php
+++ b/src/Db/Adapter/TimedOutputAdapter.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 namespace Migrations\Db\Adapter;
 
 use BadMethodCallException;
+use Cake\Console\ConsoleIo;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use Migrations\Db\Table\Table;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Wraps any adapter to record the time spend executing its commands
@@ -39,9 +39,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
 
         return function () use ($started): void {
             $end = microtime(true);
-            if (OutputInterface::VERBOSITY_VERBOSE <= $this->getOutput()->getVerbosity()) {
-                $this->getOutput()->writeln('    -> ' . sprintf('%.4fs', $end - $started));
-            }
+            $this->getIo()->out('    -> ' . sprintf('%.4fs', $end - $started));
         };
     }
 
@@ -54,10 +52,10 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      */
     public function writeCommand(string $command, array $args = []): void
     {
-        if (OutputInterface::VERBOSITY_VERBOSE > $this->getOutput()->getVerbosity()) {
+        $io = $this->getIo();
+        if ($io && $io->level() < ConsoleIo::VERBOSE) {
             return;
         }
-
         if (count($args)) {
             $outArr = [];
             foreach ($args as $arg) {
@@ -74,12 +72,12 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
 
                 $outArr[] = '\'' . $arg . '\'';
             }
-            $this->getOutput()->writeln(' -- ' . $command . '(' . implode(', ', $outArr) . ')');
+            $this->getIo()->verbose(' -- ' . $command . '(' . implode(', ', $outArr) . ')');
 
             return;
         }
 
-        $this->getOutput()->writeln(' -- ' . $command);
+        $this->getIo()->verbose(' -- ' . $command);
     }
 
     /**

--- a/src/Migration/Environment.php
+++ b/src/Migration/Environment.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Migrations\Migration;
 
+use Cake\Console\ConsoleIo;
 use Cake\Datasource\ConnectionManager;
 use Migrations\Db\Adapter\AdapterFactory;
 use Migrations\Db\Adapter\AdapterInterface;
@@ -15,8 +16,6 @@ use Migrations\Db\Adapter\PhinxAdapter;
 use Phinx\Migration\MigrationInterface;
 use Phinx\Seed\SeedInterface;
 use RuntimeException;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class Environment
 {
@@ -31,14 +30,9 @@ class Environment
     protected array $options;
 
     /**
-     * @var \Symfony\Component\Console\Input\InputInterface|null
+     * @var \Cake\Console\ConsoleIo|null
      */
-    protected ?InputInterface $input = null;
-
-    /**
-     * @var \Symfony\Component\Console\Output\OutputInterface|null
-     */
-    protected ?OutputInterface $output = null;
+    protected ?ConsoleIo $io = null;
 
     /**
      * @var int
@@ -213,49 +207,26 @@ class Environment
     }
 
     /**
-     * Sets the console input.
+     * Sets the consoleio.
      *
-     * @param \Symfony\Component\Console\Input\InputInterface $input Input
+     * @param \Cake\Console\ConsoleIo $io ConsoleIo
      * @return $this
      */
-    public function setInput(InputInterface $input)
+    public function setIo(ConsoleIo $io)
     {
-        $this->input = $input;
+        $this->io = $io;
 
         return $this;
     }
 
     /**
-     * Gets the console input.
+     * Get the io instance
      *
-     * @return \Symfony\Component\Console\Input\InputInterface|null
+     * @return \Cake\Console\ConsoleIo $io The io instance to use
      */
-    public function getInput(): ?InputInterface
+    public function getIo(): ?ConsoleIo
     {
-        return $this->input;
-    }
-
-    /**
-     * Sets the console output.
-     *
-     * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     * @return $this
-     */
-    public function setOutput(OutputInterface $output)
-    {
-        $this->output = $output;
-
-        return $this;
-    }
-
-    /**
-     * Gets the console output.
-     *
-     * @return \Symfony\Component\Console\Output\OutputInterface|null
-     */
-    public function getOutput(): ?OutputInterface
-    {
-        return $this->output;
+        return $this->io;
     }
 
     /**
@@ -343,9 +314,6 @@ class Environment
         if (!isset($options['connection'])) {
             throw new RuntimeException('No connection defined');
         }
-        // TODO Start here again. Goal is to have Connection go into
-        // AdapterFactory to choose the adapter.
-        // Adapters should use Connection API instead of PDO.
         $connection = ConnectionManager::get($options['connection']);
         $options['connection'] = $connection;
 
@@ -367,16 +335,9 @@ class Environment
                 ->getWrapper($options['wrapper'], $adapter);
         }
 
-        /** @var \Symfony\Component\Console\Input\InputInterface|null $input */
-        $input = $this->getInput();
-        if ($input) {
-            $adapter->setInput($input);
-        }
-
-        /** @var \Symfony\Component\Console\Output\OutputInterface|null $output */
-        $output = $this->getOutput();
-        if ($output) {
-            $adapter->setOutput($output);
+        $io = $this->getIo();
+        if ($io) {
+            $adapter->setIo($io);
         }
         $this->setAdapter($adapter);
 

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -1019,7 +1019,7 @@ class Manager
 
         foreach ($this->seeds as $instance) {
             // TODO fix this to not use input
-            if ($instance instanceof AbstractSeed) {
+            if (isset($input) && $instance instanceof AbstractSeed) {
                 $instance->setInput($input);
             }
         }

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -8,10 +8,12 @@ declare(strict_types=1);
 
 namespace Migrations\Migration;
 
+use Cake\Console\ConsoleIo;
 use DateTime;
 use Exception;
 use InvalidArgumentException;
 use Migrations\Config\ConfigInterface;
+use Migrations\Shim\OutputAdapter;
 use Phinx\Migration\AbstractMigration;
 use Phinx\Migration\MigrationInterface;
 use Phinx\Seed\AbstractSeed;
@@ -19,6 +21,7 @@ use Phinx\Seed\SeedInterface;
 use Phinx\Util\Util;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -34,14 +37,9 @@ class Manager
     protected ConfigInterface $config;
 
     /**
-     * @var \Symfony\Component\Console\Input\InputInterface
+     * @var \Cake\Console\ConsoleIo
      */
-    protected InputInterface $input;
-
-    /**
-     * @var \Symfony\Component\Console\Output\OutputInterface
-     */
-    protected OutputInterface $output;
+    protected ConsoleIo $io;
 
     /**
      * @var \Migrations\Migration\Environment|null
@@ -64,20 +62,13 @@ class Manager
     protected ContainerInterface $container;
 
     /**
-     * @var int
-     */
-    private int $verbosityLevel = OutputInterface::OUTPUT_NORMAL | OutputInterface::VERBOSITY_NORMAL;
-
-    /**
      * @param \Migrations\Config\ConfigInterface $config Configuration Object
-     * @param \Symfony\Component\Console\Input\InputInterface $input Console Input
-     * @param \Symfony\Component\Console\Output\OutputInterface $output Console Output
+     * @param \Cake\Console\ConsoleIo $io Console input/output
      */
-    public function __construct(ConfigInterface $config, InputInterface $input, OutputInterface $output)
+    public function __construct(ConfigInterface $config, ConsoleIo $io)
     {
         $this->setConfig($config);
-        $this->setInput($input);
-        $this->setOutput($output);
+        $this->setIo($io);
     }
 
     /**
@@ -89,7 +80,6 @@ class Manager
      */
     public function printStatus(?string $format = null): array
     {
-        // TODO remove the environment parameter. There is only one environment with builtin
         $migrations = [];
         $isJson = $format === 'json';
         $defaultMigrations = $this->getMigrations();
@@ -148,7 +138,8 @@ class Manager
      */
     protected function printMissingVersion(array $version, int $maxNameLength): void
     {
-        $this->getOutput()->writeln(sprintf(
+        $io = $this->getIo();
+        $io->out(sprintf(
             '     <error>up</error>  %14.0f  %19s  %19s  <comment>%s</comment>  <error>** MISSING MIGRATION FILE **</error>',
             $version['version'],
             $version['start_time'],
@@ -157,7 +148,7 @@ class Manager
         ));
 
         if ($version && $version['breakpoint']) {
-            $this->getOutput()->writeln('         <error>BREAKPOINT SET</error>');
+            $io->out('         <error>BREAKPOINT SET</error>');
         }
     }
 
@@ -182,17 +173,14 @@ class Manager
             }
         }
 
+        $io = $this->getIo();
         if ($versionToMigrate === null) {
-            $this->getOutput()->writeln(
-                'No migrations to run'
-            );
+            $io->out('No migrations to run');
 
             return;
         }
 
-        $this->getOutput()->writeln(
-            'Migrating to version ' . $versionToMigrate
-        );
+        $io->out('Migrating to version ' . $versionToMigrate);
         $this->migrate($versionToMigrate, $fake);
     }
 
@@ -208,13 +196,13 @@ class Manager
         $versions = array_reverse($versions);
 
         if (empty($versions) || $dateString > $versions[0]) {
-            $this->getOutput()->writeln('No migrations to rollback');
+            $this->getIo()->out('No migrations to rollback');
 
             return;
         }
 
         if ($dateString < end($versions)) {
-            $this->getOutput()->writeln('Rolling back all migrations');
+            $this->getIo()->out('Rolling back all migrations');
             $this->rollback(0);
 
             return;
@@ -229,7 +217,7 @@ class Manager
 
         $versionToRollback = $versions[$index];
 
-        $this->getOutput()->writeln('Rolling back to version ' . $versionToRollback);
+        $this->getIo()->out('Rolling back to version ' . $versionToRollback);
         $this->rollback($versionToRollback, $force);
     }
 
@@ -314,6 +302,7 @@ class Manager
         $migrations = $this->getMigrations();
         $versions = array_keys($migrations);
 
+        // TODO use console arguments
         $versionArg = $input->getArgument('version');
         $targetArg = $input->getOption('target');
         $hasAllVersion = in_array($versionArg, ['all', '*'], true);
@@ -354,6 +343,7 @@ class Manager
      */
     public function markVersionsAsMigrated(string $path, array $versions, OutputInterface $output): void
     {
+        // TODO fix output interface usage here
         $adapter = $this->getEnvironment()->getAdapter();
 
         if (!$versions) {
@@ -413,7 +403,7 @@ class Manager
             $version = max(array_merge($versions, array_keys($migrations)));
         } else {
             if ($version != 0 && !isset($migrations[$version])) {
-                $this->output->writeln(sprintf(
+                $this->getIo()->out(sprintf(
                     '<comment>warning</comment> %s is not a valid version',
                     $version
                 ));
@@ -461,8 +451,7 @@ class Manager
      */
     public function executeMigration(MigrationInterface $migration, string $direction = MigrationInterface::UP, bool $fake = false): void
     {
-        // TODO remove the environment parameter. There is only one environment with builtin
-        $this->getOutput()->writeln('', $this->verbosityLevel);
+        $this->getIo()->out('');
 
         // Skip the migration if it should not be executed
         if (!$migration->shouldExecute()) {
@@ -493,7 +482,7 @@ class Manager
      */
     public function executeSeed(SeedInterface $seed): void
     {
-        $this->getOutput()->writeln('', $this->verbosityLevel);
+        $this->getIo()->out('');
 
         // Skip the seed if it should not be executed
         if (!$seed->shouldExecute()) {
@@ -560,11 +549,10 @@ class Manager
      */
     protected function printStatusOutput(string $name, string $status, ?string $duration = null): void
     {
-        $this->getOutput()->writeln(
+        $this->getIo()->out(
             ' ==' .
             ' <info>' . $name . ':</info>' .
             ' <comment>' . $status . ' ' . $duration . '</comment>',
-            $this->verbosityLevel
         );
     }
 
@@ -587,6 +575,7 @@ class Manager
 
         // get a list of migrations sorted in the opposite way of the executed versions
         $sortedMigrations = [];
+        $io = $this->getIo();
 
         foreach ($executedVersions as $versionCreationTime => &$executedVersion) {
             // if we have a date (ie. the target must not match a version) and we are sorting by execution time, we
@@ -619,7 +608,7 @@ class Manager
             if ($found !== false) {
                 $target = (string)$found;
             } else {
-                $this->getOutput()->writeln("<error>No migration found with name ($target)</error>");
+                $io->out("<error>No migration found with name ($target)</error>");
 
                 return;
             }
@@ -628,7 +617,7 @@ class Manager
         // Check we have at least 1 migration to revert
         $executedVersionCreationTimes = array_keys($executedVersions);
         if (empty($executedVersionCreationTimes) || $target == end($executedVersionCreationTimes)) {
-            $this->getOutput()->writeln('<error>No migrations to rollback</error>');
+            $io->out('<error>No migrations to rollback</error>');
 
             return;
         }
@@ -642,7 +631,7 @@ class Manager
 
         // If the target must match a version, check the target version exists
         if ($targetMustMatchVersion && $target !== 0 && !isset($migrations[$target])) {
-            $this->getOutput()->writeln("<error>Target version ($target) not found</error>");
+            $io->out("<error>Target version ($target) not found</error>");
 
             return;
         }
@@ -668,7 +657,7 @@ class Manager
                 }
 
                 if ($executedVersion['breakpoint'] != 0 && !$force) {
-                    $this->getOutput()->writeln('<error>Breakpoint reached. Further rollbacks inhibited.</error>');
+                    $io->out('<error>Breakpoint reached. Further rollbacks inhibited.</error>');
                     break;
                 }
                 $this->executeMigration($migration, MigrationInterface::DOWN, $fake);
@@ -677,7 +666,7 @@ class Manager
         }
 
         if (!$rollbacked) {
-            $this->getOutput()->writeln('<error>No migrations to rollback</error>');
+            $this->getIo()->out('<error>No migrations to rollback</error>');
         }
     }
 
@@ -727,11 +716,33 @@ class Manager
         $envOptions['version_order'] = $config->getVersionOrder();
 
         $environment = new Environment('default', $envOptions);
-        $environment->setInput($this->getInput());
-        $environment->setOutput($this->getOutput());
+        $environment->setIo($this->getIo());
         $this->environment = $environment;
 
         return $environment;
+    }
+
+    /**
+     * Set the io instance
+     *
+     * @param \Cake\Console\ConsoleIo $io The io instance to use
+     * @return $this
+     */
+    public function setIo(ConsoleIo $io)
+    {
+        $this->io = $io;
+
+        return $this;
+    }
+
+    /**
+     * Get the io instance
+     *
+     * @return \Cake\Console\ConsoleIo $io The io instance to use
+     */
+    public function getIo(): ConsoleIo
+    {
+        return $this->io;
     }
 
     /**
@@ -761,52 +772,6 @@ class Manager
     }
 
     /**
-     * Sets the console input.
-     *
-     * @param \Symfony\Component\Console\Input\InputInterface $input Input
-     * @return $this
-     */
-    public function setInput(InputInterface $input)
-    {
-        $this->input = $input;
-
-        return $this;
-    }
-
-    /**
-     * Gets the console input.
-     *
-     * @return \Symfony\Component\Console\Input\InputInterface
-     */
-    public function getInput(): InputInterface
-    {
-        return $this->input;
-    }
-
-    /**
-     * Sets the console output.
-     *
-     * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     * @return $this
-     */
-    public function setOutput(OutputInterface $output)
-    {
-        $this->output = $output;
-
-        return $this;
-    }
-
-    /**
-     * Gets the console output.
-     *
-     * @return \Symfony\Component\Console\Output\OutputInterface
-     */
-    public function getOutput(): OutputInterface
-    {
-        return $this->output;
-    }
-
-    /**
      * Sets the database migrations.
      *
      * @param \Phinx\Migration\AbstractMigration[] $migrations Migrations
@@ -831,28 +796,26 @@ class Manager
         if ($this->migrations === null) {
             $phpFiles = $this->getMigrationFiles();
 
-            if ($this->getOutput()->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG) {
-                $this->getOutput()->writeln('Migration file');
-                $this->getOutput()->writeln(
-                    array_map(
-                        function ($phpFile) {
-                            return "    <info>{$phpFile}</info>";
-                        },
-                        $phpFiles
-                    )
-                );
-            }
+            $io = $this->getIo();
+            $io->verbose('Migration file');
+            $io->verbose(
+                array_map(
+                    function ($phpFile) {
+                        return "    <info>{$phpFile}</info>";
+                    },
+                    $phpFiles
+                )
+            );
 
             // filter the files to only get the ones that match our naming scheme
             $fileNames = [];
             /** @var \Phinx\Migration\AbstractMigration[] $versions */
             $versions = [];
 
+            $io = $this->getIo();
             foreach ($phpFiles as $filePath) {
                 if (Util::isValidMigrationFileName(basename($filePath))) {
-                    if ($this->getOutput()->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG) {
-                        $this->getOutput()->writeln("Valid migration file <info>{$filePath}</info>.");
-                    }
+                    $io->verbose("Valid migration file <info>{$filePath}</info>.");
 
                     $version = Util::getVersionFromFileName(basename($filePath));
 
@@ -873,9 +836,7 @@ class Manager
 
                     $fileNames[$class] = basename($filePath);
 
-                    if ($this->getOutput()->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG) {
-                        $this->getOutput()->writeln("Loading class <info>$class</info> from <info>$filePath</info>.");
-                    }
+                    $io->verbose("Loading class <info>$class</info> from <info>$filePath</info>.");
 
                     // load the migration file
                     $orig_display_errors_setting = ini_get('display_errors');
@@ -891,12 +852,13 @@ class Manager
                         ));
                     }
 
-                    if ($this->getOutput()->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG) {
-                        $this->getOutput()->writeln("Running <info>$class</info>.");
-                    }
+                    $io->out("Running <info>$class</info>.");
+
+                    $input = new ArgvInput();
+                    $output = new OutputAdapter($io);
 
                     // instantiate it
-                    $migration = new $class('default', $version, $this->getInput(), $this->getOutput());
+                    $migration = new $class('default', $version, $input, $output);
 
                     if (!($migration instanceof AbstractMigration)) {
                         throw new InvalidArgumentException(sprintf(
@@ -908,9 +870,7 @@ class Manager
 
                     $versions[$version] = $migration;
                 } else {
-                    if ($this->getOutput()->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG) {
-                        $this->getOutput()->writeln("Invalid migration file <error>{$filePath}</error>.");
-                    }
+                    $io->verbose("Invalid migration file <error>{$filePath}</error>.");
                 }
             }
 
@@ -1003,6 +963,9 @@ class Manager
             /** @var \Phinx\Seed\SeedInterface[] $seeds */
             $seeds = [];
 
+            $input = new ArgvInput();
+            $output = new OutputAdapter($this->io);
+
             foreach ($phpFiles as $filePath) {
                 if (Util::isValidSeedFileName(basename($filePath))) {
                     // convert the filename to a class name
@@ -1028,10 +991,7 @@ class Manager
                         $seed = new $class();
                     }
                     $seed->setEnvironment('default');
-                    $input = $this->getInput();
                     $seed->setInput($input);
-
-                    $output = $this->getOutput();
                     $seed->setOutput($output);
 
                     if (!($seed instanceof AbstractSeed)) {
@@ -1058,8 +1018,9 @@ class Manager
         }
 
         foreach ($this->seeds as $instance) {
+            // TODO fix this to not use input
             if ($instance instanceof AbstractSeed) {
-                $instance->setInput($this->input);
+                $instance->setInput($input);
             }
         }
 
@@ -1132,8 +1093,9 @@ class Manager
             $version = $lastVersion['version'];
         }
 
+        $io = $this->getIo();
         if ($version != 0 && (!isset($versions[$version]) || !isset($migrations[$version]))) {
-            $this->output->writeln(sprintf(
+            $io->out(sprintf(
                 '<comment>warning</comment> %s is not a valid version',
                 $version
             ));
@@ -1159,7 +1121,7 @@ class Manager
 
         $versions = $env->getVersionLog();
 
-        $this->getOutput()->writeln(
+        $io->out(
             ' Breakpoint ' . ($versions[$version]['breakpoint'] ? 'set' : 'cleared') .
             ' for <info>' . $version . '</info>' .
             ' <comment>' . $migrations[$version]->getName() . '</comment>'
@@ -1173,7 +1135,7 @@ class Manager
      */
     public function removeBreakpoints(): void
     {
-        $this->getOutput()->writeln(sprintf(
+        $this->getIo()->out(sprintf(
             ' %d breakpoints cleared.',
             $this->getEnvironment()->getAdapter()->resetAllBreakpoints()
         ));
@@ -1199,17 +1161,6 @@ class Manager
     public function unsetBreakpoint(?int $version): void
     {
         $this->markBreakpoint($version, self::BREAKPOINT_UNSET);
-    }
-
-    /**
-     * @param int $verbosityLevel Verbosity level for info messages
-     * @return $this
-     */
-    public function setVerbosityLevel(int $verbosityLevel)
-    {
-        $this->verbosityLevel = $verbosityLevel;
-
-        return $this;
     }
 
     /**

--- a/src/Shim/OutputAdapter.php
+++ b/src/Shim/OutputAdapter.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Migrations\Shim;
+
+use Cake\Console\ConsoleIo;
+use RuntimeException;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Traversable;
+
+class OutputAdapter implements OutputInterface
+{
+    /**
+     * Constructor
+     *
+     * @param \Cake\Console\ConsoleIo $io The io instance to wrap
+     */
+    public function __construct(private ConsoleIo $io)
+    {
+    }
+
+    public function write(string|iterable $messages, bool $newline = false, $options = 0): void
+    {
+        if ($messages instanceof Traversable) {
+            $messages = iterator_to_array($messages);
+        }
+        $this->io->out($messages, $newline ? 1 : 0);
+    }
+
+    public function writeln(string|iterable $messages, $options = 0): void
+    {
+        if ($messages instanceof Traversable) {
+            $messages = iterator_to_array($messages);
+        }
+        $this->io->out($messages, 1);
+    }
+
+    /**
+     * Sets the verbosity of the output.
+     *
+     * @param self::VERBOSITY_* $level
+     * @return void
+     */
+    public function setVerbosity(int $level): void
+    {
+        // TODO map values
+        $this->io->level($level);
+    }
+
+    /**
+     * Gets the current verbosity of the output.
+     *
+     * @return self::VERBOSITY_*
+     */
+    public function getVerbosity(): int
+    {
+        // TODO map values
+        return $this->io->level();
+    }
+
+    /**
+     * Returns whether verbosity is quiet (-q).
+     */
+    public function isQuiet(): bool
+    {
+        return $this->io->level() === ConsoleIo::QUIET;
+    }
+
+    /**
+     * Returns whether verbosity is verbose (-v).
+     */
+    public function isVerbose(): bool
+    {
+        return $this->io->level() === ConsoleIo::VERBOSE;
+    }
+
+    /**
+     * Returns whether verbosity is very verbose (-vv).
+     */
+    public function isVeryVerbose(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Returns whether verbosity is debug (-vvv).
+     */
+    public function isDebug(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Sets the decorated flag.
+     *
+     * @return void
+     */
+    public function setDecorated(bool $decorated): void
+    {
+        throw new RuntimeException('setDecorated is not implemented');
+    }
+
+    /**
+     * Gets the decorated flag.
+     */
+    public function isDecorated(): bool
+    {
+        throw new RuntimeException('isDecorated is not implemented');
+    }
+
+    /**
+     * @return void
+     */
+    public function setFormatter(OutputFormatterInterface $formatter): void
+    {
+        throw new RuntimeException('setFormatter is not implemented');
+    }
+
+    /**
+     * Returns current output formatter instance.
+     */
+    public function getFormatter(): OutputFormatterInterface
+    {
+        throw new RuntimeException('getFormatter is not implemented');
+    }
+}

--- a/src/Shim/OutputAdapter.php
+++ b/src/Shim/OutputAdapter.php
@@ -31,6 +31,9 @@ class OutputAdapter implements OutputInterface
     {
     }
 
+    /**
+     * @inheritDoc
+     */
     public function write(string|iterable $messages, bool $newline = false, $options = 0): void
     {
         if ($messages instanceof Traversable) {
@@ -39,6 +42,9 @@ class OutputAdapter implements OutputInterface
         $this->io->out($messages, $newline ? 1 : 0);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function writeln(string|iterable $messages, $options = 0): void
     {
         if ($messages instanceof Traversable) {

--- a/tests/TestCase/Command/MigrationCommandTest.php
+++ b/tests/TestCase/Command/MigrationCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Migrations\Test\TestCase\Command;
 
 use Cake\Console\ConsoleIo;
+use Cake\Console\TestSuite\StubConsoleInput;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\TestSuite\TestCase;
 use Migrations\MigrationsDispatcher;
@@ -111,10 +112,10 @@ class MigrationCommandTest extends TestCase
 
     protected function getMockIo()
     {
+        $in = new StubConsoleInput([]);
         $output = new StubConsoleOutput();
         $io = $this->getMockBuilder(ConsoleIo::class)
-            ->setConstructorArgs([$output, $output, null, null])
-            ->addMethods(['in'])
+            ->setConstructorArgs([$output, $output, $in])
             ->getMock();
 
         return $io;

--- a/tests/TestCase/Command/StatusCommandTest.php
+++ b/tests/TestCase/Command/StatusCommandTest.php
@@ -43,7 +43,7 @@ class StatusCommandTest extends TestCase
 
         assert(isset($this->_out));
         $output = $this->_out->messages();
-        $parsed = json_decode($output[0], true);
+        $parsed = json_decode($output[1], true);
         $this->assertTrue(is_array($parsed));
         $this->assertCount(1, $parsed);
         $this->assertArrayHasKey('id', $parsed[0]);

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -20,11 +20,6 @@ use PDOException;
 use Phinx\Config\FeatureFlags;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputDefinition;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\NullOutput;
 
 class MysqlAdapterTest extends TestCase
 {
@@ -61,7 +56,6 @@ class MysqlAdapterTest extends TestCase
         // leave the adapter in a disconnected state for each test
         $this->adapter->disconnect();
     }
-
 
     protected function getConsoleIo(): ConsoleIo
     {

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Migrations\Test\Db\Adapter;
 
+use Cake\Console\ConsoleIo;
+use Cake\Console\TestSuite\StubConsoleInput;
+use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Database\Connection;
 use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
@@ -29,10 +32,9 @@ class PostgresAdapterTest extends TestCase
      */
     private $adapter;
 
-    /**
-     * @var array
-     */
-    private $config;
+    private array $config;
+    private StubConsoleOutput $out;
+    private ConsoleIo $io;
 
     /**
      * Check if Postgres is enabled in the current PHP
@@ -68,7 +70,7 @@ class PostgresAdapterTest extends TestCase
             $this->markTestSkipped('Postgres is not available.  Please install php-pdo-pgsql or equivalent package.');
         }
 
-        $this->adapter = new PostgresAdapter($this->config, new ArrayInput([]), new NullOutput());
+        $this->adapter = new PostgresAdapter($this->config, $this->getConsoleIo());
 
         $this->adapter->dropAllSchemas();
         $this->adapter->createSchema('public');
@@ -84,10 +86,19 @@ class PostgresAdapterTest extends TestCase
 
     protected function tearDown(): void
     {
-        if ($this->adapter) {
-            // $this->adapter->dropAllSchemas();
-            unset($this->adapter);
-        }
+        unset($this->adapter, $this->out, $this->io);
+    }
+
+    protected function getConsoleIo(): ConsoleIo
+    {
+        $out = new StubConsoleOutput();
+        $in = new StubConsoleInput([]);
+        $io = new ConsoleIo($out, $out, $in);
+
+        $this->out = $out;
+        $this->io = $io;
+
+        return $this->io;
     }
 
     private function usingPostgres10(): bool
@@ -2381,11 +2392,9 @@ class PostgresAdapterTest extends TestCase
 
     public function testDumpCreateTable()
     {
-        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
-        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
-
-        $consoleOutput = new BufferedOutput();
-        $this->adapter->setOutput($consoleOutput);
+        $options = $this->adapter->getOptions();
+        $options['dryrun'] = true;
+        $this->adapter->setOptions($options);
 
         $table = new Table('table1', [], $this->adapter);
 
@@ -2403,7 +2412,7 @@ class PostgresAdapterTest extends TestCase
                 'NULL, "column2" INTEGER NULL, "column3" CHARACTER VARYING (255) NOT NULL  DEFAULT \'test\', CONSTRAINT ' .
                 '"table1_pkey" PRIMARY KEY ("id"));';
         }
-        $actualOutput = $consoleOutput->fetch();
+        $actualOutput = join("\n", $this->out->messages());
         $this->assertStringContainsString(
             $expectedOutput,
             $actualOutput,
@@ -2413,11 +2422,9 @@ class PostgresAdapterTest extends TestCase
 
     public function testDumpCreateTableWithSchema()
     {
-        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
-        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
-
-        $consoleOutput = new BufferedOutput();
-        $this->adapter->setOutput($consoleOutput);
+        $options = $this->adapter->getOptions();
+        $options['dryrun'] = true;
+        $this->adapter->setOptions($options);
 
         $table = new Table('schema1.table1', [], $this->adapter);
 
@@ -2435,7 +2442,7 @@ class PostgresAdapterTest extends TestCase
                 'NULL, "column2" INTEGER NULL, "column3" CHARACTER VARYING (255) NOT NULL  DEFAULT \'test\', CONSTRAINT ' .
                 '"table1_pkey" PRIMARY KEY ("id"));';
         }
-        $actualOutput = $consoleOutput->fetch();
+        $actualOutput = join("\n", $this->out->messages());
         $this->assertStringContainsString(
             $expectedOutput,
             $actualOutput,
@@ -2455,11 +2462,9 @@ class PostgresAdapterTest extends TestCase
             ->addColumn('int_col', 'integer')
             ->save();
 
-        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
-        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
-
-        $consoleOutput = new BufferedOutput();
-        $this->adapter->setOutput($consoleOutput);
+        $options = $this->adapter->getOptions();
+        $options['dryrun'] = true;
+        $this->adapter->setOptions($options);
 
         $this->adapter->insert($table->getTable(), [
             'string_col' => 'test data',
@@ -2487,7 +2492,7 @@ INSERT INTO "public"."table1" ("int_col") VALUES (23);
 OUTPUT;
         }
 
-        $actualOutput = $consoleOutput->fetch();
+        $actualOutput = join("\n", $this->out->messages());
         $this->assertStringContainsString(
             $expectedOutput,
             $actualOutput,
@@ -2512,11 +2517,9 @@ OUTPUT;
             ->addColumn('int_col', 'integer')
             ->save();
 
-        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
-        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
-
-        $consoleOutput = new BufferedOutput();
-        $this->adapter->setOutput($consoleOutput);
+        $options = $this->adapter->getOptions();
+        $options['dryrun'] = true;
+        $this->adapter->setOptions($options);
 
         $this->adapter->bulkinsert($table->getTable(), [
             [
@@ -2539,7 +2542,7 @@ INSERT INTO "public"."table1" ("string_col", "int_col") VALUES ('test_data1', 23
 OUTPUT;
         }
 
-        $actualOutput = $consoleOutput->fetch();
+        $actualOutput = join("\n", $this->out->messages());
         $this->assertStringContainsString(
             $expectedOutput,
             $actualOutput,
@@ -2554,11 +2557,9 @@ OUTPUT;
 
     public function testDumpCreateTableAndThenInsert()
     {
-        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
-        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
-
-        $consoleOutput = new BufferedOutput();
-        $this->adapter->setOutput($consoleOutput);
+        $options = $this->adapter->getOptions();
+        $options['dryrun'] = true;
+        $this->adapter->setOptions($options);
 
         $table = new Table('schema1.table1', ['id' => false, 'primary_key' => ['column1']], $this->adapter);
         $table->addColumn('column1', 'string', ['null' => false])
@@ -2583,7 +2584,7 @@ INSERT INTO "schema1"."table1" ("column1", "column2") VALUES ('id1', 1);
 OUTPUT;
         }
 
-        $actualOutput = $consoleOutput->fetch();
+        $actualOutput = join("\n", $this->out->messages());
         $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
     }
 

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -19,11 +19,6 @@ use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use PDO;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputDefinition;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\NullOutput;
 
 class PostgresAdapterTest extends TestCase
 {

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -23,11 +23,6 @@ use PDOException;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 use RuntimeException;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputDefinition;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\NullOutput;
 
 class SqliteAdapterTest extends TestCase
 {

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 namespace Migrations\Test\Db\Adapter;
 
 use BadMethodCallException;
+use Cake\Console\ConsoleIo;
+use Cake\Console\TestSuite\StubConsoleInput;
+use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Database\Connection;
 use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
@@ -28,10 +31,9 @@ class SqlserverAdapterTest extends TestCase
      */
     private $adapter;
 
-    /**
-     * @var array
-     */
-    private $config;
+    private array $config;
+    private StubConsoleOutput $out;
+    private ConsoleIo $io;
 
     protected function setUp(): void
     {
@@ -46,7 +48,7 @@ class SqlserverAdapterTest extends TestCase
             'database' => $config['database'],
         ];
 
-        $this->adapter = new SqlserverAdapter($this->config, new ArrayInput([]), new NullOutput());
+        $this->adapter = new SqlserverAdapter($this->config, $this->getConsoleIo());
 
         // ensure the database is empty for each test
         $this->adapter->dropDatabase($this->config['database']);
@@ -61,7 +63,19 @@ class SqlserverAdapterTest extends TestCase
         if (!empty($this->adapter)) {
             $this->adapter->disconnect();
         }
-        unset($this->adapter);
+        unset($this->adapter, $this->out, $this->io);
+    }
+
+    protected function getConsoleIo(): ConsoleIo
+    {
+        $out = new StubConsoleOutput();
+        $in = new StubConsoleInput([]);
+        $io = new ConsoleIo($out, $out, $in);
+
+        $this->out = $out;
+        $this->io = $io;
+
+        return $this->io;
     }
 
     public function testConnection()
@@ -1254,11 +1268,9 @@ WHERE t.name='ntable'");
 
     public function testDumpCreateTableAndThenInsert()
     {
-        $inputDefinition = new InputDefinition([new InputOption('dry-run')]);
-        $this->adapter->setInput(new ArrayInput(['--dry-run' => true], $inputDefinition));
-
-        $consoleOutput = new BufferedOutput();
-        $this->adapter->setOutput($consoleOutput);
+        $options = $this->adapter->getOptions();
+        $options['dryrun'] = true;
+        $this->adapter->setOptions($options);
 
         $table = new Table('table1', ['id' => false, 'primary_key' => ['column1']], $this->adapter);
 
@@ -1278,7 +1290,8 @@ WHERE t.name='ntable'");
 CREATE TABLE [table1] ([column1] NVARCHAR (255)   NOT NULL , [column2] INT   NULL  DEFAULT NULL, CONSTRAINT PK_table1 PRIMARY KEY ([column1]));
 INSERT INTO [table1] ([column1], [column2]) VALUES ('id1', 1);
 OUTPUT;
-        $actualOutput = str_replace("\r\n", "\n", $consoleOutput->fetch());
+        $output = join("\n", $this->out->messages());
+        $actualOutput = str_replace("\r\n", "\n", $output);
         $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create and then insert table queries to the output');
     }
 

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -18,11 +18,6 @@ use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputDefinition;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\NullOutput;
 
 class SqlserverAdapterTest extends TestCase
 {

--- a/tests/TestCase/Migration/EnvironmentTest.php
+++ b/tests/TestCase/Migration/EnvironmentTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Test\Phinx\Migration;
 
+use Cake\Console\ConsoleIo;
 use Cake\Datasource\ConnectionManager;
 use Migrations\Db\Adapter\AdapterWrapper;
 use Migrations\Db\Adapter\PdoAdapter;
@@ -253,11 +254,10 @@ class EnvironmentTest extends TestCase
 
     public function testGettingInputObject()
     {
-        $mock = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
-            ->getMock();
-        $this->environment->setInput($mock);
-        $inputObject = $this->environment->getInput();
-        $this->assertInstanceOf('\Symfony\Component\Console\Input\InputInterface', $inputObject);
+        $mock = $this->getMockBuilder(ConsoleIo::class)->getMock();
+        $this->environment->setIo($mock);
+        $inputObject = $this->environment->getIo();
+        $this->assertInstanceOf(ConsoleIo::class, $inputObject);
     }
 
     public function testExecuteMigrationCallsInit()

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -16,9 +16,7 @@ use Migrations\Shim\OutputAdapter;
 use Phinx\Console\Command\AbstractCommand;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\StreamOutput;
 
 class ManagerTest extends TestCase
 {


### PR DESCRIPTION
Continue work to remove phinx and its dependencies from migrations. These changes replace usage of Symfony/Console and use Cake's ConsoleIo objects instead.

This will likely fail CI until cakephp/cakephp#17600 is merged and released. Locally, I was getting file descriptor limits until I tracked down the leaking descriptors in `StubConsoleInput`.

### Breaking changes

- Adapters no longer have console input. I don't see a real world reason for this to exist that can't be replace by options being pushed into the Adapters.
- Migrations and Seeds cannot access console input. I don't think there is a real world scenario where this would come up.

Part of #647 