### PR TITLE
Add type parameter to getQueryBuilder()

### DIFF
--- a/src/CakeAdapter.php
+++ b/src/CakeAdapter.php
@@ -20,6 +20,8 @@ use PDO;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Adapter\AdapterWrapper;
 
+use function Cake\Core\deprecationWarning;
+
 /**
  * Decorates an AdapterInterface in order to proxy some method to the actual
  * connection object.
@@ -76,11 +78,29 @@ class CakeAdapter extends AdapterWrapper
     /**
      * Returns a new Query object
      *
+     * @param string|null $type The query type to get. Defaults to null emitting a deprecation
      * @return \Cake\Database\Query
      */
-    public function getQueryBuilder(): Query
+    public function getQueryBuilder(?string $type = null): Query
     {
-        return $this->getCakeConnection()->newQuery();
+        switch ($type) {
+            case 'delete':
+                return $this->getCakeConnection()->deleteQuery();
+            case 'insert':
+                return $this->getCakeConnection()->insertQuery();
+            case 'select':
+                return $this->getCakeConnection()->selectQuery();
+            case 'update':
+                return $this->getCakeConnection()->updateQuery();
+            case null:
+            default:
+                deprecationWarning(
+                    'Using getQueryBuilder() with no parameters is deprecated. ' .
+                    "Please provide a query type parameter e.g `getQueryBuilder('select')`"
+                );
+
+                return $this->getCakeConnection()->newQuery();
+        }
     }
 
     /**

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace Migrations\Test\TestCase;
 
 use Cake\Core\Plugin;
+use Cake\Database\Query\InsertQuery;
+use Cake\Database\Query\SelectQuery;
+use Cake\Database\Query\UpdateQuery;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Migrations\CakeAdapter;
@@ -1000,5 +1003,22 @@ class MigrationsTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    public function testQueryBuilder(): void
+    {
+        $adapter = $this->migrations
+            ->getManager()
+            ->getEnvironment('default')
+            ->getAdapter();
+
+        $this->assertInstanceOf(CakeAdapter::class, $adapter);
+        $this->assertInstanceOf(DeleteQuery::class, $adapter->getQueryBuilder('delete'));
+        $this->assertInstanceOf(InsertQuery::class, $adapter->getQueryBuilder('insert'));
+        $this->assertInstanceOf(SelectQuery::class, $adapter->getQueryBuilder('select'));
+        $this->assertInstanceOf(UpdateQuery::class, $adapter->getQueryBuilder('update'));
+        $this->deprecated(function () use ($adapter) {
+            $this->assertInstanceOf(SelectQuery::class, $adapter->getQueryBuilder());
+        });
     }
 }


### PR DESCRIPTION
This aligns the interface we have in the 4.x branch, and also gives a solution to #651 for applications that want to not have any deprecations.