### PR TITLE
Add `migrations create` alias with new backend

### DIFF
--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -48,10 +48,11 @@ class DumpCommand extends Command
      * Extract options for the dump command from another migrations option parser.
      *
      * @param \Cake\Console\Arguments $args
-     * @return array<string, mixed>
+     * @return array<int|string, mixed>
      */
     public static function extractArgs(Arguments $args): array
     {
+        /** @var array<int|string, mixed> $newArgs */
         $newArgs = [];
         if ($args->getOption('connection')) {
             $newArgs[] = '-c';

--- a/src/MigrationsPlugin.php
+++ b/src/MigrationsPlugin.php
@@ -103,7 +103,8 @@ class MigrationsPlugin extends BasePlugin
                 SeedCommand::class,
                 StatusCommand::class,
             ];
-            if (class_exists(SimpleBakeCommand::class)) {
+            $hasBake = class_exists(SimpleBakeCommand::class);
+            if ($hasBake) {
                 $classes[] = BakeMigrationCommand::class;
                 $classes[] = BakeMigrationDiffCommand::class;
                 $classes[] = BakeMigrationSnapshotCommand::class;
@@ -120,6 +121,10 @@ class MigrationsPlugin extends BasePlugin
                 }
                 $found['migrations.' . $name] = $class;
             }
+            if ($hasBake) {
+                $found['migrations create'] = BakeMigrationCommand::class;
+            }
+
             $commands->addMany($found);
 
             return $commands;

--- a/tests/TestCase/Command/BakeMigrationCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationCommandTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Migrations\Test\TestCase\Command;
 
 use Cake\Console\BaseCommand;
+use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\StringCompareTrait;
 use Migrations\Command\BakeMigrationCommand;
@@ -111,12 +112,21 @@ class BakeMigrationCommandTest extends TestCase
         $this->assertErrorContains('A migration with the name `CreateUsers` already exists. Please use a different name.');
     }
 
+    public function testCreateBuiltinAlias()
+    {
+        Configure::write('Migrations.backend', 'builtin');
+        $this->exec('migrations create CreateUsers --connection test');
+        $this->assertExitCode(BaseCommand::CODE_SUCCESS);
+        $this->assertOutputRegExp('/Wrote.*?CreateUsers\.php/');
+    }
+
     /**
      * Tests that baking a migration with the "drop" string inside the name generates a valid drop migration.
      */
     public function testCreateDropMigration()
     {
         $this->exec('bake migration DropUsers --connection test');
+        $this->assertOutputRegExp('/Wrote.*?DropUsers\.php/');
 
         $file = glob(ROOT . DS . 'config' . DS . 'Migrations' . DS . '*_DropUsers.php');
         $filePath = current($file);


### PR DESCRIPTION
When the `builtin` backend is used `migrations create` will use the `bake command`. This helps simplify migrations long term, as we can re-use the functionality in bake to generate code instead of phinx's internals.

Part of #647