### PR TITLE
Check for potentially undefined command line argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
             prefer-lowest: 'prefer-lowest'
           - php-version: '8.1'
             db-type: 'sqlite'
-            cake_version: ^5.1.0-RC1
+            cake_version: 'dev-5.next as 5.1.0'
 
     services:
       postgres:
@@ -94,7 +94,7 @@ jobs:
           elif ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then
             composer update --prefer-lowest --prefer-stable
           elif ${{ matrix.cake_version != '' }}; then
-            composer require --dev cakephp/cakephp:${{ matrix.cake_version }}
+            composer require --dev "cakephp/cakephp:${{ matrix.cake_version }}"
             composer update
           else
             composer update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           elif ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then
             composer update --prefer-lowest --prefer-stable
           elif ${{ matrix.cake_version != '' }}; then
-            composer require cakephp/cakephp:${{ matrix.cake_version }}
+            composer require --dev cakephp/cakephp:${{ matrix.cake_version }}
             composer update
           else
             composer update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,14 @@ jobs:
         php-version: ['8.1', '8.2']
         db-type: [mysql, pgsql, sqlite]
         prefer-lowest: ['']
+        cake_version: ['']
         include:
           - php-version: '8.1'
             db-type: 'sqlite'
             prefer-lowest: 'prefer-lowest'
+          - php-version: '8.1'
+            db-type: 'sqlite'
+            cake_version: ^5.1.0-RC1
 
     services:
       postgres:
@@ -89,6 +93,9 @@ jobs:
             composer install --ignore-platform-req=php
           elif ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then
             composer update --prefer-lowest --prefer-stable
+          elif ${{ matrix.cake_version != '' }}; then
+            composer require cakephp/cakephp:${{ matrix.cake_version }}
+            composer update
           else
             composer update
           fi

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -302,7 +302,10 @@ class Manager
         $migrations = $this->getMigrations();
         $versions = array_keys($migrations);
 
-        $versionArg = $args->getArgument('version');
+        $versionArg = null;
+        if ($args->hasArgument('version')) {
+            $versionArg = $args->getArgument('version');
+        }
         $targetArg = $args->getOption('target');
         $hasAllVersion = in_array($versionArg, ['all', '*'], true);
         if ((empty($versionArg) && empty($targetArg)) || $hasAllVersion) {


### PR DESCRIPTION
5.1 will introduce more strict console parameter access. We need to update to the new usage pattern.

Fixes https://github.com/cakephp/migrations/issues/725