### PR TITLE
Add Mark migrated command

### DIFF
--- a/src/Command/MarkMigratedCommand.php
+++ b/src/Command/MarkMigratedCommand.php
@@ -1,0 +1,145 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use DateTime;
+use Exception;
+use InvalidArgumentException;
+use Migrations\Config\ConfigInterface;
+use Migrations\Migration\ManagerFactory;
+use Throwable;
+
+/**
+ * MarkMigrated command marks migrations as run when they haven't been.
+ */
+class MarkMigratedCommand extends Command
+{
+    /**
+     * The default name added to the application command list
+     *
+     * @return string
+     */
+    public static function defaultName(): string
+    {
+        return 'migrations mark_migrated';
+    }
+
+    /**
+     * Configure the option parser
+     *
+     * @param \Cake\Console\ConsoleOptionParser $parser The option parser to configure
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        $parser->setDescription([
+            'Mark a migration as applied',
+            '',
+            'Can mark one or more migrations as applied without applying the changes in the migration.',
+            '',
+            '<info>migrations mark_migrated --connection secondary</info>',
+            'Mark all migrations as applied',
+            '',
+            '<info>migrations mark_migrated --connection secondary --target 003</info>',
+            'mark migrations as applied up to the 003',
+            '',
+            '<info>migrations mark_migrated --target 003 --only</info>',
+            'mark only 003 as applied.',
+            '',
+            '<info>migrations mark_migrated --target 003 --exclude</info>',
+            'mark up to 003, but not 003 as applied.',
+        ])->addOption('plugin', [
+            'short' => 'p',
+            'help' => 'The plugin to mark migrations for',
+        ])->addOption('connection', [
+            'short' => 'c',
+            'help' => 'The datasource connection to use',
+            'default' => 'default',
+        ])->addOption('source', [
+            'short' => 's',
+            'default' => ConfigInterface::DEFAULT_MIGRATION_FOLDER,
+            'help' => 'The folder where your migrations are',
+        ])->addOption('target', [
+            'short' => 't',
+            'help' => 'Migrations from the beginning to the provided version will be marked as applied.',
+        ])->addOption('only', [
+            'short' => 'o',
+            'help' => 'If present, only the target migration will be marked as applied.',
+            'boolean' => true,
+        ])->addOption('exclude', [
+            'short' => 'x',
+            'help' => 'If present, migrations from the beginning until the target version but not including the target will be marked as applied.',
+            'boolean' => true,
+        ]);
+
+        return $parser;
+    }
+
+    /**
+     * Checks for an invalid use of `--exclude` or `--only`
+     *
+     * @param \Cake\Console\Arguments $args The console arguments
+     * @return bool Returns true when it is an invalid use of `--exclude` or `--only` otherwise false
+     */
+    protected function invalidOnlyOrExclude(Arguments $args): bool
+    {
+        return ($args->getOption('exclude') && $args->getOption('only')) ||
+            ($args->getOption('exclude') || $args->getOption('only')) &&
+            $args->getOption('target') === null;
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param \Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return int|null The exit code or null for success
+     */
+    public function execute(Arguments $args, ConsoleIo $io): ?int
+    {
+        $factory = new ManagerFactory([
+            'plugin' => $args->getOption('plugin'),
+            'source' => $args->getOption('source'),
+            'connection' => $args->getOption('connection'),
+        ]);
+        $manager = $factory->createManager($io);
+        $config = $manager->getConfig();
+        $migrationPaths = $config->getMigrationPaths();
+        $path = array_pop($migrationPaths);
+
+        if ($this->invalidOnlyOrExclude($args)) {
+            $io->err(
+                '<error>You should use `--exclude` OR `--only` (not both) along with a `--target` !</error>'
+            );
+
+            return self::CODE_ERROR;
+        }
+
+        try {
+            $versions = $manager->getVersionsToMark($args);
+        } catch (InvalidArgumentException $e) {
+            $io->err(sprintf('<error>%s</error>', $e->getMessage()));
+
+            return self::CODE_ERROR;
+        }
+
+        $manager->markVersionsAsMigrated($path, $versions, $io);
+
+        return self::CODE_SUCCESS;
+    }
+}

--- a/src/Command/MarkMigratedCommand.php
+++ b/src/Command/MarkMigratedCommand.php
@@ -17,12 +17,9 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use DateTime;
-use Exception;
 use InvalidArgumentException;
 use Migrations\Config\ConfigInterface;
 use Migrations\Migration\ManagerFactory;
-use Throwable;
 
 /**
  * MarkMigrated command marks migrations as run when they haven't been.

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -23,8 +23,6 @@ use Phinx\Util\Util;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class Manager
 {

--- a/src/MigrationsPlugin.php
+++ b/src/MigrationsPlugin.php
@@ -23,6 +23,7 @@ use Migrations\Command\BakeMigrationDiffCommand;
 use Migrations\Command\BakeMigrationSnapshotCommand;
 use Migrations\Command\BakeSeedCommand;
 use Migrations\Command\DumpCommand;
+use Migrations\Command\MarkMigratedCommand;
 use Migrations\Command\MigrateCommand;
 use Migrations\Command\MigrationsCacheBuildCommand;
 use Migrations\Command\MigrationsCacheClearCommand;
@@ -94,6 +95,7 @@ class MigrationsPlugin extends BasePlugin
         if (Configure::read('Migrations.backend') == 'builtin') {
             $classes = [
                 StatusCommand::class,
+                MarkMigratedCommand::class,
                 MigrateCommand::class,
                 DumpCommand::class,
             ];

--- a/tests/TestCase/Command/CompletionTest.php
+++ b/tests/TestCase/Command/CompletionTest.php
@@ -44,7 +44,7 @@ class CompletionTest extends TestCase
     {
         $this->exec('completion subcommands migrations.migrations');
         $expected = [
-            'dump migrate orm-cache-build orm-cache-clear create mark_migrated rollback seed status',
+            'dump mark_migrated migrate orm-cache-build orm-cache-clear create rollback seed status',
         ];
         $actual = $this->_out->messages();
         $this->assertEquals($expected, $actual);

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -1,0 +1,412 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Migrations\Test\TestCase\Command;
+
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Core\Configure;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+use Exception;
+use Migrations\CakeManager;
+use Migrations\MigrationsDispatcher;
+use Migrations\Test\CommandTester as TestCommandTester;
+use Migrations\Test\TestCase\DriverConnectionTrait;
+use PDO;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * MarkMigratedTest class
+ */
+class MarkMigratedTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+    /**
+     * Instance of a Cake Connection object
+     *
+     * @var \Cake\Database\Connection
+     */
+    protected $connection;
+
+    /**
+     * setup method
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        Configure::write('Migrations.backend', 'builtin');
+
+        $this->connection = ConnectionManager::get('test');
+        $this->connection->execute('DROP TABLE IF EXISTS phinxlog');
+        $this->connection->execute('DROP TABLE IF EXISTS numbers');
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        $this->connection->execute('DROP TABLE IF EXISTS phinxlog');
+        $this->connection->execute('DROP TABLE IF EXISTS numbers');
+    }
+
+    /**
+     * Test executing "mark_migration" in a standard way
+     *
+     * @return void
+     */
+    public function testExecute()
+    {
+        $this->exec('migrations mark_migrated --connection=test --source=TestsMigrations');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains(
+            'Migration `20150826191400` successfully marked migrated !',
+        );
+        $this->assertOutputContains(
+            'Migration `20150724233100` successfully marked migrated !',
+        );
+        $this->assertOutputContains(
+            'Migration `20150704160200` successfully marked migrated !',
+        );
+
+        $result = $this->connection->selectQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
+        $this->assertEquals('20150704160200', $result[0]['version']);
+        $this->assertEquals('20150724233100', $result[1]['version']);
+        $this->assertEquals('20150826191400', $result[2]['version']);
+
+        $this->exec('migrations mark_migrated --connection=test --source=TestsMigrations');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains(
+            'Skipping migration `20150704160200` (already migrated).',
+        );
+        $this->assertOutputContains(
+            'Skipping migration `20150724233100` (already migrated).',
+        );
+        $this->assertOutputContains(
+            'Skipping migration `20150826191400` (already migrated).',
+        );
+
+        $result = $this->connection->selectQuery()->select(['COUNT(*)'])->from('phinxlog')->execute();
+        $this->assertEquals(4, $result->fetchColumn(0));
+    }
+
+    /**
+     * Test executing "mark_migration" with deprecated `all` version
+     *
+     * @return void
+     */
+    public function testExecuteAll()
+    {
+        $this->markTestIncomplete();
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'version' => 'all',
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $this->assertStringContainsString(
+            'Migration `20150826191400` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertStringContainsString(
+            'Migration `20150724233100` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertStringContainsString(
+            'Migration `20150704160200` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertStringContainsString(
+            'DEPRECATED: `all` or `*` as version is deprecated. Use `bin/cake migrations mark_migrated` instead',
+            $this->commandTester->getDisplay()
+        );
+
+        $result = $this->connection->selectQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
+        $this->assertEquals('20150704160200', $result[0]['version']);
+        $this->assertEquals('20150724233100', $result[1]['version']);
+        $this->assertEquals('20150826191400', $result[2]['version']);
+
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'version' => 'all',
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $this->assertStringContainsString(
+            'Skipping migration `20150704160200` (already migrated).',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertStringContainsString(
+            'Skipping migration `20150724233100` (already migrated).',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertStringContainsString(
+            'Skipping migration `20150826191400` (already migrated).',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertStringContainsString(
+            'DEPRECATED: `all` or `*` as version is deprecated. Use `bin/cake migrations mark_migrated` instead',
+            $this->commandTester->getDisplay()
+        );
+    }
+
+    public function testExecuteTarget()
+    {
+        $this->markTestIncomplete();
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--target' => '20150704160200',
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $this->assertStringContainsString(
+            'Migration `20150704160200` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+
+        $result = $this->connection->selectQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
+        $this->assertEquals('20150704160200', $result[0]['version']);
+
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--target' => '20150826191400',
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $this->assertStringContainsString(
+            'Skipping migration `20150704160200` (already migrated).',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertStringContainsString(
+            'Migration `20150724233100` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertStringContainsString(
+            'Migration `20150826191400` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+
+        $result = $this->connection->selectQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
+        $this->assertEquals('20150704160200', $result[0]['version']);
+        $this->assertEquals('20150724233100', $result[1]['version']);
+        $this->assertEquals('20150826191400', $result[2]['version']);
+        $result = $this->connection->selectQuery()->select(['COUNT(*)'])->from('phinxlog')->execute();
+        $this->assertEquals(3, $result->fetchColumn(0));
+
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--target' => '20150704160610',
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $this->assertStringContainsString(
+            'Migration `20150704160610` was not found !',
+            $this->commandTester->getDisplay()
+        );
+    }
+
+    public function testExecuteTargetWithExclude()
+    {
+        $this->markTestIncomplete();
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--target' => '20150724233100',
+            '--exclude' => true,
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $this->assertStringContainsString(
+            'Migration `20150704160200` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+
+        $result = $this->connection->selectQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
+        $this->assertEquals('20150704160200', $result[0]['version']);
+
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--target' => '20150826191400',
+            '--exclude' => true,
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $this->assertStringContainsString(
+            'Skipping migration `20150704160200` (already migrated).',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertStringContainsString(
+            'Migration `20150724233100` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+
+        $result = $this->connection->selectQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
+        $this->assertEquals('20150704160200', $result[0]['version']);
+        $this->assertEquals('20150724233100', $result[1]['version']);
+        $result = $this->connection->selectQuery()->select(['COUNT(*)'])->from('phinxlog')->execute();
+        $this->assertEquals(2, $result->fetchColumn(0));
+
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--target' => '20150704160610',
+            '--exclude' => true,
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $this->assertStringContainsString(
+            'Migration `20150704160610` was not found !',
+            $this->commandTester->getDisplay()
+        );
+    }
+
+    public function testExecuteTargetWithOnly()
+    {
+        $this->markTestIncomplete();
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--target' => '20150724233100',
+            '--only' => true,
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $this->assertStringContainsString(
+            'Migration `20150724233100` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+
+        $result = $this->connection->selectQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
+        $this->assertEquals('20150724233100', $result[0]['version']);
+
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--target' => '20150826191400',
+            '--only' => true,
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $this->assertStringContainsString(
+            'Migration `20150826191400` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+
+        $result = $this->connection->selectQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
+        $this->assertEquals('20150826191400', $result[1]['version']);
+        $this->assertEquals('20150724233100', $result[0]['version']);
+        $result = $this->connection->selectQuery()->select(['COUNT(*)'])->from('phinxlog')->execute();
+        $this->assertEquals(2, $result->fetchColumn(0));
+
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--target' => '20150704160610',
+            '--only' => true,
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $this->assertStringContainsString(
+            'Migration `20150704160610` was not found !',
+            $this->commandTester->getDisplay()
+        );
+    }
+
+    public function testExecuteWithVersionAsArgument()
+    {
+        $this->markTestIncomplete();
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'version' => '20150724233100',
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $this->assertStringContainsString(
+            'Migration `20150724233100` successfully marked migrated !',
+            $this->commandTester->getDisplay()
+        );
+        $this->assertStringContainsString(
+            'DEPRECATED: VERSION as argument is deprecated. Use: ' .
+            '`bin/cake migrations mark_migrated --target=VERSION --only`',
+            $this->commandTester->getDisplay()
+        );
+
+        $result = $this->connection->selectQuery()->select(['*'])->from('phinxlog')->execute()->fetchAll('assoc');
+        $this->assertSame(1, count($result));
+        $this->assertEquals('20150724233100', $result[0]['version']);
+    }
+
+    public function testExecuteInvalidUseOfOnlyAndExclude()
+    {
+        $this->markTestIncomplete();
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--exclude' => true,
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $result = $this->connection->selectQuery()->select(['COUNT(*)'])->from('phinxlog')->execute();
+        $this->assertEquals(0, $result->fetchColumn(0));
+        $this->assertStringContainsString(
+            'You should use `--exclude` OR `--only` (not both) along with a `--target` !',
+            $this->commandTester->getDisplay()
+        );
+
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--only' => true,
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $result = $this->connection->selectQuery()->select(['COUNT(*)'])->from('phinxlog')->execute();
+        $this->assertEquals(0, $result->fetchColumn(0));
+        $this->assertStringContainsString(
+            'You should use `--exclude` OR `--only` (not both) along with a `--target` !',
+            $this->commandTester->getDisplay()
+        );
+
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--target' => '20150724233100',
+            '--only' => true,
+            '--exclude' => true,
+            '--connection' => 'test',
+            '--source' => 'TestsMigrations',
+        ]);
+
+        $result = $this->connection->selectQuery()->select(['COUNT(*)'])->from('phinxlog')->execute();
+        $this->assertEquals(0, $result->fetchColumn(0));
+        $this->assertStringContainsString(
+            'You should use `--exclude` OR `--only` (not both) along with a `--target` !',
+            $this->commandTester->getDisplay()
+        );
+    }
+}

--- a/tests/TestCase/Command/MarkMigratedTest.php
+++ b/tests/TestCase/Command/MarkMigratedTest.php
@@ -17,15 +17,6 @@ use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
-use Exception;
-use Migrations\CakeManager;
-use Migrations\MigrationsDispatcher;
-use Migrations\Test\CommandTester as TestCommandTester;
-use Migrations\Test\TestCase\DriverConnectionTrait;
-use PDO;
-use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Output\StreamOutput;
-use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * MarkMigratedTest class
@@ -33,6 +24,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 class MarkMigratedTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
+
     /**
      * Instance of a Cake Connection object
      *
@@ -268,6 +260,7 @@ class MarkMigratedTest extends TestCase
             'You should use `--exclude` OR `--only` (not both) along with a `--target` !',
         );
     }
+
     public function testExecuteInvalidUseOfOnly(): void
     {
         $this->exec('migrations mark_migrated --connection=test --source=TestsMigrations --only');


### PR DESCRIPTION
Add a `mark_migrated` command that uses the new migration backend.

Part of #647 