### PR TITLE
Add new Migrate command

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -37,16 +37,19 @@
 
         <!-- SQLite
         <env name="DB" value="sqlite"/>
-        <env name="DB_URL" value="sqlite://127.0.0.1/cakephp_test"/>
+        <env name="DB_URL" value="sqlite://127.0.0.1/tests.sqlite"/>
+        <env name="DB_URL_SNAPSHOT" value="sqlite://127.0.0.1/snapshot-tests.sqlite"/>
         -->
         <!-- Postgres
         <env name="DB" value="pgsql"/>
         <env name="DB_URL" value="postgres://localhost/cake_test?timezone=UTC"/>
+        <env name="DB_URL_SNAPSHOT" value="postgres://localhost/cake_snapshot_test?timezone=UTC"/>
         -->
         <!-- Mysql
         <env name="DB" value="mysql"/>
         <env name="DB_URL" value="mysql://localhost/cake_test?timezone=UTC"/>
         <env name="DB_URL_COMPARE" value="mysql://localhost/cake_comparison"/>
+        <env name="DB_URL_SNAPSHOT" value="mysql://localhost/cake_snapshot"/>
         -->
     </php>
 </phpunit>

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -1,0 +1,239 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Console\Exception\StopException;
+use Cake\Core\Plugin;
+use Cake\Datasource\ConnectionManager;
+use Cake\Event\EventDispatcherTrait;
+use Cake\Utility\Inflector;
+use DateTime;
+use Exception;
+use Migrations\Config\Config;
+use Migrations\Migration\Manager;
+use Throwable;
+
+/**
+ * Migrate command runs migrations
+ */
+class MigrateCommand extends Command
+{
+    /**
+     * @use \Cake\Event\EventDispatcherTrait<\Migrations\Command\MigrateCommand>
+     */
+    use EventDispatcherTrait;
+
+    /**
+     * The default name added to the application command list
+     *
+     * @return string
+     */
+    public static function defaultName(): string
+    {
+        return 'migrations migrate';
+    }
+
+    /**
+     * Configure the option parser
+     *
+     * @param \Cake\Console\ConsoleOptionParser $parser The option parser to configure
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        $parser->setDescription([
+            'Apply migrations to a SQL datasource',
+            '',
+            'Will run all available migrations, optionally up to a specific version',
+            '',
+            '<info>migrations migrate --connection secondary</info>',
+            '<info>migrations migrate --connection secondary --target 003</info>',
+        ])->addOption('plugin', [
+            'short' => 'p',
+            'help' => 'The plugin to run migrations for',
+        ])->addOption('connection', [
+            'short' => 'c',
+            'help' => 'The datasource connection to use',
+            'default' => 'default',
+        ])->addOption('source', [
+            'short' => 's',
+            'help' => 'The folder where your migrations are',
+        ])->addOption('target', [
+            'short' => 't',
+            'help' => 'The target version to migrate to.',
+        ])->addOption('date', [
+            'short' => 'd',
+            'help' => 'The date to migrate to',
+        ])->addOption('fake', [
+            'help' => "Mark any migrations selected as run, but don't actually execute them",
+            'boolean' => true,
+        ])->addOption('no-lock', [
+            'help' => 'If present, no lock file will be generated after migrating',
+            'boolean' => true,
+        ]);
+
+        return $parser;
+    }
+
+    /**
+     * Generate a configuration object for the migrations operation.
+     *
+     * @param \Cake\Console\Arguments $args The console arguments
+     * @return \Migrations\Config\Config The generated config instance.
+     */
+    protected function getConfig(Arguments $args): Config
+    {
+        $folder = (string)$args->getOption('source');
+
+        // Get the filepath for migrations and seeds(not implemented yet)
+        $dir = ROOT . '/config/' . $folder;
+        if (defined('CONFIG')) {
+            $dir = CONFIG . $folder;
+        }
+        $plugin = $args->getOption('plugin');
+        if ($plugin && is_string($plugin)) {
+            $dir = Plugin::path($plugin) . 'config/' . $folder;
+        }
+
+        // Get the phinxlog table name. Plugins have separate migration history.
+        // The names and separate table history is something we could change in the future.
+        $table = 'phinxlog';
+        if ($plugin && is_string($plugin)) {
+            $prefix = Inflector::underscore($plugin) . '_';
+            $prefix = str_replace(['\\', '/', '.'], '_', $prefix);
+            $table = $prefix . $table;
+        }
+        $templatePath = dirname(__DIR__) . DS . 'templates' . DS;
+        $connectionName = (string)$args->getOption('connection');
+
+        // TODO this all needs to go away. But first Environment and Manager need to work
+        // with Cake's ConnectionManager.
+        $connectionConfig = ConnectionManager::getConfig($connectionName);
+        if (!$connectionConfig) {
+            throw new StopException("Could not find connection `{$connectionName}`");
+        }
+
+        /** @var array<string, string> $connectionConfig */
+        $adapter = $connectionConfig['scheme'] ?? null;
+        $adapterConfig = [
+            'adapter' => $adapter,
+            'connection' => $connectionName,
+            'database' => $connectionConfig['database'],
+            'migration_table' => $table,
+            'dryrun' => $args->getOption('dry-run'),
+        ];
+
+        $configData = [
+            'paths' => [
+                'migrations' => $dir,
+            ],
+            'templates' => [
+                'file' => $templatePath . 'Phinx/create.php.template',
+            ],
+            'migration_base_class' => 'Migrations\AbstractMigration',
+            'environment' => $adapterConfig,
+            // TODO do we want to support the DI container in migrations?
+        ];
+
+        return new Config($configData);
+    }
+
+    /**
+     * Get the migration manager for the current CLI options and application configuration.
+     *
+     * @param \Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\ConsoleIo $io The command io.
+     * @return \Migrations\Migration\Manager
+     */
+    protected function getManager(Arguments $args, ConsoleIo $io): Manager
+    {
+        $config = $this->getConfig($args);
+
+        return new Manager($config, $io);
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param \Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return int|null The exit code or null for success
+     */
+    public function execute(Arguments $args, ConsoleIo $io): ?int
+    {
+        $event = $this->dispatchEvent('Migration.beforeMigrate');
+        if ($event->isStopped()) {
+            return $event->getResult() ? self::CODE_SUCCESS : self::CODE_ERROR;
+        }
+        $result = $this->executeMigrations($args, $io);
+        $this->dispatchEvent('Migration.afterMigrate');
+
+        return $result;
+    }
+
+    /**
+     * Execute migrations based on console inputs.
+     *
+     * @param \Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return int|null The exit code or null for success
+     */
+    protected function executeMigrations(Arguments $args, ConsoleIo $io): ?int
+    {
+        $version = $args->getOption('target') !== null ? (int)$args->getOption('target') : null;
+        $date = $args->getOption('date');
+        $fake = (bool)$args->getOption('fake');
+
+        $manager = $this->getManager($args, $io);
+        $config = $manager->getConfig();
+
+        $versionOrder = $config->getVersionOrder();
+        $io->out('<info>using connection</info> ' . (string)$args->getOption('connection'));
+        $io->out('<info>ordering by</info> ' . $versionOrder . ' time');
+
+        if ($fake) {
+            $io->out('<warning>warning</warning> performing fake migrations');
+        }
+
+        try {
+            // run the migrations
+            $start = microtime(true);
+            if ($date !== null) {
+                $manager->migrateToDateTime(new DateTime((string)$date), $fake);
+            } else {
+                $manager->migrate($version, $fake);
+            }
+            $end = microtime(true);
+        } catch (Exception $e) {
+            $io->err('<error>' . $e->getMessage() . '</error>');
+            $io->out($e->getTraceAsString(), 1, ConsoleIo::VERBOSE);
+
+            return self::CODE_ERROR;
+        } catch (Throwable $e) {
+            $io->err('<error>' . $e->getMessage() . '</error>');
+            $io->out($e->getTraceAsString(), 1, ConsoleIo::VERBOSE);
+
+            return self::CODE_ERROR;
+        }
+
+        $io->out('');
+        $io->out('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+
+        return self::CODE_SUCCESS;
+    }
+}

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -103,13 +103,13 @@ class MigrateCommand extends Command
         $folder = (string)$args->getOption('source');
 
         // Get the filepath for migrations and seeds(not implemented yet)
-        $dir = ROOT . '/config/' . $folder;
+        $dir = ROOT . DS . 'config' . DS . $folder;
         if (defined('CONFIG')) {
             $dir = CONFIG . $folder;
         }
         $plugin = $args->getOption('plugin');
         if ($plugin && is_string($plugin)) {
-            $dir = Plugin::path($plugin) . 'config/' . $folder;
+            $dir = Plugin::path($plugin) . 'config' . DS . $folder;
         }
 
         // Get the phinxlog table name. Plugins have separate migration history.

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -25,6 +25,7 @@ use Cake\Utility\Inflector;
 use DateTime;
 use Exception;
 use Migrations\Config\Config;
+use Migrations\Config\ConfigInterface;
 use Migrations\Migration\Manager;
 use Throwable;
 
@@ -72,6 +73,7 @@ class MigrateCommand extends Command
             'default' => 'default',
         ])->addOption('source', [
             'short' => 's',
+            'default' => ConfigInterface::DEFAULT_MIGRATION_FOLDER,
             'help' => 'The folder where your migrations are',
         ])->addOption('target', [
             'short' => 't',
@@ -98,7 +100,7 @@ class MigrateCommand extends Command
      */
     protected function getConfig(Arguments $args): Config
     {
-        $folder = (string)$args->getOption('source');
+        $folder = $args->getOption('source');
 
         // Get the filepath for migrations and seeds(not implemented yet)
         $dir = ROOT . '/config/' . $folder;
@@ -233,6 +235,38 @@ class MigrateCommand extends Command
 
         $io->out('');
         $io->out('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+
+        // Run dump command to generate lock file
+        /* TODO(mark) port this in
+        if (
+            isset($this->argv[1]) && in_array($this->argv[1], ['migrate', 'rollback'], true) &&
+            !in_array('--no-lock', $this->argv, true) &&
+            $exitCode === 0
+        ) {
+            $newArgs = [];
+            if (!empty($args->getOption('connection'))) {
+                $newArgs[] = '-c';
+                $newArgs[] = $args->getOption('connection');
+            }
+
+            if (!empty($args->getOption('plugin'))) {
+                $newArgs[] = '-p';
+                $newArgs[] = $args->getOption('plugin');
+            }
+
+            $io->out('');
+            $io->out('Dumps the current schema of the database to be used while baking a diff');
+            $io->out('');
+
+            $dumpExitCode = $this->executeCommand(MigrationsDumpCommand::class, $newArgs, $io);
+        }
+
+        if (isset($dumpExitCode) && $exitCode === 0 && $dumpExitCode !== 0) {
+            $exitCode = 1;
+        }
+
+        return $exitCode;
+        */
 
         return self::CODE_SUCCESS;
     }

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -238,36 +238,7 @@ class MigrateCommand extends Command
         $io->out('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
 
         // Run dump command to generate lock file
-        /* TODO(mark) port this in
-        if (
-            isset($this->argv[1]) && in_array($this->argv[1], ['migrate', 'rollback'], true) &&
-            !in_array('--no-lock', $this->argv, true) &&
-            $exitCode === 0
-        ) {
-            $newArgs = [];
-            if (!empty($args->getOption('connection'))) {
-                $newArgs[] = '-c';
-                $newArgs[] = $args->getOption('connection');
-            }
-
-            if (!empty($args->getOption('plugin'))) {
-                $newArgs[] = '-p';
-                $newArgs[] = $args->getOption('plugin');
-            }
-
-            $io->out('');
-            $io->out('Dumps the current schema of the database to be used while baking a diff');
-            $io->out('');
-
-            $dumpExitCode = $this->executeCommand(MigrationsDumpCommand::class, $newArgs, $io);
-        }
-
-        if (isset($dumpExitCode) && $exitCode === 0 && $dumpExitCode !== 0) {
-            $exitCode = 1;
-        }
-
-        return $exitCode;
-        */
+        // TODO(mark) port in logic from src/Command/MigrationsCommand.php : 142:164
 
         return self::CODE_SUCCESS;
     }

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -100,7 +100,7 @@ class MigrateCommand extends Command
      */
     protected function getConfig(Arguments $args): Config
     {
-        $folder = $args->getOption('source');
+        $folder = (string)$args->getOption('source');
 
         // Get the filepath for migrations and seeds(not implemented yet)
         $dir = ROOT . '/config/' . $folder;

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -206,6 +206,7 @@ class MigrateCommand extends Command
 
         $versionOrder = $config->getVersionOrder();
         $io->out('<info>using connection</info> ' . (string)$args->getOption('connection'));
+        $io->out('<info>using paths</info> ' . implode(', ', $config->getMigrationPaths()));
         $io->out('<info>ordering by</info> ' . $versionOrder . ' time');
 
         if ($fake) {

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -22,6 +22,7 @@ use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Inflector;
 use Migrations\Config\Config;
+use Migrations\Config\ConfigInterface;
 use Migrations\Migration\Manager;
 
 /**
@@ -77,7 +78,7 @@ class StatusCommand extends Command
         ])->addOption('source', [
             'short' => 's',
             'help' => 'The folder under src/Config that migrations are in',
-            'default' => 'Migrations',
+            'default' => ConfigInterface::DEFAULT_MIGRATION_FOLDER,
         ])->addOption('format', [
             'short' => 'f',
             'help' => 'The output format: text or json. Defaults to text.',
@@ -96,7 +97,7 @@ class StatusCommand extends Command
      */
     protected function getConfig(Arguments $args): Config
     {
-        $folder = $args->getOption('source') ?? 'Migrations';
+        $folder = (string)$args->getOption('source');
 
         // Get the filepath for migrations and seeds(not implemented yet)
         $dir = ROOT . '/config/' . $folder;

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -96,7 +96,7 @@ class StatusCommand extends Command
      */
     protected function getConfig(Arguments $args): Config
     {
-        $folder = (string)$args->getOption('source');
+        $folder = $args->getOption('source') ?? 'Migrations';
 
         // Get the filepath for migrations and seeds(not implemented yet)
         $dir = ROOT . '/config/' . $folder;

--- a/src/Config/ConfigInterface.php
+++ b/src/Config/ConfigInterface.php
@@ -18,6 +18,8 @@ use Psr\Container\ContainerInterface;
  */
 interface ConfigInterface extends ArrayAccess
 {
+    public const DEFAULT_MIGRATION_FOLDER = 'Migrations';
+
     /**
      * Returns the configuration for the current environment.
      *

--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Migrations\Db\Adapter;
 
 use Cake\Console\ConsoleIo;
+use Cake\Database\Connection;
 use Cake\Database\Query;
 use Cake\Database\Query\DeleteQuery;
 use Cake\Database\Query\InsertQuery;
@@ -21,8 +22,6 @@ use Phinx\Migration\MigrationInterface;
 
 /**
  * Adapter Interface.
- *
- * @method \PDO getConnection()
  */
 interface AdapterInterface
 {
@@ -520,4 +519,11 @@ interface AdapterInterface
      * @return \Cake\Console\ConsoleIo $io The io instance to use
      */
     public function getIo(): ?ConsoleIo;
+
+    /**
+     * Get the Connection for this adapter.
+     *
+     * @return \Cake\Database\Connection The connection
+     */
+    public function getConnection(): Connection;
 }

--- a/src/Db/Adapter/AdapterWrapper.php
+++ b/src/Db/Adapter/AdapterWrapper.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Migrations\Db\Adapter;
 
 use Cake\Console\ConsoleIo;
+use Cake\Database\Connection;
 use Cake\Database\Query;
 use Cake\Database\Query\DeleteQuery;
 use Cake\Database\Query\InsertQuery;
@@ -17,7 +18,6 @@ use Cake\Database\Query\UpdateQuery;
 use Migrations\Db\Literal;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\Table;
-use PDO;
 use Phinx\Migration\MigrationInterface;
 
 /**
@@ -430,9 +430,9 @@ abstract class AdapterWrapper implements WrapperInterface
     }
 
     /**
-     * @return \PDO
+     * @return \Cake\Database\Connection
      */
-    public function getConnection(): PDO
+    public function getConnection(): Connection
     {
         return $this->getAdapter()->getConnection();
     }

--- a/src/Db/Adapter/PhinxAdapter.php
+++ b/src/Db/Adapter/PhinxAdapter.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Migrations\Db\Adapter;
 
+use Cake\Database\Connection;
 use Cake\Database\Query;
 use Cake\Database\Query\DeleteQuery;
 use Cake\Database\Query\InsertQuery;
@@ -32,7 +33,6 @@ use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use Migrations\Db\Table\Table;
-use PDO;
 use Phinx\Db\Action\Action as PhinxAction;
 use Phinx\Db\Action\AddColumn as PhinxAddColumn;
 use Phinx\Db\Action\AddForeignKey as PhinxAddForeignKey;
@@ -747,9 +747,9 @@ class PhinxAdapter implements PhinxAdapterInterface
     }
 
     /**
-     * @return \PDO
+     * @return \Cake\Database\Connection
      */
-    public function getConnection(): PDO
+    public function getConnection(): Connection
     {
         return $this->adapter->getConnection();
     }
@@ -811,5 +811,13 @@ class PhinxAdapter implements PhinxAdapterInterface
     public function getDeleteBuilder(): DeleteQuery
     {
         return $this->adapter->getDeleteBuilder();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCakeConnection(): Connection
+    {
+        return $this->adapter->getConnection();
     }
 }

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -852,7 +852,7 @@ class Manager
                         ));
                     }
 
-                    $io->out("Running <info>$class</info>.");
+                    $io->verbose("Constructing <info>$class</info>.");
 
                     $input = new ArgvInput();
                     $output = new OutputAdapter($io);

--- a/src/MigrationsPlugin.php
+++ b/src/MigrationsPlugin.php
@@ -22,6 +22,7 @@ use Migrations\Command\BakeMigrationCommand;
 use Migrations\Command\BakeMigrationDiffCommand;
 use Migrations\Command\BakeMigrationSnapshotCommand;
 use Migrations\Command\BakeSeedCommand;
+use Migrations\Command\MigrateCommand;
 use Migrations\Command\MigrationsCacheBuildCommand;
 use Migrations\Command\MigrationsCacheClearCommand;
 use Migrations\Command\MigrationsCommand;
@@ -92,6 +93,7 @@ class MigrationsPlugin extends BasePlugin
         if (Configure::read('Migrations.backend') == 'builtin') {
             $classes = [
                 StatusCommand::class,
+                MigrateCommand::class,
             ];
             if (class_exists(SimpleBakeCommand::class)) {
                 $classes[] = BakeMigrationCommand::class;

--- a/tests/TestCase/Command/CompletionTest.php
+++ b/tests/TestCase/Command/CompletionTest.php
@@ -44,7 +44,7 @@ class CompletionTest extends TestCase
     {
         $this->exec('completion subcommands migrations.migrations');
         $expected = [
-            'orm-cache-build orm-cache-clear create dump mark_migrated migrate rollback seed status',
+            'migrate orm-cache-build orm-cache-clear create dump mark_migrated rollback seed status',
         ];
         $actual = $this->_out->messages();
         $this->assertEquals($expected, $actual);

--- a/tests/TestCase/Command/MigrateCommandTest.php
+++ b/tests/TestCase/Command/MigrateCommandTest.php
@@ -19,11 +19,16 @@ class MigrateCommandTest extends TestCase
         parent::setUp();
         Configure::write('Migrations.backend', 'builtin');
 
-        $table = $this->fetchTable('Phinxlog');
         try {
+            $table = $this->fetchTable('Phinxlog');
             $table->deleteAll('1=1');
         } catch (DatabaseException $e) {
-            //debug($e->getMessage());
+        }
+
+        try {
+            $table = $this->fetchTable('MigratorPhinxlog');
+            $table->deleteAll('1=1');
+        } catch (DatabaseException $e) {
         }
     }
 
@@ -206,7 +211,7 @@ class MigrateCommandTest extends TestCase
      * Test that migrating with the `--no-lock` option will not dispatch a dump shell
      *
      * @return void
-     * /
+     */
     public function testMigrateWithNoLock()
     {
         $this->markTestIncomplete('not done here');
@@ -228,7 +233,7 @@ class MigrateCommandTest extends TestCase
      * Test that rolling back without the `--no-lock` option will dispatch a dump shell
      *
      * @return void
-     * /
+     */
     public function testRollbackWithLock()
     {
         $this->markTestIncomplete('not done here');
@@ -249,7 +254,7 @@ class MigrateCommandTest extends TestCase
      * Test that rolling back with the `--no-lock` option will not dispatch a dump shell
      *
      * @return void
-     * /
+     */
     public function testRollbackWithNoLock()
     {
         $this->markTestIncomplete('not done here');
@@ -266,5 +271,4 @@ class MigrateCommandTest extends TestCase
 
         $this->command->run($argv, $this->getMockIo());
     }
-    */
 }

--- a/tests/TestCase/Command/MigrateCommandTest.php
+++ b/tests/TestCase/Command/MigrateCommandTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Migrations\Test\TestCase\Command;
 
+use Cake\Console\ConsoleOutput;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
@@ -26,24 +27,38 @@ class MigrateCommandTest extends TestCase
     }
 
     /**
-     * Test that migrating without the `--no-lock` option will dispatch a dump shell
+     * Test that running with no migrations is successful
      *
      * @return void
      */
-    public function testMigrateWithLock()
+    public function testMigrateNoMigrationsSuccess()
     {
-        $this->markTestIncomplete('not done here');
-        $argv = [
-            '-c',
-            'test',
-        ];
+        $this->exec('migrations migrate -c test -s Missing');
+        $this->assertExitSuccess();
 
-        $this->command = $this->getMockCommand('MigrationsMigrateCommand');
+        $this->assertOutputContains('<info>using connection</info> test');
+        $this->assertOutputContains('All Done');
 
-        $this->command->expects($this->once())
-            ->method('executeCommand');
+        $table = $this->fetchTable('Phinxlog');
+        $this->assertCount(0, $table->find()->all()->toArray());
+    }
 
-        $this->command->run($argv, $this->getMockIo());
+    /**
+     * Test that running with a no-op migrations is successful
+     *
+     * @return void
+     */
+    public function testMigrateWithSourceMigration()
+    {
+        $this->exec('migrations migrate -c test -s Migrations');
+        $this->assertExitSuccess();
+
+        $this->assertOutputContains('<info>using connection</info> test');
+        $this->assertOutputContains('Running <info>MarkMigratedTest</info>');
+        $this->assertOutputContains('All Done');
+
+        $table = $this->fetchTable('Phinxlog');
+        $this->assertCount(1, $table->find()->all()->toArray());
     }
 
     /**

--- a/tests/TestCase/Command/MigrateCommandTest.php
+++ b/tests/TestCase/Command/MigrateCommandTest.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+namespace Migrations\Test\TestCase\Command;
+
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+
+class MigrateCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        Configure::write('Migrations.backend', 'builtin');
+    }
+
+    public function testHelp()
+    {
+        $this->exec('migrations migrate --help');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('Apply migrations to a SQL datasource');
+    }
+
+    /**
+     * Test that migrating without the `--no-lock` option will dispatch a dump shell
+     *
+     * @return void
+     */
+    public function testMigrateWithLock()
+    {
+        $this->markTestIncomplete('not done here');
+        $argv = [
+            '-c',
+            'test',
+        ];
+
+        $this->command = $this->getMockCommand('MigrationsMigrateCommand');
+
+        $this->command->expects($this->once())
+            ->method('executeCommand');
+
+        $this->command->run($argv, $this->getMockIo());
+    }
+
+    /**
+     * Test that migrating with the `--no-lock` option will not dispatch a dump shell
+     *
+     * @return void
+     */
+    public function testMigrateWithNoLock()
+    {
+        $this->markTestIncomplete('not done here');
+        $argv = [
+            '-c',
+            'test',
+            '--no-lock',
+        ];
+
+        $this->command = $this->getMockCommand('MigrationsMigrateCommand');
+
+        $this->command->expects($this->never())
+            ->method('executeCommand');
+
+        $this->command->run($argv, $this->getMockIo());
+    }
+
+    /**
+     * Test that rolling back without the `--no-lock` option will dispatch a dump shell
+     *
+     * @return void
+     */
+    public function testRollbackWithLock()
+    {
+        $this->markTestIncomplete('not done here');
+        $argv = [
+            '-c',
+            'test',
+        ];
+
+        $this->command = $this->getMockCommand('MigrationsRollbackCommand');
+
+        $this->command->expects($this->once())
+            ->method('executeCommand');
+
+        $this->command->run($argv, $this->getMockIo());
+    }
+
+    /**
+     * Test that rolling back with the `--no-lock` option will not dispatch a dump shell
+     *
+     * @return void
+     */
+    public function testRollbackWithNoLock()
+    {
+        $this->markTestIncomplete('not done here');
+        $argv = [
+            '-c',
+            'test',
+            '--no-lock',
+        ];
+
+        $this->command = $this->getMockCommand('MigrationsRollbackCommand');
+
+        $this->command->expects($this->never())
+            ->method('executeCommand');
+
+        $this->command->run($argv, $this->getMockIo());
+    }
+
+    public function testMigrate()
+    {
+        $this->markTestIncomplete('not done here');
+    }
+
+    public function testMigrateSource()
+    {
+        $this->markTestIncomplete('not done here');
+    }
+
+    public function testMigrateSourceInvalid()
+    {
+        $this->markTestIncomplete('not done here');
+    }
+
+    public function testMigrateDate()
+    {
+        $this->markTestIncomplete('not done here');
+    }
+
+    public function testMigrateDateNotFound()
+    {
+        $this->markTestIncomplete('not done here');
+    }
+
+    public function testMigrateTarget()
+    {
+        $this->markTestIncomplete('not done here');
+    }
+
+    public function testMigrateTargetNotFound()
+    {
+        $this->markTestIncomplete('not done here');
+    }
+
+    public function testMigrateFake()
+    {
+        $this->markTestIncomplete('not done here');
+    }
+
+    public function testMigratePlugin()
+    {
+        $this->markTestIncomplete('not done here');
+    }
+
+    public function testMigratePluginInvalid()
+    {
+        $this->markTestIncomplete('not done here');
+    }
+}

--- a/tests/TestCase/Command/MigrateCommandTest.php
+++ b/tests/TestCase/Command/MigrateCommandTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Migrations\Test\TestCase\Command;
 
-use Cake\Console\ConsoleOutput;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Configure;
 use Cake\Core\Exception\MissingPluginException;
@@ -131,7 +130,6 @@ class MigrateCommandTest extends TestCase
     }
 
     /**
-     *
      * Test advancing migrations with an offset.
      */
     public function testMigrateTarget()

--- a/tests/TestCase/Command/MigrateCommandTest.php
+++ b/tests/TestCase/Command/MigrateCommandTest.php
@@ -49,7 +49,7 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test -s Missing');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<info>using paths</info> ' . ROOT . '/config/Missing');
+        $this->assertOutputContains('<info>using paths</info> ' . ROOT . DS . 'config' . DS . 'Missing');
         $this->assertOutputContains('<info>using connection</info> test');
         $this->assertOutputContains('All Done');
 
@@ -66,7 +66,7 @@ class MigrateCommandTest extends TestCase
         $this->assertExitSuccess();
 
         $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . ROOT . '/config/Migrations');
+        $this->assertOutputContains('<info>using paths</info> ' . ROOT . DS . 'config' . DS . 'Migrations');
         $this->assertOutputContains('MarkMigratedTest:</info> <comment>migrated');
         $this->assertOutputContains('All Done');
 
@@ -85,7 +85,7 @@ class MigrateCommandTest extends TestCase
         $this->assertExitSuccess();
 
         $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . ROOT . '/config/ShouldExecute');
+        $this->assertOutputContains('<info>using paths</info> ' . ROOT . DS . 'config' . DS . 'ShouldExecute');
         $this->assertOutputContains('ShouldExecuteMigration:</info> <comment>migrated');
         $this->assertOutputContains('ShouldNotExecuteMigration:</info> <comment>skipped </comment>');
         $this->assertOutputContains('All Done');
@@ -103,7 +103,7 @@ class MigrateCommandTest extends TestCase
         $this->assertExitSuccess();
 
         $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . ROOT . '/config/Migrations');
+        $this->assertOutputContains('<info>using paths</info> ' . ROOT . DS . 'config' . DS . 'Migrations');
         $this->assertOutputContains('MarkMigratedTest:</info> <comment>migrated');
         $this->assertOutputContains('All Done');
 
@@ -120,7 +120,7 @@ class MigrateCommandTest extends TestCase
         $this->assertExitSuccess();
 
         $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . ROOT . '/config/Migrations');
+        $this->assertOutputContains('<info>using paths</info> ' . ROOT . DS . 'config' . DS . 'Migrations');
         $this->assertOutputNotContains('MarkMigratedTest');
         $this->assertOutputContains('No migrations to run');
         $this->assertOutputContains('All Done');
@@ -138,7 +138,7 @@ class MigrateCommandTest extends TestCase
         $this->assertExitSuccess();
 
         $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . ROOT . '/config/Migrations');
+        $this->assertOutputContains('<info>using paths</info> ' . ROOT . DS . 'config' . DS . 'Migrations');
         $this->assertOutputContains('MarkMigratedTest:</info> <comment>migrated');
         $this->assertOutputNotContains('MarkMigratedTestSecond');
         $this->assertOutputContains('All Done');
@@ -153,7 +153,7 @@ class MigrateCommandTest extends TestCase
         $this->assertExitSuccess();
 
         $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . ROOT . '/config/Migrations');
+        $this->assertOutputContains('<info>using paths</info> ' . ROOT . DS . 'config' . DS . 'Migrations');
         $this->assertOutputNotContains('MarkMigratedTest');
         $this->assertOutputNotContains('MarkMigratedTestSecond');
         $this->assertOutputContains('<comment>warning</comment> 99 is not a valid version');
@@ -169,7 +169,7 @@ class MigrateCommandTest extends TestCase
         $this->assertExitSuccess();
 
         $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . ROOT . '/config/Migrations');
+        $this->assertOutputContains('<info>using paths</info> ' . ROOT . DS . 'config' . DS . 'Migrations');
         $this->assertOutputContains('warning</warning> performing fake migrations');
         $this->assertOutputContains('MarkMigratedTest:</info> <comment>migrated');
         $this->assertOutputContains('MarkMigratedTestSecond:</info> <comment>migrated');
@@ -186,7 +186,7 @@ class MigrateCommandTest extends TestCase
         $this->assertExitSuccess();
 
         $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . ROOT . '/Plugin/Migrator/config/Migrations');
+        $this->assertOutputContains('<info>using paths</info> ' . ROOT . DS . 'Plugin' . DS . 'Migrator' . DS . 'config' . DS . 'Migrations');
         $this->assertOutputContains('Migrator:</info> <comment>migrated');
         $this->assertOutputContains('All Done');
 

--- a/tests/TestCase/Command/StatusCommandTest.php
+++ b/tests/TestCase/Command/StatusCommandTest.php
@@ -6,6 +6,7 @@ namespace Migrations\Test\TestCase\Command;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Configure;
 use Cake\Core\Exception\MissingPluginException;
+use Cake\Database\Exception\DatabaseException;
 use Cake\TestSuite\TestCase;
 
 class StatusCommandTest extends TestCase
@@ -16,6 +17,12 @@ class StatusCommandTest extends TestCase
     {
         parent::setUp();
         Configure::write('Migrations.backend', 'builtin');
+
+        $table = $this->fetchTable('Phinxlog');
+        try {
+            $table->deleteAll('1=1');
+        } catch (DatabaseException $e) {
+        }
     }
 
     public function testHelp(): void
@@ -43,9 +50,9 @@ class StatusCommandTest extends TestCase
 
         assert(isset($this->_out));
         $output = $this->_out->messages();
-        $parsed = json_decode($output[1], true);
+        $parsed = json_decode($output[0], true);
         $this->assertTrue(is_array($parsed));
-        $this->assertCount(1, $parsed);
+        $this->assertCount(2, $parsed);
         $this->assertArrayHasKey('id', $parsed[0]);
         $this->assertArrayHasKey('status', $parsed[0]);
         $this->assertArrayHasKey('name', $parsed[0]);

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -581,6 +581,11 @@ class MigrationsTest extends TestCase
                 'id' => '20150416223600',
                 'name' => 'MarkMigratedTest',
             ],
+            [
+                'status' => 'down',
+                'id' => '20240309223600',
+                'name' => 'MarkMigratedTestSecond',
+            ],
         ];
         $this->assertEquals($expected, $result);
 
@@ -588,18 +593,19 @@ class MigrationsTest extends TestCase
         $this->assertTrue($migrate);
         $result = $this->migrations->status(['source' => 'Migrations']);
         $expected[0]['status'] = 'up';
+        $expected[1]['status'] = 'up';
         $this->assertEquals($expected, $result);
 
         $rollback = $this->migrations->rollback(['source' => 'Migrations']);
         $this->assertTrue($rollback);
         $result = $this->migrations->status(['source' => 'Migrations']);
-        $expected[0]['status'] = 'down';
+        $expected[0]['status'] = 'up';
+        $expected[1]['status'] = 'down';
         $this->assertEquals($expected, $result);
 
         $migrate = $this->migrations->markMigrated(20150416223600, ['source' => 'Migrations']);
         $this->assertTrue($migrate);
         $result = $this->migrations->status(['source' => 'Migrations']);
-        $expected[0]['status'] = 'up';
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/test_app/config/Migrations/20240309223600_mark_migrated_test_second.php
+++ b/tests/test_app/config/Migrations/20240309223600_mark_migrated_test_second.php
@@ -1,0 +1,14 @@
+<?php
+
+use Migrations\AbstractMigration;
+
+class MarkMigratedTestSecond extends AbstractMigration
+{
+    public function up(): void
+    {
+    }
+
+    public function down(): void
+    {
+    }
+}


### PR DESCRIPTION
- Add a `migrate` command that uses the new backend.
- It has similar behavior and output to the phinx backend.
- There is a bit of duplication forming between new backend commands. I'm going to extract it soon, and I'd like to avoid inheritance.
- I still have to implement the `no-lock` and dump features. I'll do those in a follow up pull request.

Part of #647 