### PR TITLE
Add getDecoratedConnection to 4.x

### DIFF
--- a/src/Db/Adapter/PdoAdapter.php
+++ b/src/Db/Adapter/PdoAdapter.php
@@ -177,6 +177,16 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     }
 
     /**
+     * Backwards compatibility shim for migrations 3.x
+     *
+     * @return \Cake\Database\Connection
+     */
+    public function getDecoratedConnection(): Connection
+    {
+        return $this->getConnection();
+    }
+
+    /**
      * @inheritDoc
      */
     abstract public function connect(): void;

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -78,9 +78,11 @@ class SqliteAdapterTest extends TestCase
         unset($this->adapter, $this->out, $this->io);
     }
 
-    public function testConnection()
+    public function testGetConnection()
     {
-        $this->assertInstanceOf(Connection::class, $this->adapter->getConnection());
+        $connection = $this->adapter->getConnection();
+        $this->assertInstanceOf(Connection::class, $connection);
+        $this->assertSame($connection, $this->adapter->getDecoratedConnection());
     }
 
     public function testBeginTransaction()


### PR DESCRIPTION
Having this method will improve compatibility with historical migrations.

Refs #651