### PR TITLE
Migrations builtin backend

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -132,6 +132,11 @@
       <code>$executedVersion</code>
     </ReferenceReusedFromConfusingScope>
   </file>
+  <file src="src/Migration/PhinxBackend.php">
+    <DeprecatedTrait>
+      <code>ConfigurationTrait</code>
+    </DeprecatedTrait>
+  </file>
   <file src="src/Migrations.php">
     <DeprecatedTrait>
       <code>ConfigurationTrait</code>

--- a/src/Command/MarkMigratedCommand.php
+++ b/src/Command/MarkMigratedCommand.php
@@ -135,7 +135,8 @@ class MarkMigratedCommand extends Command
             return self::CODE_ERROR;
         }
 
-        $manager->markVersionsAsMigrated($path, $versions, $io);
+        $output = $manager->markVersionsAsMigrated($path, $versions);
+        array_map(fn ($line) => $io->out($line), $output);
 
         return self::CODE_SUCCESS;
     }

--- a/src/Db/Adapter/PdoAdapter.php
+++ b/src/Db/Adapter/PdoAdapter.php
@@ -119,7 +119,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     {
         parent::setOptions($options);
 
-        // TODO: Consider renaming this class to ConnectionAdapter
         if (isset($options['connection']) && $options['connection'] instanceof Connection) {
             $this->setConnection($options['connection']);
         }

--- a/src/Migration/BuiltinBackend.php
+++ b/src/Migration/BuiltinBackend.php
@@ -13,22 +13,13 @@ declare(strict_types=1);
  */
 namespace Migrations\Migration;
 
-use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\StubConsoleInput;
 use Cake\Console\TestSuite\StubConsoleOutput;
-use Cake\Datasource\ConnectionManager;
 use DateTime;
 use InvalidArgumentException;
-use Migrations\Command\StatusCommand;
-use Phinx\Config\Config;
-use Phinx\Config\ConfigInterface;
-use Phinx\Db\Adapter\WrapperInterface;
-use Migrations\Migration\Manager;
-use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -108,7 +99,6 @@ class BuiltinBackend
      * - `connection` The datasource connection to use
      * - `source` The folder where migrations are in
      * - `plugin` The plugin containing the migrations
-     *
      * @return array The migrations list and their statuses
      */
     public function status(array $options = []): array

--- a/src/Migration/BuiltinBackend.php
+++ b/src/Migration/BuiltinBackend.php
@@ -169,17 +169,17 @@ class BuiltinBackend
      */
     public function migrate(array $options = []): bool
     {
-        $this->setCommand('migrate');
-        $input = $this->getInput('Migrate', [], $options);
-        $method = 'migrate';
-        $params = ['default', $input->getOption('target')];
+        $manager = $this->getManager($options);
 
-        if ($input->getOption('date')) {
-            $method = 'migrateToDateTime';
-            $params[1] = new DateTime($input->getOption('date'));
+        if (!empty($options['date'])) {
+            $date = new DateTime($options['date']);
+
+            $manager->migrateToDateTime($date);
+
+            return true;
         }
 
-        $this->run($method, $params, $input);
+        $manager->migrate($options['target'] ?? null);
 
         return true;
     }
@@ -351,6 +351,8 @@ class BuiltinBackend
      */
     public function getManager(array $options): Manager
     {
+        $options += $this->default;
+
         $factory = new ManagerFactory([
             'plugin' => $options['plugin'] ?? null,
             'source' => $options['source'] ?? null,

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -22,7 +22,9 @@ use Phinx\Seed\SeedInterface;
 use Phinx\Util\Util;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
-use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
 
 class Manager
 {
@@ -848,7 +850,12 @@ class Manager
 
                     $io->verbose("Constructing <info>$class</info>.");
 
-                    $input = new ArgvInput();
+                    $config = $this->getConfig();
+                    $input = new ArrayInput([
+                        '--plugin' => $config['plugin'],
+                        '--source' => $config['source'],
+                        '--connection' => $config->getConnection(),
+                    ]);
                     $output = new OutputAdapter($io);
 
                     // instantiate it
@@ -957,7 +964,17 @@ class Manager
             /** @var \Phinx\Seed\SeedInterface[] $seeds */
             $seeds = [];
 
-            $input = new ArgvInput();
+            $config = $this->getConfig();
+            $optionDef = new InputDefinition([
+                new InputOption('plugin', mode: InputOption::VALUE_OPTIONAL, default: ''),
+                new InputOption('connection', mode: InputOption::VALUE_OPTIONAL, default: ''),
+                new InputOption('source', mode: InputOption::VALUE_OPTIONAL, default: ''),
+            ]);
+            $input = new ArrayInput([
+                '--plugin' => $config['plugin'],
+                '--connection' => $config->getConnection(),
+                '--source' => $config['source'],
+            ], $optionDef);
             $output = new OutputAdapter($this->io);
 
             foreach ($phpFiles as $filePath) {

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -336,7 +336,6 @@ class Manager
      *
      * @param string $path Path where to look for migrations
      * @param array<int> $versions Versions which should be marked
-     * @param \Cake\Console\ConsoleIo $io ConsoleIo to write output too
      * @return list<string> Output from the operation
      */
     public function markVersionsAsMigrated(string $path, array $versions): array
@@ -852,8 +851,8 @@ class Manager
 
                     $config = $this->getConfig();
                     $input = new ArrayInput([
-                        '--plugin' => $config['plugin'],
-                        '--source' => $config['source'],
+                        '--plugin' => $config['plugin'] ?? null,
+                        '--source' => $config['source'] ?? null,
                         '--connection' => $config->getConnection(),
                     ]);
                     $output = new OutputAdapter($io);
@@ -971,9 +970,9 @@ class Manager
                 new InputOption('source', mode: InputOption::VALUE_OPTIONAL, default: ''),
             ]);
             $input = new ArrayInput([
-                '--plugin' => $config['plugin'],
+                '--plugin' => $config['plugin'] ?? null,
+                '--source' => $config['source'] ?? null,
                 '--connection' => $config->getConnection(),
-                '--source' => $config['source'],
             ], $optionDef);
             $output = new OutputAdapter($this->io);
 

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -161,7 +161,6 @@ class Manager
      */
     public function migrateToDateTime(DateTime $dateTime, bool $fake = false): void
     {
-        // TODO remove the environment parameter. There is only one environment with builtin
         /** @var array<int> $versions */
         $versions = array_keys($this->getMigrations());
         $dateString = $dateTime->format('Ymdhis');
@@ -301,7 +300,6 @@ class Manager
         $migrations = $this->getMigrations();
         $versions = array_keys($migrations);
 
-        // TODO use console arguments
         $versionArg = $args->getArgument('version');
         $targetArg = $args->getOption('target');
         $hasAllVersion = in_array($versionArg, ['all', '*'], true);
@@ -1012,7 +1010,6 @@ class Manager
         }
 
         foreach ($this->seeds as $instance) {
-            // TODO fix this to not use input
             if (isset($input) && $instance instanceof AbstractSeed) {
                 $instance->setInput($input);
             }

--- a/src/Migration/ManagerFactory.php
+++ b/src/Migration/ManagerFactory.php
@@ -92,8 +92,6 @@ class ManagerFactory
         $templatePath = dirname(__DIR__) . DS . 'templates' . DS;
         $connectionName = (string)$this->getOption('connection');
 
-        // TODO this all needs to go away. But first Environment and Manager need to work
-        // with Cake's ConnectionManager.
         $connectionConfig = ConnectionManager::getConfig($connectionName);
         if (!$connectionConfig) {
             throw new RuntimeException("Could not find connection `{$connectionName}`");

--- a/src/Migration/ManagerFactory.php
+++ b/src/Migration/ManagerFactory.php
@@ -118,6 +118,8 @@ class ManagerFactory
             ],
             'migration_base_class' => 'Migrations\AbstractMigration',
             'environment' => $adapterConfig,
+            'plugin' => $plugin,
+            'source' =>  (string)$this->getOption('source'),
             // TODO do we want to support the DI container in migrations?
         ];
 

--- a/src/Migration/ManagerFactory.php
+++ b/src/Migration/ManagerFactory.php
@@ -119,7 +119,7 @@ class ManagerFactory
             'migration_base_class' => 'Migrations\AbstractMigration',
             'environment' => $adapterConfig,
             'plugin' => $plugin,
-            'source' =>  (string)$this->getOption('source'),
+            'source' => (string)$this->getOption('source'),
             // TODO do we want to support the DI container in migrations?
         ];
 

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -15,14 +15,10 @@ namespace Migrations;
 
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
-use DateTime;
 use InvalidArgumentException;
 use Migrations\Migration\BuiltinBackend;
 use Migrations\Migration\PhinxBackend;
-use Phinx\Config\Config;
 use Phinx\Config\ConfigInterface;
-use Phinx\Db\Adapter\WrapperInterface;
-use Phinx\Migration\Manager;
 use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -32,8 +28,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * The Migrations class is responsible for handling migrations command
  * within an none-shell application.
- *
- * TODO(mark) This needs to be adapted to use the configure backend selection.
  */
 class Migrations
 {

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -206,19 +206,9 @@ class Migrations
      */
     public function rollback(array $options = []): bool
     {
-        $this->setCommand('rollback');
-        $input = $this->getInput('Rollback', [], $options);
-        $method = 'rollback';
-        $params = ['default', $input->getOption('target')];
+        $backend = $this->getBackend();
 
-        if ($input->getOption('date')) {
-            $method = 'rollbackToDateTime';
-            $params[1] = new DateTime($input->getOption('date'));
-        }
-
-        $this->run($method, $params, $input);
-
-        return true;
+        return $backend->rollback($options);
     }
 
     /**
@@ -235,32 +225,9 @@ class Migrations
      */
     public function markMigrated(int|string|null $version = null, array $options = []): bool
     {
-        $this->setCommand('mark_migrated');
+        $backend = $this->getBackend();
 
-        if (
-            isset($options['target']) &&
-            isset($options['exclude']) &&
-            isset($options['only'])
-        ) {
-            $exceptionMessage = 'You should use `exclude` OR `only` (not both) along with a `target` argument';
-            throw new InvalidArgumentException($exceptionMessage);
-        }
-
-        $input = $this->getInput('MarkMigrated', ['version' => $version], $options);
-        $this->setInput($input);
-
-        // This will need to vary based on the config option.
-        $migrationPaths = $this->getConfig()->getMigrationPaths();
-        $config = $this->getConfig(true);
-        $params = [
-            array_pop($migrationPaths),
-            $this->getManager($config)->getVersionsToMark($input),
-            $this->output,
-        ];
-
-        $this->run('markVersionsAsMigrated', $params, $input);
-
-        return true;
+        return $backend->markMigrated($version, $options);
     }
 
     /**
@@ -277,76 +244,9 @@ class Migrations
      */
     public function seed(array $options = []): bool
     {
-        $this->setCommand('seed');
-        $input = $this->getInput('Seed', [], $options);
+        $backend = $this->getBackend();
 
-        $seed = $input->getOption('seed');
-        if (!$seed) {
-            $seed = null;
-        }
-
-        $params = ['default', $seed];
-        $this->run('seed', $params, $input);
-
-        return true;
-    }
-
-    /**
-     * Runs the method needed to execute and return
-     *
-     * @param string $method Manager method to call
-     * @param array $params Manager params to pass
-     * @param \Symfony\Component\Console\Input\InputInterface $input InputInterface needed for the
-     * Manager to properly run
-     * @return mixed The result of the CakeManager::$method() call
-     */
-    protected function run(string $method, array $params, InputInterface $input): mixed
-    {
-        // This will need to vary based on the backend configuration
-        if ($this->configuration instanceof Config) {
-            $migrationPaths = $this->getConfig()->getMigrationPaths();
-            $migrationPath = array_pop($migrationPaths);
-            $seedPaths = $this->getConfig()->getSeedPaths();
-            $seedPath = array_pop($seedPaths);
-        }
-
-        $pdo = null;
-        if ($this->manager instanceof Manager) {
-            $pdo = $this->manager->getEnvironment('default')
-                ->getAdapter()
-                ->getConnection();
-        }
-
-        $this->setInput($input);
-        $newConfig = $this->getConfig(true);
-        $manager = $this->getManager($newConfig);
-        $manager->setInput($input);
-
-        // Why is this being done? Is this something we can eliminate in the new code path?
-        if ($pdo !== null) {
-            /** @var \Phinx\Db\Adapter\PdoAdapter|\Migrations\CakeAdapter $adapter */
-            /** @psalm-suppress PossiblyNullReference */
-            $adapter = $this->manager->getEnvironment('default')->getAdapter();
-            while ($adapter instanceof WrapperInterface) {
-                /** @var \Phinx\Db\Adapter\PdoAdapter|\Migrations\CakeAdapter $adapter */
-                $adapter = $adapter->getAdapter();
-            }
-            $adapter->setConnection($pdo);
-        }
-
-        $newMigrationPaths = $newConfig->getMigrationPaths();
-        if (isset($migrationPath) && array_pop($newMigrationPaths) !== $migrationPath) {
-            $manager->resetMigrations();
-        }
-        $newSeedPaths = $newConfig->getSeedPaths();
-        if (isset($seedPath) && array_pop($newSeedPaths) !== $seedPath) {
-            $manager->resetSeeds();
-        }
-
-        /** @var callable $callable */
-        $callable = [$manager, $method];
-
-        return call_user_func_array($callable, $params);
+        return $backend->seed($options);
     }
 
     /**

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -141,10 +141,10 @@ class Migrations
     {
         $backend = (string)(Configure::read('Migrations.backend') ?? 'phinx');
         if ($backend === 'builtin') {
-            return new BuiltinBackend();
+            return new BuiltinBackend($this->default);
         }
         if ($backend === 'phinx') {
-            return new PhinxBackend();
+            return new PhinxBackend($this->default);
         }
 
         throw new RuntimeException("Unknown `Migrations.backend` of `{$backend}`");
@@ -164,7 +164,6 @@ class Migrations
      */
     public function status(array $options = []): array
     {
-        $options = $options + $this->default;
         $backend = $this->getBackend();
 
         return $backend->status($options);
@@ -186,19 +185,9 @@ class Migrations
      */
     public function migrate(array $options = []): bool
     {
-        $this->setCommand('migrate');
-        $input = $this->getInput('Migrate', [], $options);
-        $method = 'migrate';
-        $params = ['default', $input->getOption('target')];
+        $backend = $this->getBackend();
 
-        if ($input->getOption('date')) {
-            $method = 'migrateToDateTime';
-            $params[1] = new DateTime($input->getOption('date'));
-        }
-
-        $this->run($method, $params, $input);
-
-        return true;
+        return $backend->migrate($options);
     }
 
     /**

--- a/tests/TestCase/Command/Phinx/StatusTest.php
+++ b/tests/TestCase/Command/Phinx/StatusTest.php
@@ -185,6 +185,7 @@ class StatusTest extends TestCase
         $migrations = $this->getMigrations();
         $migrations->migrate();
 
+        $migrations = $this->getMigrations();
         $migrationPaths = $migrations->getConfig()->getMigrationPaths();
         $migrationPath = array_pop($migrationPaths);
         $origin = $migrationPath . DS . '20150724233100_update_numbers_table.php';
@@ -248,7 +249,14 @@ class StatusTest extends TestCase
             'connection' => 'test',
             'source' => 'TestsMigrations',
         ];
+        $args = [
+            '--connection' => $params['connection'],
+            '--source' => $params['source'],
+        ];
+        $input = new ArrayInput($args, $this->command->getDefinition());
         $migrations = new Migrations($params);
+        $migrations->setInput($input);
+        $this->command->setInput($input);
 
         $adapter = $migrations
             ->getManager($this->command->getConfig())

--- a/tests/TestCase/Config/AbstractConfigTestCase.php
+++ b/tests/TestCase/Config/AbstractConfigTestCase.php
@@ -55,7 +55,6 @@ abstract class AbstractConfigTestCase extends TestCase
                 'file' => '%%PHINX_CONFIG_PATH%%/tpl/testtemplate.txt',
                 'class' => '%%PHINX_CONFIG_PATH%%/tpl/testtemplate.php',
             ],
-            // TODO ideally we only need the connection and migration table name.
             'environment' => $adapter,
         ];
     }

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -134,7 +134,6 @@ class ManagerTest extends TestCase
         $adapter = $connectionConfig['scheme'] ?? null;
         $adapterConfig = [
             'connection' => 'test',
-            // TODO all of this should go away
             'adapter' => $adapter,
             'user' => $connectionConfig['username'],
             'pass' => $connectionConfig['password'],

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -20,7 +20,6 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Exception;
 use InvalidArgumentException;
-use Migrations\CakeAdapter;
 use Migrations\Migrations;
 use Phinx\Config\FeatureFlags;
 use Phinx\Db\Adapter\WrapperInterface;
@@ -127,7 +126,7 @@ class MigrationsTest extends TestCase
     {
         return [
             ['builtin'],
-            ['phinx']
+            ['phinx'],
         ];
     }
 

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -259,10 +259,13 @@ class MigrationsTest extends TestCase
     /**
      * Tests the collation table behavior when using MySQL
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testCreateWithEncoding()
+    public function testCreateWithEncoding($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $this->skipIf(env('DB') !== 'mysql', 'Requires MySQL');
 
         $migrate = $this->migrations->migrate();
@@ -285,10 +288,13 @@ class MigrationsTest extends TestCase
      * Tests calling Migrations::markMigrated without params marks everything
      * as migrated
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedAll()
+    public function testMarkMigratedAll($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $markMigrated = $this->migrations->markMigrated();
         $this->assertTrue($markMigrated);
         $status = $this->migrations->status();
@@ -322,10 +328,13 @@ class MigrationsTest extends TestCase
      * string 'all' marks everything
      * as migrated
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedAllAsVersion()
+    public function testMarkMigratedAllAsVersion($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $markMigrated = $this->migrations->markMigrated('all');
         $this->assertTrue($markMigrated);
         $status = $this->migrations->status();
@@ -358,10 +367,13 @@ class MigrationsTest extends TestCase
      * Tests calling Migrations::markMigrated with the target option will mark
      * only up to that one
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedTarget()
+    public function testMarkMigratedTarget($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $markMigrated = $this->migrations->markMigrated(null, ['target' => '20150704160200']);
         $this->assertTrue($markMigrated);
         $status = $this->migrations->status();
@@ -400,10 +412,13 @@ class MigrationsTest extends TestCase
      * Tests calling Migrations::markMigrated with the target option set to a
      * non-existent target will throw an exception
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedTargetError()
+    public function testMarkMigratedTargetError($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Migration `20150704160610` was not found !');
         $this->migrations->markMigrated(null, ['target' => '20150704160610']);
@@ -413,10 +428,13 @@ class MigrationsTest extends TestCase
      * Tests calling Migrations::markMigrated with the target option with the exclude
      * option will mark only up to that one, excluding it
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedTargetExclude()
+    public function testMarkMigratedTargetExclude($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $markMigrated = $this->migrations->markMigrated(null, ['target' => '20150704160200', 'exclude' => true]);
         $this->assertTrue($markMigrated);
         $status = $this->migrations->status();
@@ -455,10 +473,13 @@ class MigrationsTest extends TestCase
      * Tests calling Migrations::markMigrated with the target option with the only
      * option will mark only that specific migrations
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedTargetOnly()
+    public function testMarkMigratedTargetOnly($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $markMigrated = $this->migrations->markMigrated(null, ['target' => '20150724233100', 'only' => true]);
         $this->assertTrue($markMigrated);
         $status = $this->migrations->status();
@@ -497,10 +518,13 @@ class MigrationsTest extends TestCase
      * Tests calling Migrations::markMigrated with the target option, the only option
      * and the exclude option will throw an exception
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedTargetExcludeOnly()
+    public function testMarkMigratedTargetExcludeOnly($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('You should use `exclude` OR `only` (not both) along with a `target` argument');
         $this->migrations->markMigrated(null, ['target' => '20150724233100', 'only' => true, 'exclude' => true]);
@@ -510,10 +534,13 @@ class MigrationsTest extends TestCase
      * Tests calling Migrations::markMigrated with the target option with the exclude
      * option will mark only up to that one, excluding it
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedVersion()
+    public function testMarkMigratedVersion($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $markMigrated = $this->migrations->markMigrated(20150704160200);
         $this->assertTrue($markMigrated);
         $status = $this->migrations->status();
@@ -552,10 +579,13 @@ class MigrationsTest extends TestCase
      * Tests that calling the migrations methods while passing
      * parameters will override the default ones
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testOverrideOptions()
+    public function testOverrideOptions($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $result = $this->migrations->status();
         $expectedStatus = [
             [
@@ -620,10 +650,13 @@ class MigrationsTest extends TestCase
      * Tests that calling the migrations methods while passing the ``date``
      * parameter works as expected
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testMigrateDateOption()
+    public function testMigrateDateOption($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         // If we want to migrate to a date before the first first migration date,
         // we should not migrate anything
         $this->migrations->migrate(['date' => '20140705']);
@@ -796,10 +829,13 @@ class MigrationsTest extends TestCase
     /**
      * Tests seeding the database
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testSeed()
+    public function testSeed($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $this->migrations->migrate();
         $seed = $this->migrations->seed(['source' => 'Seeds']);
         $this->assertTrue($seed);
@@ -872,10 +908,13 @@ class MigrationsTest extends TestCase
     /**
      * Tests seeding the database with seeder
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testSeedOneSeeder()
+    public function testSeedOneSeeder($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $this->migrations->migrate();
 
         $seed = $this->migrations->seed(['source' => 'AltSeeds', 'seed' => 'AnotherNumbersSeed']);
@@ -921,10 +960,13 @@ class MigrationsTest extends TestCase
     /**
      * Tests seeding the database with seeder
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testSeedCallSeeder()
+    public function testSeedCallSeeder($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $this->migrations->migrate();
 
         $seed = $this->migrations->seed(['source' => 'CallSeeds', 'seed' => 'DatabaseSeed']);
@@ -982,13 +1024,31 @@ class MigrationsTest extends TestCase
     /**
      * Tests that requesting a unexistant seed throws an exception
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testSeedWrongSeed()
+    public function testSeedWrongSeed($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The seed class "DerpSeed" does not exist');
         $this->migrations->seed(['source' => 'AltSeeds', 'seed' => 'DerpSeed']);
+    }
+
+    /**
+     * Tests migrating the baked snapshots with builtin backend
+     *
+     * @dataProvider snapshotMigrationsProvider
+     * @param string $basePath Snapshot file path
+     * @param string $filename Snapshot file name
+     * @param array $flags Feature flags
+     * @return void
+     */
+    public function testMigrateSnapshotsBuiltin(string $basePath, string $filename, array $flags = []): void
+    {
+        Configure::write('Migrations.backend', 'builtin');
+        $this->runMigrateSnapshots($basePath, $filename, $flags);
     }
 
     /**
@@ -1000,7 +1060,12 @@ class MigrationsTest extends TestCase
      * @param array $flags Feature flags
      * @return void
      */
-    public function testMigrateSnapshots(string $basePath, string $filename, array $flags = []): void
+    public function testMigrateSnapshotsPhinx(string $basePath, string $filename, array $flags = []): void
+    {
+        $this->runMigrateSnapshots($basePath, $filename, $flags);
+    }
+
+    protected function runMigrateSnapshots(string $basePath, string $filename, array $flags): void
     {
         if ($this->Connection->getDriver() instanceof Sqlserver) {
             // TODO once migrations is using the inlined sqlserver adapter, this skip should
@@ -1047,9 +1112,13 @@ class MigrationsTest extends TestCase
 
     /**
      * Tests that migrating in case of error throws an exception
+     *
+     * @dataProvider backendProvider
      */
-    public function testMigrateErrors()
+    public function testMigrateErrors($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $this->expectException(Exception::class);
         $this->migrations->markMigrated(20150704160200);
         $this->migrations->migrate();
@@ -1057,9 +1126,13 @@ class MigrationsTest extends TestCase
 
     /**
      * Tests that rolling back in case of error throws an exception
+     *
+     * @dataProvider backendProvider
      */
-    public function testRollbackErrors()
+    public function testRollbackErrors($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $this->expectException(Exception::class);
         $this->migrations->markMigrated('all');
         $this->migrations->rollback();
@@ -1068,9 +1141,13 @@ class MigrationsTest extends TestCase
     /**
      * Tests that marking migrated a non-existant migrations returns an error
      * and can return a error message
+     *
+     * @dataProvider backendProvider
      */
-    public function testMarkMigratedErrors()
+    public function testMarkMigratedErrors($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $this->expectException(Exception::class);
         $this->migrations->markMigrated(20150704000000);
     }

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -123,13 +123,24 @@ class MigrationsTest extends TestCase
         FeatureFlags::setFlagsFromConfig(Configure::read('Migrations'));
     }
 
+    public static function backendProvider(): array
+    {
+        return [
+            ['builtin'],
+            ['phinx']
+        ];
+    }
+
     /**
      * Tests the status method
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testStatus()
+    public function testStatus(string $backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         $result = $this->migrations->status();
         $expected = [
             [
@@ -154,13 +165,6 @@ class MigrationsTest extends TestCase
             ],
         ];
         $this->assertEquals($expected, $result);
-
-        $adapter = $this->migrations
-            ->getManager()
-            ->getEnvironment('default')
-            ->getAdapter();
-
-        $this->assertInstanceOf(CakeAdapter::class, $adapter);
     }
 
     /**

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -170,10 +170,13 @@ class MigrationsTest extends TestCase
     /**
      * Tests the migrations and rollbacks
      *
+     * @dataProvider backendProvider
      * @return void
      */
-    public function testMigrateAndRollback()
+    public function testMigrateAndRollback($backend)
     {
+        Configure::write('Migrations.backend', $backend);
+
         if ($this->Connection->getDriver() instanceof Sqlserver) {
             // TODO This test currently fails in CI because numbers table
             // has no columns in sqlserver. This table should have columns as the


### PR DESCRIPTION
Extract the current logic from `Migrations`, and create an adapter between phinx and the 'builtin' backends. This approach optimizes for isolation between the backends until we have more confidence that it is correct.

The interface compatibility is ensured by tests. We likely have coverage gaps in these tests. We'll soon find out.

Part of #647 