### PR TITLE
Correcting getGlobalSchemaName to use the correct schema

### DIFF
--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -1506,8 +1506,9 @@ class PostgresAdapter extends PdoAdapter
     protected function getGlobalSchemaName(): string
     {
         $options = $this->getOptions();
+        $config = $options['connection']->config() ?? [];
 
-        return empty($options['schema']) ? 'public' : $options['schema'];
+        return empty($config['schema']) ? 'public' : $config['schema'];
     }
 
     /**

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -132,6 +132,36 @@ class PostgresAdapterTest extends TestCase
         $this->assertEquals('"schema.schema"', $this->adapter->quoteSchemaName('schema.schema'));
     }
 
+    public function testGetGlobalSchemaName()
+    {
+        $config = ConnectionManager::getConfig('test');
+        $config['schema'] = 'test_schema';
+        ConnectionManager::drop('test');
+        ConnectionManager::setConfig('test', $config);
+        // Emulate the results of Util::parseDsn()
+        $this->config = [
+            'adapter' => 'postgres',
+            'connection' => ConnectionManager::get('test'),
+            'database' => $config['database'],
+        ];
+
+        $this->adapter = new PostgresAdapter($this->config, $this->getConsoleIo());
+
+        $this->adapter->dropAllSchemas();
+        $this->adapter->createSchema('test_schema');
+
+        $this->adapter->disconnect();
+
+        $this->assertEquals('"test_schema"."table"', $this->adapter->quoteTableName('table'));
+
+        $config = ConnectionManager::getConfig('test');
+        unset($config['schema']);
+        ConnectionManager::drop('test');
+        ConnectionManager::setConfig('test', $config);
+
+        $this->adapter->disconnect();
+    }
+
     public function testQuoteTableName()
     {
         $this->assertEquals('"public"."table"', $this->adapter->quoteTableName('table'));

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -137,12 +137,11 @@ class PostgresAdapterTest extends TestCase
     {
         $config = ConnectionManager::getConfig('test');
         $config['schema'] = 'test_schema';
-        ConnectionManager::drop('test');
-        ConnectionManager::setConfig('test', $config);
+        ConnectionManager::setConfig('test-schema', $config);
         // Emulate the results of Util::parseDsn()
         $this->config = [
             'adapter' => 'postgres',
-            'connection' => ConnectionManager::get('test'),
+            'connection' => ConnectionManager::get('test-schema'),
             'database' => $config['database'],
         ];
 
@@ -155,12 +154,7 @@ class PostgresAdapterTest extends TestCase
 
         $this->assertEquals('"test_schema"."table"', $this->adapter->quoteTableName('table'));
 
-        $config = ConnectionManager::getConfig('test');
-        unset($config['schema']);
-        ConnectionManager::drop('test');
-        ConnectionManager::setConfig('test', $config);
-
-        $this->adapter->disconnect();
+        ConnectionManager::drop('test-schema');
     }
 
     public function testQuoteTableName()


### PR DESCRIPTION
When using CakePHP 5.0.9 and Migrations 4.3.1, if you are using Postgres and try to run the seeds on a schema other than `public` the seed will fail.