### PR TITLE
Use actual Migrations version in builtin backend doc

### DIFF
--- a/docs/en/upgrading-to-builtin-backend.rst
+++ b/docs/en/upgrading-to-builtin-backend.rst
@@ -1,7 +1,7 @@
 Upgrading to the builtin backend
 ################################
 
-As of migrations XXX there is a new migrations backend that uses CakePHP's
+As of migrations 4.3 there is a new migrations backend that uses CakePHP's
 database abstractions and ORM. Longer term this will allow for phinx to be
 removed as a dependency. This greatly reduces the dependency footprint of
 migrations.


### PR DESCRIPTION
The builtin backend was released in [`4.3.0`](https://github.com/cakephp/migrations/releases/tag/4.3.0), so updating the docs to reflect that.