### PR TITLE
Convert FeatureFlags to Configure operations

### DIFF
--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Migrations\Db\Adapter;
 
+use Cake\Core\Configure;
 use Cake\Database\Connection;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
@@ -16,7 +17,6 @@ use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use Migrations\Db\Table\Table;
-use Phinx\Config\FeatureFlags;
 
 /**
  * Phinx MySQL Adapter.
@@ -232,12 +232,13 @@ class MysqlAdapter extends PdoAdapter
         }
 
         if (isset($options['id']) && is_string($options['id'])) {
+            $useUnsigned = (bool)Configure::read('Migrations.unsigned_primary_keys');
             // Handle id => "field_name" to support AUTO_INCREMENT
             $column = new Column();
             $column->setName($options['id'])
                    ->setType('integer')
                    ->setOptions([
-                       'signed' => $options['signed'] ?? !FeatureFlags::$unsignedPrimaryKeys,
+                       'signed' => $options['signed'] ?? !$useUnsigned,
                        'identity' => true,
                    ]);
 

--- a/src/Db/Table/Column.php
+++ b/src/Db/Table/Column.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Migrations\Db\Table;
 
+use Cake\Core\Configure;
 use Migrations\Db\Literal;
-use Phinx\Config\FeatureFlags;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Adapter\PostgresAdapter;
 use RuntimeException;
@@ -166,7 +166,7 @@ class Column
      */
     public function __construct()
     {
-        $this->null = FeatureFlags::$columnNullDefault;
+        $this->null = (bool)Configure::read('Migrations.column_null_default');
     }
 
     /**

--- a/src/Migration/BuiltinBackend.php
+++ b/src/Migration/BuiltinBackend.php
@@ -19,6 +19,7 @@ use Cake\Console\TestSuite\StubConsoleInput;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use DateTime;
 use InvalidArgumentException;
+use Migrations\Config\ConfigInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -218,7 +219,9 @@ class BuiltinBackend
      */
     public function seed(array $options = []): bool
     {
+        $options['source'] ??= ConfigInterface::DEFAULT_SEED_FOLDER;
         $seed = $options['seed'] ?? null;
+
         $manager = $this->getManager($options);
         $manager->seed($seed);
 
@@ -237,7 +240,7 @@ class BuiltinBackend
 
         $factory = new ManagerFactory([
             'plugin' => $options['plugin'] ?? null,
-            'source' => $options['source'] ?? null,
+            'source' => $options['source'] ?? ConfigInterface::DEFAULT_MIGRATION_FOLDER,
             'connection' => $options['connection'] ?? 'default',
         ]);
         $io = new ConsoleIo(

--- a/src/Migration/ManagerFactory.php
+++ b/src/Migration/ManagerFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Migrations\Migration;
 
 use Cake\Console\ConsoleIo;
+use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Inflector;
@@ -120,6 +121,10 @@ class ManagerFactory
             'environment' => $adapterConfig,
             'plugin' => $plugin,
             'source' => (string)$this->getOption('source'),
+            'feature_flags' => [
+                'unsigned_primary_keys' => Configure::read('Migrations.unsigned_primary_keys'),
+                'column_null_default' => Configure::read('Migrations.column_null_default'),
+            ],
             // TODO do we want to support the DI container in migrations?
         ];
 

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -24,7 +24,6 @@ use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Cake\View\Helper;
 use Cake\View\View;
-use Phinx\Config\FeatureFlags;
 
 /**
  * Migration Helper class for output of field data in migration files.
@@ -309,10 +308,7 @@ class MigrationHelper extends Helper
             return false;
         }
 
-        $useUnsignedPrimaryKes = Configure::read(
-            'Migrations.unsigned_primary_keys',
-            FeatureFlags::$unsignedPrimaryKeys
-        );
+        $useUnsignedPrimaryKes = (bool)Configure::read('Migrations.unsigned_primary_keys');
 
         foreach ($tables as $table) {
             $schema = $table;

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -6,6 +6,7 @@ namespace Migrations\Test\Db\Adapter;
 use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\StubConsoleInput;
 use Cake\Console\TestSuite\StubConsoleOutput;
+use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
@@ -17,7 +18,6 @@ use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use PDO;
 use PDOException;
-use Phinx\Config\FeatureFlags;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -465,7 +465,7 @@ class MysqlAdapterTest extends TestCase
     {
         $this->adapter->connect();
 
-        FeatureFlags::$unsignedPrimaryKeys = false;
+        Configure::write('Migrations.unsigned_primary_keys', false);
 
         $table = new Table('table1', [], $this->adapter);
         $table->create();

--- a/tests/TestCase/Db/Table/ColumnTest.php
+++ b/tests/TestCase/Db/Table/ColumnTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Migrations\Test\TestCase\Db\Table;
 
+use Cake\Core\Configure;
 use Migrations\Db\Table\Column;
-use Phinx\Config\FeatureFlags;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -39,7 +39,7 @@ class ColumnTest extends TestCase
         $column = new Column();
         $this->assertTrue($column->isNull());
 
-        FeatureFlags::$columnNullDefault = false;
+        Configure::write('Migrations.column_null_default', false);
         $column = new Column();
         $this->assertFalse($column->isNull());
     }

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\TestCase;
 use Exception;
 use InvalidArgumentException;
 use Migrations\Migrations;
-use Phinx\Config\FeatureFlags;
 use Phinx\Db\Adapter\WrapperInterface;
 use function Cake\Core\env;
 
@@ -118,8 +117,6 @@ class MigrationsTest extends TestCase
                 unlink($file);
             }
         }
-
-        FeatureFlags::setFlagsFromConfig(Configure::read('Migrations'));
     }
 
     public static function backendProvider(): array

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -17,11 +17,9 @@ declare(strict_types=1);
 namespace Migrations\Test\TestCase;
 
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
-use Cake\Core\Configure;
 use Cake\Routing\Router;
 use Cake\TestSuite\StringCompareTrait;
 use Cake\TestSuite\TestCase as BaseTestCase;
-use Phinx\Config\FeatureFlags;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -63,8 +61,6 @@ abstract class TestCase extends BaseTestCase
             }
             $this->generatedFiles = [];
         }
-
-        FeatureFlags::setFlagsFromConfig(Configure::read('Migrations'));
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,7 +20,6 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Routing\Router;
 use Cake\TestSuite\Fixture\SchemaLoader;
 use Migrations\MigrationsPlugin;
-use Phinx\Config\FeatureFlags;
 use SimpleSnapshot\Plugin as SimpleSnapshotPlugin;
 use TestBlog\Plugin as TestBlogPlugin;
 use function Cake\Core\env;
@@ -69,8 +68,8 @@ Configure::write('App', [
 ]);
 
 Configure::write('Migrations', [
-    'unsigned_primary_keys' => FeatureFlags::$unsignedPrimaryKeys,
-    'column_null_default' => FeatureFlags::$columnNullDefault,
+    'unsigned_primary_keys' => true,
+    'column_null_default' => true,
 ]);
 
 Cache::setConfig([


### PR DESCRIPTION
Instead of Phinx's feature flags we should use Configure. I've chosen to read and write directly to Configure to avoid more complexity.

The additional default values in `Migrator` will improve compatibility with existing usage.

Part of #647 