### PR TITLE
696 - Fix table method to add the table to array as phinx does

### DIFF
--- a/src/AbstractMigration.php
+++ b/src/AbstractMigration.php
@@ -45,6 +45,7 @@ class AbstractMigration extends BaseAbstractMigration
         }
 
         $table = new Table($tableName, $options, $this->getAdapter());
+        $this->tables[] = $table;
 
         return $table;
     }


### PR DESCRIPTION
Fixes #696 

After creating table, it needs to be added to array to ensure postFlightCheck reports pending actions in tables. Phinx does that in table method but for some reason the override was missing it.

I have sent a PR to cakephp/phinx to ensure postFlightCheck is executed before commiting the transaction to avoid getting the exception after damage is done.

https://github.com/cakephp/phinx/pull/2272