### PR TITLE
Add Dump command for new backend

### DIFF
--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -1,0 +1,123 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Database\Connection;
+use Cake\Datasource\ConnectionManager;
+use Migrations\Config\ConfigInterface;
+use Migrations\Migration\ManagerFactory;
+use Migrations\TableFinderTrait;
+
+/**
+ * Dump command class.
+ * A "dump" is a snapshot of a database at a given point in time. It is stored in a
+ * .lock file in the same folder as migrations files.
+ */
+class DumpCommand extends Command
+{
+    use TableFinderTrait;
+
+    protected string $connection;
+
+    /**
+     * The default name added to the application command list
+     *
+     * @return string
+     */
+    public static function defaultName(): string
+    {
+        return 'migrations dump';
+    }
+
+    /**
+     * Configure the option parser
+     *
+     * @param \Cake\Console\ConsoleOptionParser $parser The option parser to configure
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        $parser->setDescription([
+            'Dumps the current scheam of the database to be used while baking a diff',
+            '',
+            '<info>migrations dump -c secondary</info>',
+        ])->addOption('plugin', [
+            'short' => 'p',
+            'help' => 'The plugin to dump migrations for',
+        ])->addOption('connection', [
+            'short' => 'c',
+            'help' => 'The datasource connection to use',
+            'default' => 'default',
+        ])->addOption('source', [
+            'short' => 's',
+            'help' => 'The folder under src/Config that migrations are in',
+            'default' => ConfigInterface::DEFAULT_MIGRATION_FOLDER,
+        ]);
+
+        return $parser;
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param \Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return int|null The exit code or null for success
+     */
+    public function execute(Arguments $args, ConsoleIo $io): ?int
+    {
+        $factory = new ManagerFactory([
+            'plugin' => $args->getOption('plugin'),
+            'source' => $args->getOption('source'),
+            'connection' => $args->getOption('connection'),
+        ]);
+        $config = $factory->createConfig();
+        $path = $config->getMigrationPaths()[0];
+        $connectionName = (string)$config->getConnection();
+        $connection = ConnectionManager::get($connectionName);
+        assert($connection instanceof Connection);
+
+        $collection = $connection->getSchemaCollection();
+        $options = [
+            'require-table' => false,
+            'plugin' => $args->getOption('plugin'),
+        ];
+        // The connection property is used by the trait methods.
+        $this->connection = $connectionName;
+        $tables = $this->getTablesToBake($collection, $options);
+
+        $dump = [];
+        if ($tables) {
+            foreach ($tables as $table) {
+                $schema = $collection->describe($table);
+                $dump[$table] = $schema;
+            }
+        }
+
+        $filePath = $path . DS . 'schema-dump-' . $connectionName . '.lock';
+        $io->out("<info>Writing dump file `{$filePath}`...</info>");
+        if (file_put_contents($filePath, serialize($dump))) {
+            $io->out("<info>Dump file `{$filePath}` was successfully written</info>");
+
+            return self::CODE_SUCCESS;
+        }
+        $io->out("<error>An error occurred while writing dump file `{$filePath}`</error>");
+
+        return self::CODE_ERROR;
+    }
+}

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -17,16 +17,10 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use Cake\Console\Exception\StopException;
-use Cake\Core\Plugin;
-use Cake\Datasource\ConnectionManager;
 use Cake\Event\EventDispatcherTrait;
-use Cake\Utility\Inflector;
 use DateTime;
 use Exception;
-use Migrations\Config\Config;
 use Migrations\Config\ConfigInterface;
-use Migrations\Migration\Manager;
 use Migrations\Migration\ManagerFactory;
 use Throwable;
 

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -27,6 +27,7 @@ use Exception;
 use Migrations\Config\Config;
 use Migrations\Config\ConfigInterface;
 use Migrations\Migration\Manager;
+use Migrations\Migration\ManagerFactory;
 use Throwable;
 
 /**
@@ -93,83 +94,6 @@ class MigrateCommand extends Command
     }
 
     /**
-     * Generate a configuration object for the migrations operation.
-     *
-     * @param \Cake\Console\Arguments $args The console arguments
-     * @return \Migrations\Config\Config The generated config instance.
-     */
-    protected function getConfig(Arguments $args): Config
-    {
-        $folder = (string)$args->getOption('source');
-
-        // Get the filepath for migrations and seeds(not implemented yet)
-        $dir = ROOT . DS . 'config' . DS . $folder;
-        if (defined('CONFIG')) {
-            $dir = CONFIG . $folder;
-        }
-        $plugin = $args->getOption('plugin');
-        if ($plugin && is_string($plugin)) {
-            $dir = Plugin::path($plugin) . 'config' . DS . $folder;
-        }
-
-        // Get the phinxlog table name. Plugins have separate migration history.
-        // The names and separate table history is something we could change in the future.
-        $table = 'phinxlog';
-        if ($plugin && is_string($plugin)) {
-            $prefix = Inflector::underscore($plugin) . '_';
-            $prefix = str_replace(['\\', '/', '.'], '_', $prefix);
-            $table = $prefix . $table;
-        }
-        $templatePath = dirname(__DIR__) . DS . 'templates' . DS;
-        $connectionName = (string)$args->getOption('connection');
-
-        // TODO this all needs to go away. But first Environment and Manager need to work
-        // with Cake's ConnectionManager.
-        $connectionConfig = ConnectionManager::getConfig($connectionName);
-        if (!$connectionConfig) {
-            throw new StopException("Could not find connection `{$connectionName}`");
-        }
-
-        /** @var array<string, string> $connectionConfig */
-        $adapter = $connectionConfig['scheme'] ?? null;
-        $adapterConfig = [
-            'adapter' => $adapter,
-            'connection' => $connectionName,
-            'database' => $connectionConfig['database'],
-            'migration_table' => $table,
-            'dryrun' => $args->getOption('dry-run'),
-        ];
-
-        $configData = [
-            'paths' => [
-                'migrations' => $dir,
-            ],
-            'templates' => [
-                'file' => $templatePath . 'Phinx/create.php.template',
-            ],
-            'migration_base_class' => 'Migrations\AbstractMigration',
-            'environment' => $adapterConfig,
-            // TODO do we want to support the DI container in migrations?
-        ];
-
-        return new Config($configData);
-    }
-
-    /**
-     * Get the migration manager for the current CLI options and application configuration.
-     *
-     * @param \Cake\Console\Arguments $args The command arguments.
-     * @param \Cake\Console\ConsoleIo $io The command io.
-     * @return \Migrations\Migration\Manager
-     */
-    protected function getManager(Arguments $args, ConsoleIo $io): Manager
-    {
-        $config = $this->getConfig($args);
-
-        return new Manager($config, $io);
-    }
-
-    /**
      * Execute the command.
      *
      * @param \Cake\Console\Arguments $args The command arguments.
@@ -201,7 +125,13 @@ class MigrateCommand extends Command
         $date = $args->getOption('date');
         $fake = (bool)$args->getOption('fake');
 
-        $manager = $this->getManager($args, $io);
+        $factory = new ManagerFactory([
+            'plugin' => $args->getOption('plugin'),
+            'source' => $args->getOption('source'),
+            'connection' => $args->getOption('connection'),
+            'dry-run' => $args->getOption('dry-run'),
+        ]);
+        $manager = $factory->createManager($io);
         $config = $manager->getConfig();
 
         $versionOrder = $config->getVersionOrder();

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -24,6 +24,7 @@ use Cake\Utility\Inflector;
 use Migrations\Config\Config;
 use Migrations\Config\ConfigInterface;
 use Migrations\Migration\Manager;
+use Migrations\Migration\ManagerFactory;
 
 /**
  * Status command for built in backend
@@ -90,83 +91,6 @@ class StatusCommand extends Command
     }
 
     /**
-     * Generate a configuration object for the migrations operation.
-     *
-     * @param \Cake\Console\Arguments $args The console arguments
-     * @return \Migrations\Config\Config The generated config instance.
-     */
-    protected function getConfig(Arguments $args): Config
-    {
-        $folder = (string)$args->getOption('source');
-
-        // Get the filepath for migrations and seeds(not implemented yet)
-        $dir = ROOT . '/config/' . $folder;
-        if (defined('CONFIG')) {
-            $dir = CONFIG . $folder;
-        }
-        $plugin = $args->getOption('plugin');
-        if ($plugin && is_string($plugin)) {
-            $dir = Plugin::path($plugin) . 'config/' . $folder;
-        }
-
-        // Get the phinxlog table name. Plugins have separate migration history.
-        // The names and separate table history is something we could change in the future.
-        $table = 'phinxlog';
-        if ($plugin && is_string($plugin)) {
-            $prefix = Inflector::underscore($plugin) . '_';
-            $prefix = str_replace(['\\', '/', '.'], '_', $prefix);
-            $table = $prefix . $table;
-        }
-        $templatePath = dirname(__DIR__) . DS . 'templates' . DS;
-        $connectionName = (string)$args->getOption('connection');
-
-        // TODO this all needs to go away. But first Environment and Manager need to work
-        // with Cake's ConnectionManager.
-        $connectionConfig = ConnectionManager::getConfig($connectionName);
-        if (!$connectionConfig) {
-            throw new StopException("Could not find connection `{$connectionName}`");
-        }
-
-        /** @var array<string, string> $connectionConfig */
-        $adapter = $connectionConfig['scheme'] ?? null;
-        $adapterConfig = [
-            'adapter' => $adapter,
-            'connection' => $connectionName,
-            'database' => $connectionConfig['database'],
-            'migration_table' => $table,
-            'dryrun' => $args->getOption('dry-run'),
-        ];
-
-        $configData = [
-            'paths' => [
-                'migrations' => $dir,
-            ],
-            'templates' => [
-                'file' => $templatePath . 'Phinx/create.php.template',
-            ],
-            'migration_base_class' => 'Migrations\AbstractMigration',
-            'environment' => $adapterConfig,
-            // TODO do we want to support the DI container in migrations?
-        ];
-
-        return new Config($configData);
-    }
-
-    /**
-     * Get the migration manager for the current CLI options and application configuration.
-     *
-     * @param \Cake\Console\Arguments $args The command arguments.
-     * @param \Cake\Console\ConsoleIo $io The command io.
-     * @return \Migrations\Migration\Manager
-     */
-    protected function getManager(Arguments $args, ConsoleIo $io): Manager
-    {
-        $config = $this->getConfig($args);
-
-        return new Manager($config, $io);
-    }
-
-    /**
      * Execute the command.
      *
      * @param \Cake\Console\Arguments $args The command arguments.
@@ -177,7 +101,15 @@ class StatusCommand extends Command
     {
         /** @var string|null $format */
         $format = $args->getOption('format');
-        $migrations = $this->getManager($args, $io)->printStatus($format);
+
+        $factory = new ManagerFactory([
+            'plugin' => $args->getOption('plugin'),
+            'source' => $args->getOption('source'),
+            'connection' => $args->getOption('connection'),
+            'dry-run' => $args->getOption('dry-run'),
+        ]);
+        $manager = $factory->createManager($io);
+        $migrations = $manager->printStatus($format);
 
         switch ($format) {
             case 'json':

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -17,13 +17,7 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use Cake\Console\Exception\StopException;
-use Cake\Core\Plugin;
-use Cake\Datasource\ConnectionManager;
-use Cake\Utility\Inflector;
-use Migrations\Config\Config;
 use Migrations\Config\ConfigInterface;
-use Migrations\Migration\Manager;
 use Migrations\Migration\ManagerFactory;
 
 /**

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -113,7 +113,7 @@ class Config implements ConfigInterface
      */
     public function getConnection(): string|false
     {
-        return $this->values['connection'] ?? false;
+        return $this->values['environment']['connection'] ?? false;
     }
 
     /**

--- a/src/Migration/ManagerFactory.php
+++ b/src/Migration/ManagerFactory.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Migration;
+
+use Cake\Console\ConsoleIo;
+use Cake\Core\Plugin;
+use Cake\Datasource\ConnectionManager;
+use Cake\Utility\Inflector;
+use Migrations\Config\Config;
+use Migrations\Config\ConfigInterface;
+use RuntimeException;
+
+/**
+ * Factory for Config and Manager
+ *
+ * Used by Console commands.
+ *
+ * @internal
+ */
+class ManagerFactory
+{
+    /**
+     * Constructor
+     *
+     * ## Options
+     *
+     * - source - The directory in app/config that migrations should be read from.
+     * - plugin - The plugin name that migrations are being run on.
+     * - connection - The connection name.
+     * - dry-run - Whether or not dry-run mode should be enabled.
+     *
+     * @param array $options The command line options for creating config/manager.
+     */
+    public function __construct(protected array $options)
+    {
+    }
+
+    public function getOption(string $name): mixed
+    {
+        if (!isset($this->options[$name])) {
+            return null;
+        }
+
+        return $this->options[$name];
+    }
+
+    public function createConfig(): ConfigInterface
+    {
+        $folder = (string)$this->getOption('source');
+
+        // Get the filepath for migrations and seeds(not implemented yet)
+        $dir = ROOT . DS . 'config' . DS . $folder;
+        if (defined('CONFIG')) {
+            $dir = CONFIG . $folder;
+        }
+        $plugin = $this->getOption('plugin');
+        if ($plugin && is_string($plugin)) {
+            $dir = Plugin::path($plugin) . 'config' . DS . $folder;
+        }
+
+        // Get the phinxlog table name. Plugins have separate migration history.
+        // The names and separate table history is something we could change in the future.
+        $table = 'phinxlog';
+        if ($plugin && is_string($plugin)) {
+            $prefix = Inflector::underscore($plugin) . '_';
+            $prefix = str_replace(['\\', '/', '.'], '_', $prefix);
+            $table = $prefix . $table;
+        }
+        $templatePath = dirname(__DIR__) . DS . 'templates' . DS;
+        $connectionName = (string)$this->getOption('connection');
+
+        // TODO this all needs to go away. But first Environment and Manager need to work
+        // with Cake's ConnectionManager.
+        $connectionConfig = ConnectionManager::getConfig($connectionName);
+        if (!$connectionConfig) {
+            throw new RuntimeException("Could not find connection `{$connectionName}`");
+        }
+
+        /** @var array<string, string> $connectionConfig */
+        $adapter = $connectionConfig['scheme'] ?? null;
+        $adapterConfig = [
+            'adapter' => $adapter,
+            'connection' => $connectionName,
+            'database' => $connectionConfig['database'],
+            'migration_table' => $table,
+            'dryrun' => $this->getOption('dry-run'),
+        ];
+
+        $configData = [
+            'paths' => [
+                'migrations' => $dir,
+            ],
+            'templates' => [
+                'file' => $templatePath . 'Phinx/create.php.template',
+            ],
+            'migration_base_class' => 'Migrations\AbstractMigration',
+            'environment' => $adapterConfig,
+            // TODO do we want to support the DI container in migrations?
+        ];
+
+        return new Config($configData);
+    }
+
+    /**
+     * Get the migration manager for the current CLI options and application configuration.
+     *
+     * @param \Cake\Console\ConsoleIo $io The command io.
+     * @param \Migrations\Config\ConfigInterface $config A config instance. Providing null will create a new Config
+     * based on the factory constructor options.
+     * @return \Migrations\Migration\Manager
+     */
+    public function createManager(ConsoleIo $io, ConfigInterface|null $config = null): Manager
+    {
+        $config ??= $this->createConfig();
+
+        return new Manager($config, $io);
+    }
+}
+

--- a/src/Migration/ManagerFactory.php
+++ b/src/Migration/ManagerFactory.php
@@ -46,6 +46,12 @@ class ManagerFactory
     {
     }
 
+    /**
+     * Read configuration options used for this factory
+     *
+     * @param string $name The option name to read
+     * @return mixed Option value or null
+     */
     public function getOption(string $name): mixed
     {
         if (!isset($this->options[$name])) {
@@ -55,6 +61,11 @@ class ManagerFactory
         return $this->options[$name];
     }
 
+    /**
+     * Create a ConfigInterface instance based on the factory options.
+     *
+     * @return \Migrations\Config\ConfigInterface
+     */
     public function createConfig(): ConfigInterface
     {
         $folder = (string)$this->getOption('source');
@@ -120,11 +131,10 @@ class ManagerFactory
      * based on the factory constructor options.
      * @return \Migrations\Migration\Manager
      */
-    public function createManager(ConsoleIo $io, ConfigInterface|null $config = null): Manager
+    public function createManager(ConsoleIo $io, ?ConfigInterface $config = null): Manager
     {
         $config ??= $this->createConfig();
 
         return new Manager($config, $io);
     }
 }
-

--- a/src/MigrationsPlugin.php
+++ b/src/MigrationsPlugin.php
@@ -22,6 +22,7 @@ use Migrations\Command\BakeMigrationCommand;
 use Migrations\Command\BakeMigrationDiffCommand;
 use Migrations\Command\BakeMigrationSnapshotCommand;
 use Migrations\Command\BakeSeedCommand;
+use Migrations\Command\DumpCommand;
 use Migrations\Command\MigrateCommand;
 use Migrations\Command\MigrationsCacheBuildCommand;
 use Migrations\Command\MigrationsCacheClearCommand;
@@ -94,6 +95,7 @@ class MigrationsPlugin extends BasePlugin
             $classes = [
                 StatusCommand::class,
                 MigrateCommand::class,
+                DumpCommand::class,
             ];
             if (class_exists(SimpleBakeCommand::class)) {
                 $classes[] = BakeMigrationCommand::class;

--- a/src/TableFinderTrait.php
+++ b/src/TableFinderTrait.php
@@ -20,6 +20,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
 use ReflectionClass;
 
+// TODO(mark) Make this into a standalone class instead of a trait.
 trait TableFinderTrait
 {
     /**

--- a/tests/TestCase/Command/CompletionTest.php
+++ b/tests/TestCase/Command/CompletionTest.php
@@ -44,7 +44,7 @@ class CompletionTest extends TestCase
     {
         $this->exec('completion subcommands migrations.migrations');
         $expected = [
-            'migrate orm-cache-build orm-cache-clear create dump mark_migrated rollback seed status',
+            'dump migrate orm-cache-build orm-cache-clear create mark_migrated rollback seed status',
         ];
         $actual = $this->_out->messages();
         $this->assertEquals($expected, $actual);

--- a/tests/TestCase/Command/DumpCommandTest.php
+++ b/tests/TestCase/Command/DumpCommandTest.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+namespace Migrations\Test\TestCase\Command;
+
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Core\Configure;
+use Cake\Core\Exception\MissingPluginException;
+use Cake\Core\Plugin;
+use Cake\Database\Connection;
+use Cake\Database\Schema\TableSchema;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+use RuntimeException;
+
+class DumpCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    protected Connection $connection;
+    protected string $_compareBasePath;
+    protected string $dumpFile;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        Configure::write('Migrations.backend', 'builtin');
+
+        /** @var \Cake\Database\Connection $this->connection */
+        $this->connection = ConnectionManager::get('test');
+        $this->connection->execute('DROP TABLE IF EXISTS numbers');
+        $this->connection->execute('DROP TABLE IF EXISTS letters');
+        $this->connection->execute('DROP TABLE IF EXISTS parts');
+        $this->connection->execute('DROP TABLE IF EXISTS phinxlog');
+
+        $this->dumpFile = ROOT . DS . 'config/TestsMigrations/schema-dump-test.lock';
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->connection->execute('DROP TABLE IF EXISTS numbers');
+        $this->connection->execute('DROP TABLE IF EXISTS letters');
+        $this->connection->execute('DROP TABLE IF EXISTS parts');
+        $this->connection->execute('DROP TABLE IF EXISTS phinxlog');
+        if (file_exists($this->dumpFile)) {
+            unlink($this->dumpFile);
+        }
+    }
+
+    public function testExecuteIncorrectConnection(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->exec('migrations dump --connection lolnope');
+    }
+
+    public function testExecuteIncorrectPlugin(): void
+    {
+        $this->expectException(MissingPluginException::class);
+        $this->exec('migrations dump --plugin lolnope');
+    }
+
+    public function testExecuteSuccess(): void
+    {
+        // Run migrations
+        $this->exec('migrations migrate --connection test --source TestsMigrations --no-lock');
+        $this->assertExitSuccess();
+
+        // Generate dump file.
+        $this->exec('migrations dump --connection test --source TestsMigrations');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('config/TestsMigrations/schema-dump-test.lock');
+
+        $this->assertFileExists($this->dumpFile);
+        /** @var array<string, TableSchema> $generatedDump */
+        $generatedDump = unserialize(file_get_contents($this->dumpFile));
+
+        $this->assertArrayHasKey('letters', $generatedDump);
+        $this->assertArrayHasKey('numbers', $generatedDump);
+        $this->assertInstanceOf(TableSchema::class, $generatedDump['numbers']);
+        $this->assertInstanceOf(TableSchema::class, $generatedDump['letters']);
+        $this->assertEquals(['id', 'number', 'radix'], $generatedDump['numbers']->columns());
+        $this->assertEquals(['id', 'letter'], $generatedDump['letters']->columns());
+    }
+
+    public function testExecutePlugin(): void
+    {
+        $this->loadPlugins(['Migrator']);
+
+        $this->exec('migrations dump --connection test --plugin Migrator');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('Migrator/config/Migrations/schema-dump-test.lock');
+
+        $dumpFile = Plugin::path('Migrator') . '/config/Migrations/schema-dump-test.lock';
+        if (file_exists($dumpFile)) {
+            unlink($dumpFile);
+        }
+    }
+}

--- a/tests/TestCase/Command/DumpCommandTest.php
+++ b/tests/TestCase/Command/DumpCommandTest.php
@@ -71,7 +71,7 @@ class DumpCommandTest extends TestCase
         $this->exec('migrations dump --connection test --source TestsMigrations');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('config/TestsMigrations/schema-dump-test.lock');
+        $this->assertOutputContains('config' . DS . 'TestsMigrations' . DS . 'schema-dump-test.lock');
 
         $this->assertFileExists($this->dumpFile);
         /** @var array<string, TableSchema> $generatedDump */
@@ -92,7 +92,7 @@ class DumpCommandTest extends TestCase
         $this->exec('migrations dump --connection test --plugin Migrator');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('Migrator/config/Migrations/schema-dump-test.lock');
+        $this->assertOutputContains('Migrator' . DS . 'config' . DS . 'Migrations' . DS . 'schema-dump-test.lock');
 
         $dumpFile = Plugin::path('Migrator') . '/config/Migrations/schema-dump-test.lock';
         if (file_exists($dumpFile)) {

--- a/tests/TestCase/Command/Phinx/DumpTest.php
+++ b/tests/TestCase/Command/Phinx/DumpTest.php
@@ -91,6 +91,7 @@ class DumpTest extends TestCase
         $this->connection->execute('DROP TABLE IF EXISTS numbers');
         $this->connection->execute('DROP TABLE IF EXISTS letters');
         $this->connection->execute('DROP TABLE IF EXISTS parts');
+        $this->connection->execute('DROP TABLE IF EXISTS stores');
         $this->dumpfile = ROOT . DS . 'config/TestsMigrations/schema-dump-test.lock';
     }
 
@@ -106,6 +107,7 @@ class DumpTest extends TestCase
         $this->connection->execute('DROP TABLE IF EXISTS numbers');
         $this->connection->execute('DROP TABLE IF EXISTS letters');
         $this->connection->execute('DROP TABLE IF EXISTS parts');
+        $this->connection->execute('DROP TABLE IF EXISTS stores');
     }
 
     /**

--- a/tests/TestCase/Command/StatusCommandTest.php
+++ b/tests/TestCase/Command/StatusCommandTest.php
@@ -8,6 +8,7 @@ use Cake\Core\Configure;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Database\Exception\DatabaseException;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 
 class StatusCommandTest extends TestCase
 {
@@ -74,7 +75,7 @@ class StatusCommandTest extends TestCase
 
     public function testExecuteConnectionDoesNotExist(): void
     {
+        $this->expectException(RuntimeException::class);
         $this->exec('migrations status -c lolnope');
-        $this->assertExitError();
     }
 }

--- a/tests/TestCase/Config/AbstractConfigTestCase.php
+++ b/tests/TestCase/Config/AbstractConfigTestCase.php
@@ -34,9 +34,9 @@ abstract class AbstractConfigTestCase extends TestCase
         $adapter = [
             'migration_table' => 'phinxlog',
             'adapter' => $connectionConfig['scheme'],
-            'user' => $connectionConfig['username'],
-            'pass' => $connectionConfig['password'],
-            'host' => $connectionConfig['host'],
+            'user' => $connectionConfig['username'] ?? '',
+            'pass' => $connectionConfig['password'] ?? '',
+            'host' => $connectionConfig['host'] ?? '',
             'name' => $connectionConfig['database'],
         ];
 

--- a/tests/TestCase/Db/Adapter/PhinxAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PhinxAdapterTest.php
@@ -14,18 +14,12 @@ use Migrations\Db\Adapter\PhinxAdapter;
 use Migrations\Db\Adapter\SqliteAdapter;
 use Migrations\Db\Literal;
 use Migrations\Db\Table\ForeignKey;
-use PDO;
 use PDOException;
 use Phinx\Db\Table as PhinxTable;
 use Phinx\Db\Table\Column as PhinxColumn;
 use Phinx\Util\Literal as PhinxLiteral;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputDefinition;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\BufferedOutput;
-use UnexpectedValueException;
 
 class PhinxAdapterTest extends TestCase
 {
@@ -1136,7 +1130,6 @@ OUTPUT;
      */
     public function testDumpInsert()
     {
-
         $table = new PhinxTable('table1', [], $this->adapter);
         $table->addColumn('string_col', 'string')
             ->addColumn('int_col', 'integer')
@@ -1177,7 +1170,6 @@ OUTPUT;
      */
     public function testDumpBulkinsert()
     {
-
         $table = new PhinxTable('table1', [], $this->adapter);
         $table->addColumn('string_col', 'string')
             ->addColumn('int_col', 'integer')


### PR DESCRIPTION
- Add a `migrations dump` command that uses the new backend.
- Extract common factory logic into a factory class instead of using inheritance or traits to create `Config` and `Manager` instances.

Part of #647