### PR TITLE
Handle database with escapable identifiers in name

### DIFF
--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -811,7 +811,7 @@ class MysqlAdapter extends PdoAdapter
               REFERENCED_COLUMN_NAME
             FROM information_schema.KEY_COLUMN_USAGE
             WHERE REFERENCED_TABLE_NAME IS NOT NULL
-              AND TABLE_SCHEMA = '%s'
+              AND TABLE_SCHEMA = %s
               AND TABLE_NAME = '%s'
             ORDER BY POSITION_IN_UNIQUE_CONSTRAINT",
             empty($schema) ? 'DATABASE()' : "'$schema'",

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -107,7 +107,7 @@ class MysqlAdapter extends PdoAdapter
      */
     public function setConnection(Connection $connection): AdapterInterface
     {
-        $connection->execute(sprintf('USE %s', $this->getOption('database')));
+        $connection->execute(sprintf('USE %s', $this->quoteTableName($this->getOption('database'))));
 
         return parent::setConnection($connection);
     }
@@ -811,7 +811,7 @@ class MysqlAdapter extends PdoAdapter
               REFERENCED_COLUMN_NAME
             FROM information_schema.KEY_COLUMN_USAGE
             WHERE REFERENCED_TABLE_NAME IS NOT NULL
-              AND TABLE_SCHEMA = %s
+              AND TABLE_SCHEMA = '%s'
               AND TABLE_NAME = '%s'
             ORDER BY POSITION_IN_UNIQUE_CONSTRAINT",
             empty($schema) ? 'DATABASE()' : "'$schema'",
@@ -1242,15 +1242,15 @@ class MysqlAdapter extends PdoAdapter
 
         if (isset($options['collation'])) {
             $this->execute(sprintf(
-                'CREATE DATABASE `%s` DEFAULT CHARACTER SET `%s` COLLATE `%s`',
-                $name,
+                'CREATE DATABASE %s DEFAULT CHARACTER SET `%s` COLLATE `%s`',
+                $this->quoteTableName($name),
                 $charset,
                 $options['collation']
             ));
         } else {
-            $this->execute(sprintf('CREATE DATABASE `%s` DEFAULT CHARACTER SET `%s`', $name, $charset));
+            $this->execute(sprintf('CREATE DATABASE %s DEFAULT CHARACTER SET `%s`', $this->quoteTableName($name), $charset));
         }
-        $this->execute(sprintf('USE %s', $name));
+        $this->execute(sprintf('USE %s', $this->quoteTableName($name)));
     }
 
     /**
@@ -1279,7 +1279,7 @@ class MysqlAdapter extends PdoAdapter
      */
     public function dropDatabase(string $name): void
     {
-        $this->execute(sprintf('DROP DATABASE IF EXISTS `%s`', $name));
+        $this->execute(sprintf('DROP DATABASE IF EXISTS %s', $this->quoteTableName($name)));
         $this->createdTables = [];
     }
 

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -104,6 +104,14 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasIndex($this->adapter->getSchemaTableName(), ['version']));
     }
 
+    public function testDatabaseNameWithEscapedCharacter()
+    {
+        $this->adapter->dropDatabase($this->config['database'] . '-test');
+        $this->adapter->createDatabase($this->config['database'] . '-test', ['charset' => 'utf8mb4']);
+        $this->assertTrue($this->adapter->hasDatabase($this->config['database'] . '-test'));
+        $this->adapter->dropDatabase($this->config['database'] . '-test');
+    }
+
     public function testQuoteTableName()
     {
         $this->assertEquals('`test_table`', $this->adapter->quoteTableName('test_table'));


### PR DESCRIPTION
In the case where a MySQL database has a hyphen in it, the updated migrations in 4.3.0 cause the migration to fail with a syntax error.  The previous Phinx-backed migrations did not encounter this.

Looking into the code, there were only two locations that did not escape the database name, `setConnection()` and `createDatabase()`, which have been updated to use the `quoteTableName()` method.  Additionally, there were a couple other instances where the database name was being manually quoted with backticks, so I refactored those to use the `quoteTableName()` method as well for consistency.

Tests have been updated to explicitly create and drop a database with the configured name plus a hyphenated suffix component.  All tests continue to pass.  The `dropDatabase()` method which runs before `createDatabase()` in the test setup had previously had quoting hard-coded into the query, which explains why the original syntax error did not occur at that point. After refactoring, the `dropDatabase()` method continued to work without regression.