### PR TITLE
4.next: add PHPUnit 11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
         "robmorgan/phinx": "^0.16.0"
     },
     "require-dev": {
-        "cakephp/bake": "^3.0",
-        "cakephp/cakephp": "^5.0.3",
+        "cakephp/bake": "dev-3.next",
+        "cakephp/cakephp": "dev-5.next as 5.1.0",
         "cakephp/cakephp-codesniffer": "^5.0",
-        "phpunit/phpunit": "^10.1.0"
+        "phpunit/phpunit": "^10.5.5 || ^11.1.3"
     },
     "suggest": {
         "cakephp/bake": "If you want to generate migrations.",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.20.0@3f284e96c9d9be6fe6b15c79416e1d1903dcfef4">
   <file src="src/Command/MigrationsCommand.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->argv]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedClass>
       <code>MigrationsDispatcher</code>
       <code>MigrationsDispatcher::getCommands()</code>
@@ -112,6 +115,12 @@
   </file>
   <file src="src/Migration/Manager.php">
     <ArgumentTypeCoercion>
+      <code><![CDATA[array_map(
+                    function ($phpFile) {
+                        return "    <info>{$phpFile}</info>";
+                    },
+                    $phpFiles
+                )]]></code>
       <code>array_merge($versions, array_keys($migrations))</code>
     </ArgumentTypeCoercion>
     <RedundantPropertyInitializationCheck>
@@ -137,12 +146,23 @@
     </DeprecatedTrait>
   </file>
   <file src="src/Shim/OutputAdapter.php">
+    <ArgumentTypeCoercion>
+      <code>$messages</code>
+      <code>$messages</code>
+    </ArgumentTypeCoercion>
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->io->level()]]></code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType>
       <code>self::VERBOSITY_*</code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="src/TestSuite/Migrator.php">
+    <ArgumentTypeCoercion>
+      <code>$dropTables</code>
+      <code>$phinxTables</code>
+      <code>$tables</code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="src/Util/ColumnParser.php">
     <ArgumentTypeCoercion>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.20.0@3f284e96c9d9be6fe6b15c79416e1d1903dcfef4">
   <file src="src/Command/MigrationsCommand.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$this->argv]]></code>
-    </ArgumentTypeCoercion>
     <DeprecatedClass>
       <code>MigrationsDispatcher</code>
       <code>MigrationsDispatcher::getCommands()</code>

--- a/tests/TestCase/Command/BakeMigrationCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationCommandTest.php
@@ -19,6 +19,7 @@ use Cake\Core\Plugin;
 use Cake\TestSuite\StringCompareTrait;
 use Migrations\Command\BakeMigrationCommand;
 use Migrations\Test\TestCase\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * BakeMigrationCommandTest class
@@ -86,10 +87,9 @@ class BakeMigrationCommandTest extends TestCase
     /**
      * Test the execute method.
      *
-     * @dataProvider nameVariations
      * @return void
      */
-    public function testCreate($name, $fileSuffix)
+    #[DataProvider('nameVariations')] public function testCreate($name, $fileSuffix)
     {
         $this->exec("bake migration CreateUsers  {$name} --connection test");
 
@@ -181,7 +181,6 @@ class BakeMigrationCommandTest extends TestCase
     }
 
     /**
-     * @covers \Migrations\Command\BakeMigrationCommand::detectAction()
      * @return void
      */
     public function testDetectAction()

--- a/tests/TestCase/Command/BakeMigrationCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationCommandTest.php
@@ -89,7 +89,8 @@ class BakeMigrationCommandTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('nameVariations')] public function testCreate($name, $fileSuffix)
+    #[DataProvider('nameVariations')]
+    public function testCreate($name, $fileSuffix)
     {
         $this->exec("bake migration CreateUsers  {$name} --connection test");
 

--- a/tests/TestCase/Command/BakeMigrationSnapshotCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationSnapshotCommandTest.php
@@ -56,6 +56,7 @@ class BakeMigrationSnapshotCommandTest extends TestCase
     {
         parent::setUp();
 
+        $this->loadPlugins(['SimpleSnapshot']);
         $this->_compareBasePath = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Migration' . DS;
         $this->migrationPath = ROOT . DS . 'config' . DS . 'Migrations' . DS;
 

--- a/tests/TestCase/Command/MigrationCommandTest.php
+++ b/tests/TestCase/Command/MigrationCommandTest.php
@@ -135,11 +135,11 @@ class MigrationCommandTest extends TestCase
 
         $mock->expects($this->any())
             ->method('getOutput')
-            ->will($this->returnValue(new NullOutput()));
+            ->willReturn(new NullOutput());
 
         $mock->expects($this->any())
             ->method('getApp')
-            ->will($this->returnValue(new MigrationsDispatcher(PHINX_VERSION)));
+            ->willReturn(new MigrationsDispatcher(PHINX_VERSION));
 
         return $mock;
     }

--- a/tests/TestCase/Command/Phinx/MarkMigratedTest.php
+++ b/tests/TestCase/Command/Phinx/MarkMigratedTest.php
@@ -154,9 +154,9 @@ class MarkMigratedTest extends TestCase
             ->getMock();
 
         $manager->expects($this->any())
-            ->method('getEnvironment')->will($this->returnValue($env));
+            ->method('getEnvironment')->willReturn($env);
         $manager->expects($this->any())
-            ->method('getMigrations')->will($this->returnValue($migrations));
+            ->method('getMigrations')->willReturn($migrations);
         $manager
             ->method('markMigrated')->will($this->throwException(new Exception('Error during marking process')));
 

--- a/tests/TestCase/Command/Phinx/SeedTest.php
+++ b/tests/TestCase/Command/Phinx/SeedTest.php
@@ -118,7 +118,7 @@ class SeedTest extends TestCase
         $result = $this->connection->selectQuery()
             ->select(['*'])
             ->from('numbers')
-            ->order('id DESC')
+            ->orderBy('id DESC')
             ->limit(1)
             ->execute()->fetchAll('assoc');
         $expected = [
@@ -160,7 +160,7 @@ class SeedTest extends TestCase
         $result = $this->connection->selectQuery()
             ->select(['*'])
             ->from('numbers')
-            ->order('id DESC')
+            ->orderBy('id DESC')
             ->limit(1)
             ->execute()->fetchAll('assoc');
         $expected = [

--- a/tests/TestCase/Config/AbstractConfigTestCase.php
+++ b/tests/TestCase/Config/AbstractConfigTestCase.php
@@ -7,8 +7,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Class AbstractConfigTest
- *
- * @coversNothing
  */
 abstract class AbstractConfigTestCase extends TestCase
 {

--- a/tests/TestCase/Config/ConfigTest.php
+++ b/tests/TestCase/Config/ConfigTest.php
@@ -4,19 +4,14 @@ namespace Migrations\Test\TestCase\Config;
 
 use InvalidArgumentException;
 use Migrations\Config\Config;
+use PHPUnit\Framework\Attributes\DataProvider;
 use UnexpectedValueException;
 
 /**
  * Class ConfigTest
- *
- * @package Test\Phinx\Config
- * @group config
  */
 class ConfigTest extends AbstractConfigTestCase
 {
-    /**
-     * @covers \Phinx\Config\Config::getEnvironment
-     */
     public function testGetEnvironmentMethod()
     {
         $config = new Config($this->getConfigArray());
@@ -33,12 +28,6 @@ class ConfigTest extends AbstractConfigTestCase
         $this->assertSame('test_table', $config->getEnvironment()['migration_table']);
     }
 
-    /**
-     * @covers \Phinx\Config\Config::offsetGet
-     * @covers \Phinx\Config\Config::offsetSet
-     * @covers \Phinx\Config\Config::offsetExists
-     * @covers \Phinx\Config\Config::offsetUnset
-     */
     public function testArrayAccessMethods()
     {
         $config = new Config([]);
@@ -49,9 +38,6 @@ class ConfigTest extends AbstractConfigTestCase
         $this->assertArrayNotHasKey('foo', $config);
     }
 
-    /**
-     * @covers \Phinx\Config\Config::offsetGet
-     */
     public function testUndefinedArrayAccess()
     {
         $config = new Config([]);
@@ -62,46 +48,30 @@ class ConfigTest extends AbstractConfigTestCase
         $config['foo'];
     }
 
-    /**
-     * @covers \Phinx\Config\Config::getMigrationBaseClassName
-     */
     public function testGetMigrationBaseClassNameGetsDefaultBaseClass()
     {
         $config = new Config([]);
         $this->assertEquals('AbstractMigration', $config->getMigrationBaseClassName());
     }
 
-    /**
-     * @covers \Phinx\Config\Config::getMigrationBaseClassName
-     */
     public function testGetMigrationBaseClassNameGetsDefaultBaseClassWithNamespace()
     {
         $config = new Config([]);
         $this->assertEquals('Phinx\Migration\AbstractMigration', $config->getMigrationBaseClassName(false));
     }
 
-    /**
-     * @covers \Phinx\Config\Config::getMigrationBaseClassName
-     */
     public function testGetMigrationBaseClassNameGetsAlternativeBaseClass()
     {
         $config = new Config(['migration_base_class' => 'Phinx\Migration\AlternativeAbstractMigration']);
         $this->assertEquals('AlternativeAbstractMigration', $config->getMigrationBaseClassName());
     }
 
-    /**
-     * @covers \Phinx\Config\Config::getMigrationBaseClassName
-     */
     public function testGetMigrationBaseClassNameGetsAlternativeBaseClassWithNamespace()
     {
         $config = new Config(['migration_base_class' => 'Phinx\Migration\AlternativeAbstractMigration']);
         $this->assertEquals('Phinx\Migration\AlternativeAbstractMigration', $config->getMigrationBaseClassName(false));
     }
 
-    /**
-     * @covers \Phinx\Config\Config::getTemplateFile
-     * @covers \Phinx\Config\Config::getTemplateClass
-     */
     public function testGetTemplateValuesFalseOnEmpty()
     {
         $config = new Config([]);
@@ -118,9 +88,6 @@ class ConfigTest extends AbstractConfigTestCase
         $this->assertEquals('db/seeds1', $config->getSeedPath());
     }
 
-    /**
-     * @covers \Phinx\Config\Config::getSeedPaths
-     */
     public function testGetSeedPathThrowsException()
     {
         $config = new Config([]);
@@ -134,8 +101,6 @@ class ConfigTest extends AbstractConfigTestCase
     /**
      * Checks if base class is returned correctly when specified without
      * a namespace.
-     *
-     * @covers \Phinx\Config\Config::getMigrationBaseClassName
      */
     public function testGetMigrationBaseClassNameNoNamespace()
     {
@@ -146,8 +111,6 @@ class ConfigTest extends AbstractConfigTestCase
     /**
      * Checks if base class is returned correctly when specified without
      * a namespace.
-     *
-     * @covers \Phinx\Config\Config::getMigrationBaseClassName
      */
     public function testGetMigrationBaseClassNameNoNamespaceNoDrop()
     {
@@ -155,9 +118,6 @@ class ConfigTest extends AbstractConfigTestCase
         $this->assertEquals('BaseMigration', $config->getMigrationBaseClassName(false));
     }
 
-    /**
-     * @covers \Phinx\Config\Config::getVersionOrder
-     */
     public function testGetVersionOrder()
     {
         $config = new Config([]);
@@ -165,10 +125,7 @@ class ConfigTest extends AbstractConfigTestCase
         $this->assertEquals(Config::VERSION_ORDER_EXECUTION_TIME, $config->getVersionOrder());
     }
 
-    /**
-     * @covers \Phinx\Config\Config::isVersionOrderCreationTime
-     * @dataProvider isVersionOrderCreationTimeDataProvider
-     */
+    #[DataProvider('isVersionOrderCreationTimeDataProvider')]
     public function testIsVersionOrderCreationTime($versionOrder, $expected)
     {
         // get config stub
@@ -184,9 +141,6 @@ class ConfigTest extends AbstractConfigTestCase
         $this->assertEquals($expected, $configStub->isVersionOrderCreationTime());
     }
 
-    /**
-     * @covers \Phinx\Config\Config::isVersionOrderCreationTime
-     */
     public static function isVersionOrderCreationTimeDataProvider()
     {
         return [
@@ -216,9 +170,7 @@ class ConfigTest extends AbstractConfigTestCase
         ];
     }
 
-    /**
-     * @dataProvider templateStyleDataProvider
-     */
+    #[DataProvider('templateStyleDataProvider')]
     public function testTemplateStyle(string $style, string $expected): void
     {
         $config = new Config(['templates' => ['style' => $style]]);

--- a/tests/TestCase/Config/ConfigTest.php
+++ b/tests/TestCase/Config/ConfigTest.php
@@ -179,7 +179,7 @@ class ConfigTest extends AbstractConfigTestCase
 
         $configStub->expects($this->once())
             ->method('getVersionOrder')
-            ->will($this->returnValue($versionOrder));
+            ->willReturn($versionOrder);
 
         $this->assertEquals($expected, $configStub->isVersionOrderCreationTime());
     }

--- a/tests/TestCase/ConfigurationTraitTest.php
+++ b/tests/TestCase/ConfigurationTraitTest.php
@@ -277,12 +277,10 @@ class ConfigurationTraitTest extends TestCase
         $command->setInput($input);
         $command->expects($this->any())
             ->method('getOperationsPath')
-            ->will(
-                $this->returnValueMap([
-                    [$input, 'Migrations', $migrationsPath],
-                    [$input, 'Seeds', $seedsPath],
-                ])
-            );
+            ->willReturnMap([
+                [$input, 'Migrations', $migrationsPath],
+                [$input, 'Seeds', $seedsPath],
+            ]);
 
         return $command;
     }

--- a/tests/TestCase/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/TestCase/Db/Adapter/AdapterFactoryTest.php
@@ -5,6 +5,7 @@ namespace Migrations\Test\Db\Adapter;
 
 use Migrations\Db\Adapter\AdapterFactory;
 use Migrations\Db\Adapter\PdoAdapter;
+use Migrations\Test\TestCase\Db\Adapter\DefaultPdoAdapterTrait;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use RuntimeException;
@@ -33,14 +34,16 @@ class AdapterFactoryTest extends TestCase
 
     public function testRegisterAdapter()
     {
-        $mock = $this->getMockForAbstractClass(PdoAdapter::class, [['foo' => 'bar']]);
-        $this->factory->registerAdapter('test', function (array $options) use ($mock) {
+        $pdo = new class (['foo' => 'bar']) extends PdoAdapter {
+            use DefaultPdoAdapterTrait;
+        };
+        $this->factory->registerAdapter('test', function (array $options) use ($pdo) {
             $this->assertEquals('value', $options['key']);
 
-            return $mock;
+            return $pdo;
         });
 
-        $this->assertEquals($mock, $this->factory->getAdapter('test', ['key' => 'value']));
+        $this->assertEquals($pdo, $this->factory->getAdapter('test', ['key' => 'value']));
     }
 
     public function testRegisterAdapterFailure()

--- a/tests/TestCase/Db/Adapter/DefaultPdoAdapterTrait.php
+++ b/tests/TestCase/Db/Adapter/DefaultPdoAdapterTrait.php
@@ -1,0 +1,180 @@
+<?php
+declare(strict_types=1);
+
+namespace Migrations\Test\TestCase\Db\Adapter;
+
+use Migrations\Db\AlterInstructions;
+use Migrations\Db\Literal;
+use Migrations\Db\Table\Column;
+use Migrations\Db\Table\ForeignKey;
+use Migrations\Db\Table\Index;
+use Migrations\Db\Table\Table;
+
+trait DefaultPdoAdapterTrait
+{
+    public function hasTransactions(): bool
+    {
+        return false;
+    }
+
+    public function beginTransaction(): void
+    {
+    }
+
+    public function commitTransaction(): void
+    {
+    }
+
+    public function rollbackTransaction(): void
+    {
+    }
+
+    public function quoteTableName(string $tableName): string
+    {
+        return "'log'";
+    }
+
+    public function quoteColumnName(string $columnName): string
+    {
+        return $columnName;
+    }
+
+    public function hasTable(string $tableName): bool
+    {
+        return false;
+    }
+
+    public function createTable(Table $table, array $columns = [], array $indexes = []): void
+    {
+    }
+
+    public function truncateTable(string $tableName): void
+    {
+    }
+
+    public function getColumns(string $tableName): array
+    {
+        return [];
+    }
+
+    public function hasColumn(string $tableName, string $columnName): bool
+    {
+        return false;
+    }
+
+    public function hasIndex(string $tableName, array|string $columns): bool
+    {
+        return false;
+    }
+
+    public function hasIndexByName(string $tableName, string $indexName): bool
+    {
+        return false;
+    }
+
+    public function hasPrimaryKey(string $tableName, array|string $columns, ?string $constraint = null): bool
+    {
+        return false;
+    }
+
+    public function hasForeignKey(string $tableName, array|string $columns, ?string $constraint = null): bool
+    {
+        return false;
+    }
+
+    public function getSqlType(Literal|string $type, ?int $limit = null): array
+    {
+        return [];
+    }
+
+    public function createDatabase(string $name, array $options = []): void
+    {
+    }
+
+    public function hasDatabase(string $name): bool
+    {
+        return false;
+    }
+
+    public function dropDatabase(string $name): void
+    {
+    }
+
+    public function connect(): void
+    {
+    }
+
+    public function disconnect(): void
+    {
+    }
+
+    protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions
+    {
+        return new AlterInstructions();
+    }
+
+    protected function getRenameColumnInstructions(string $tableName, string $columnName, string $newColumnName): AlterInstructions
+    {
+        return new AlterInstructions();
+    }
+
+    protected function getChangeColumnInstructions(string $tableName, string $columnName, Column $newColumn): AlterInstructions
+    {
+        return new AlterInstructions();
+    }
+
+    protected function getDropColumnInstructions(string $tableName, string $columnName): AlterInstructions
+    {
+        return new AlterInstructions();
+    }
+
+    protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
+    {
+        return new AlterInstructions();
+    }
+
+    protected function getDropIndexByColumnsInstructions(string $tableName, array|string $columns): AlterInstructions
+    {
+        return new AlterInstructions();
+    }
+
+    protected function getDropIndexByNameInstructions(string $tableName, string $indexName): AlterInstructions
+    {
+        return new AlterInstructions();
+    }
+
+    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey): AlterInstructions
+    {
+        return new AlterInstructions();
+    }
+
+    protected function getDropForeignKeyInstructions(string $tableName, string $constraint): AlterInstructions
+    {
+        return new AlterInstructions();
+    }
+
+    protected function getDropForeignKeyByColumnsInstructions(string $tableName, array $columns): AlterInstructions
+    {
+        return new AlterInstructions();
+    }
+
+    protected function getDropTableInstructions(string $tableName): AlterInstructions
+    {
+        return new AlterInstructions();
+    }
+
+    protected function getRenameTableInstructions(string $tableName, string $newTableName): AlterInstructions
+    {
+        return new AlterInstructions();
+    }
+
+    protected function getChangePrimaryKeyInstructions(Table $table, array|string|null $newColumns): AlterInstructions
+    {
+        return new AlterInstructions();
+    }
+
+    protected function getChangeCommentInstructions(Table $table, ?string $newComment): AlterInstructions
+    {
+        return new AlterInstructions();
+    }
+}

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -2207,7 +2207,7 @@ OUTPUT;
             ->addColumn('int_col', 'integer')
             ->save();
 
-        $builder = $this->adapter->getQueryBuilder(Query::TYPE_INSERT);
+        $builder = $this->adapter->getInsertBuilder();
         $stm = $builder
             ->insert(['string_col', 'int_col'])
             ->into('table1')
@@ -2217,7 +2217,7 @@ OUTPUT;
 
         $this->assertEquals(2, $stm->rowCount());
 
-        $builder = $this->adapter->getQueryBuilder(Query::TYPE_SELECT);
+        $builder = $this->adapter->getSelectBuilder();
         $stm = $builder
             ->select('*')
             ->from('table1')
@@ -2230,7 +2230,7 @@ OUTPUT;
             $stm->fetch('assoc')
         );
 
-        $builder = $this->adapter->getQueryBuilder(query::TYPE_DELETE);
+        $builder = $this->adapter->getDeleteBuilder();
         $stm = $builder
             ->delete('table1')
             ->where(['int_col <' => 2])

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -8,7 +8,6 @@ use Cake\Console\TestSuite\StubConsoleInput;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Core\Configure;
 use Cake\Database\Connection;
-use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
 use InvalidArgumentException;
 use Migrations\Db\Adapter\AdapterInterface;
@@ -18,6 +17,7 @@ use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use PDO;
 use PDOException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -751,10 +751,7 @@ class MysqlAdapterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider integerDataProvider
-     */
-    public function testIntegerColumnTypes($phinx_type, $options, $sql_type, $width, $extra)
+    #[DataProvider('integerDataProvider')] public function testIntegerColumnTypes($phinx_type, $options, $sql_type, $width, $extra)
     {
         $table = new Table('table1', [], $this->adapter);
         $table->save();
@@ -973,10 +970,9 @@ class MysqlAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider sqlTypeIntConversionProvider
      * The second argument is not typed as MysqlAdapter::INT_BIG is a float, and all other values are integers
      */
-    public function testGetSqlTypeIntegerConversion(string $type, $limit, string $expectedType, int $expectedLimit)
+    #[DataProvider('sqlTypeIntConversionProvider')] public function testGetSqlTypeIntegerConversion(string $type, $limit, string $expectedType, int $expectedLimit)
     {
         $sqlType = $this->adapter->getSqlType($type, $limit);
         $this->assertSame($expectedType, $sqlType['name']);
@@ -1028,8 +1024,7 @@ class MysqlAdapterTest extends TestCase
         ];
     }
 
-    /** @dataProvider binaryToBlobAutomaticConversionData */
-    public function testBinaryToBlobAutomaticConversion(?int $limit, string $expectedType, int $expectedLimit)
+    #[DataProvider('binaryToBlobAutomaticConversionData')] public function testBinaryToBlobAutomaticConversion(?int $limit, string $expectedType, int $expectedLimit)
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'binary', ['limit' => $limit])
@@ -1055,8 +1050,7 @@ class MysqlAdapterTest extends TestCase
         ];
     }
 
-    /** @dataProvider varbinaryToBlobAutomaticConversionData */
-    public function testVarbinaryToBlobAutomaticConversion(?int $limit, string $expectedType, int $expectedLimit)
+    #[DataProvider('varbinaryToBlobAutomaticConversionData')] public function testVarbinaryToBlobAutomaticConversion(?int $limit, string $expectedType, int $expectedLimit)
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'varbinary', ['limit' => $limit])
@@ -1097,8 +1091,7 @@ class MysqlAdapterTest extends TestCase
         ];
     }
 
-    /** @dataProvider blobColumnsData */
-    public function testblobColumns(string $type, string $expectedType, ?int $limit, int $expectedLimit)
+    #[DataProvider('blobColumnsData')] public function testblobColumns(string $type, string $expectedType, ?int $limit, int $expectedLimit)
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', $type, ['limit' => $limit])
@@ -1278,10 +1271,7 @@ class MysqlAdapterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider columnsProvider
-     */
-    public function testGetColumns($colName, $type, $options)
+    #[DataProvider('columnsProvider')] public function testGetColumns($colName, $type, $options)
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn($colName, $type, $options)->save();
@@ -1698,10 +1688,9 @@ class MysqlAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider nonExistentForeignKeyColumnsProvider
      * @param array $columns
      */
-    public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
+    #[DataProvider('nonExistentForeignKeyColumnsProvider')] public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
     {
         $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
@@ -1789,10 +1778,7 @@ class MysqlAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
     }
 
-    /**
-     * @dataProvider provideForeignKeysToCheck
-     */
-    public function testHasForeignKey($tableDef, $key, $exp)
+    #[DataProvider('provideForeignKeysToCheck')] public function testHasForeignKey($tableDef, $key, $exp)
     {
         $conn = $this->adapter->getConnection();
         $conn->execute('CREATE TABLE other(a int, b int, c int, key(a), key(b), key(a,b), key(a,b,c));');
@@ -2293,11 +2279,10 @@ INPUT;
     }
 
     /**
-     * @dataProvider geometryTypeProvider
      * @param string $type
      * @param string $geom
      */
-    public function testGeometrySridSupport($type, $geom)
+    #[DataProvider('geometryTypeProvider')] public function testGeometrySridSupport($type, $geom)
     {
         $this->adapter->connect();
         if (!$this->usingMysql8()) {
@@ -2317,11 +2302,10 @@ INPUT;
     }
 
     /**
-     * @dataProvider geometryTypeProvider
      * @param string $type
      * @param string $geom
      */
-    public function testGeometrySridThrowsInsertDifferentSrid($type, $geom)
+    #[DataProvider('geometryTypeProvider')] public function testGeometrySridThrowsInsertDifferentSrid($type, $geom)
     {
         $this->adapter->connect();
         if (!$this->usingMysql8()) {
@@ -2374,11 +2358,10 @@ INPUT;
      * MySQL 8 added support for specifying defaults for the BLOB, TEXT, GEOMETRY, and JSON data types,
      * however requiring that they be wrapped in expressions.
      *
-     * @dataProvider defaultsCastAsExpressions
      * @param string $type
      * @param string $default
      */
-    public function testDefaultsCastAsExpressionsForCertainTypes(string $type, string $default): void
+    #[DataProvider('defaultsCastAsExpressions')] public function testDefaultsCastAsExpressionsForCertainTypes(string $type, string $default): void
     {
         $this->adapter->connect();
 
@@ -2443,10 +2426,7 @@ INPUT;
         ];
     }
 
-    /**
-     * @dataProvider integerDataTypesSQLProvider
-     */
-    public function testGetPhinxTypeFromSQLDefinition(string $sqlDefinition, array $expectedResponse)
+    #[DataProvider('integerDataTypesSQLProvider')] public function testGetPhinxTypeFromSQLDefinition(string $sqlDefinition, array $expectedResponse)
     {
         $result = $this->adapter->getPhinxType($sqlDefinition);
 

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -18,6 +18,7 @@ use Migrations\Db\Table\Column;
 use PDO;
 use PDOException;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -466,9 +467,7 @@ class MysqlAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testUnsignedPksFeatureFlag()
     {
         $this->adapter->connect();
@@ -484,9 +483,7 @@ class MysqlAdapterTest extends TestCase
         $this->assertTrue($columns[0]->getSigned());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testAddTimestampsFeatureFlag()
     {
         Configure::write('Migrations.add_timestamps_use_datetime', true);

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -748,7 +748,8 @@ class MysqlAdapterTest extends TestCase
         ];
     }
 
-    #[DataProvider('integerDataProvider')] public function testIntegerColumnTypes($phinx_type, $options, $sql_type, $width, $extra)
+    #[DataProvider('integerDataProvider')]
+    public function testIntegerColumnTypes($phinx_type, $options, $sql_type, $width, $extra)
     {
         $table = new Table('table1', [], $this->adapter);
         $table->save();
@@ -969,7 +970,8 @@ class MysqlAdapterTest extends TestCase
     /**
      * The second argument is not typed as MysqlAdapter::INT_BIG is a float, and all other values are integers
      */
-    #[DataProvider('sqlTypeIntConversionProvider')] public function testGetSqlTypeIntegerConversion(string $type, $limit, string $expectedType, int $expectedLimit)
+    #[DataProvider('sqlTypeIntConversionProvider')]
+    public function testGetSqlTypeIntegerConversion(string $type, $limit, string $expectedType, int $expectedLimit)
     {
         $sqlType = $this->adapter->getSqlType($type, $limit);
         $this->assertSame($expectedType, $sqlType['name']);
@@ -1021,7 +1023,8 @@ class MysqlAdapterTest extends TestCase
         ];
     }
 
-    #[DataProvider('binaryToBlobAutomaticConversionData')] public function testBinaryToBlobAutomaticConversion(?int $limit, string $expectedType, int $expectedLimit)
+    #[DataProvider('binaryToBlobAutomaticConversionData')]
+    public function testBinaryToBlobAutomaticConversion(?int $limit, string $expectedType, int $expectedLimit)
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'binary', ['limit' => $limit])
@@ -1047,7 +1050,8 @@ class MysqlAdapterTest extends TestCase
         ];
     }
 
-    #[DataProvider('varbinaryToBlobAutomaticConversionData')] public function testVarbinaryToBlobAutomaticConversion(?int $limit, string $expectedType, int $expectedLimit)
+    #[DataProvider('varbinaryToBlobAutomaticConversionData')]
+    public function testVarbinaryToBlobAutomaticConversion(?int $limit, string $expectedType, int $expectedLimit)
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'varbinary', ['limit' => $limit])
@@ -1088,7 +1092,8 @@ class MysqlAdapterTest extends TestCase
         ];
     }
 
-    #[DataProvider('blobColumnsData')] public function testblobColumns(string $type, string $expectedType, ?int $limit, int $expectedLimit)
+    #[DataProvider('blobColumnsData')]
+    public function testblobColumns(string $type, string $expectedType, ?int $limit, int $expectedLimit)
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', $type, ['limit' => $limit])
@@ -1268,7 +1273,8 @@ class MysqlAdapterTest extends TestCase
         ];
     }
 
-    #[DataProvider('columnsProvider')] public function testGetColumns($colName, $type, $options)
+    #[DataProvider('columnsProvider')]
+    public function testGetColumns($colName, $type, $options)
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn($colName, $type, $options)->save();
@@ -1687,7 +1693,8 @@ class MysqlAdapterTest extends TestCase
     /**
      * @param array $columns
      */
-    #[DataProvider('nonExistentForeignKeyColumnsProvider')] public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
+    #[DataProvider('nonExistentForeignKeyColumnsProvider')]
+    public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
     {
         $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
@@ -1775,7 +1782,8 @@ class MysqlAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
     }
 
-    #[DataProvider('provideForeignKeysToCheck')] public function testHasForeignKey($tableDef, $key, $exp)
+    #[DataProvider('provideForeignKeysToCheck')]
+    public function testHasForeignKey($tableDef, $key, $exp)
     {
         $conn = $this->adapter->getConnection();
         $conn->execute('CREATE TABLE other(a int, b int, c int, key(a), key(b), key(a,b), key(a,b,c));');
@@ -2279,7 +2287,8 @@ INPUT;
      * @param string $type
      * @param string $geom
      */
-    #[DataProvider('geometryTypeProvider')] public function testGeometrySridSupport($type, $geom)
+    #[DataProvider('geometryTypeProvider')]
+    public function testGeometrySridSupport($type, $geom)
     {
         $this->adapter->connect();
         if (!$this->usingMysql8()) {
@@ -2302,7 +2311,8 @@ INPUT;
      * @param string $type
      * @param string $geom
      */
-    #[DataProvider('geometryTypeProvider')] public function testGeometrySridThrowsInsertDifferentSrid($type, $geom)
+    #[DataProvider('geometryTypeProvider')]
+    public function testGeometrySridThrowsInsertDifferentSrid($type, $geom)
     {
         $this->adapter->connect();
         if (!$this->usingMysql8()) {
@@ -2358,7 +2368,8 @@ INPUT;
      * @param string $type
      * @param string $default
      */
-    #[DataProvider('defaultsCastAsExpressions')] public function testDefaultsCastAsExpressionsForCertainTypes(string $type, string $default): void
+    #[DataProvider('defaultsCastAsExpressions')]
+    public function testDefaultsCastAsExpressionsForCertainTypes(string $type, string $default): void
     {
         $this->adapter->connect();
 
@@ -2423,7 +2434,8 @@ INPUT;
         ];
     }
 
-    #[DataProvider('integerDataTypesSQLProvider')] public function testGetPhinxTypeFromSQLDefinition(string $sqlDefinition, array $expectedResponse)
+    #[DataProvider('integerDataTypesSQLProvider')]
+    public function testGetPhinxTypeFromSQLDefinition(string $sqlDefinition, array $expectedResponse)
     {
         $result = $this->adapter->getPhinxType($sqlDefinition);
 

--- a/tests/TestCase/Db/Adapter/PhinxAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PhinxAdapterTest.php
@@ -18,6 +18,7 @@ use PDOException;
 use Phinx\Db\Table as PhinxTable;
 use Phinx\Db\Table\Column as PhinxColumn;
 use Phinx\Util\Literal as PhinxLiteral;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -643,9 +644,6 @@ class PhinxAdapterTest extends TestCase
         $this->assertEquals("'test1'", $rows[1]['dflt_value']);
     }
 
-    /**
-     * @group bug922
-     */
     public function testChangeColumnWithForeignKey()
     {
         $refTable = new PhinxTable('ref_table', [], $this->adapter);
@@ -1485,9 +1483,6 @@ INPUT;
         $this->assertEquals(Literal::from('decimal'), array_pop($columns)->getType());
     }
 
-    /**
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::hasPrimaryKey
-     */
     public function testHasNamedPrimaryKey()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -1495,7 +1490,6 @@ INPUT;
         $this->adapter->hasPrimaryKey('t', [], 'named_constraint');
     }
 
-    /** @covers \Migrations\Db\Adapter\SqliteAdapter::getColumnTypes */
     public function testGetColumnTypes()
     {
         $columnTypes = $this->adapter->getColumnTypes();
@@ -1529,10 +1523,7 @@ INPUT;
         $this->assertEquals($expected, $columnTypes);
     }
 
-    /**
-     * @dataProvider provideColumnTypesForValidation
-     * @covers \Phinx\Db\Adapter\SqliteAdapter::isValidColumnType
-     */
+    #[DataProvider('provideColumnTypesForValidation')]
     public function testIsValidColumnType($phinxType, $exp)
     {
         $col = (new PhinxColumn())->setType($phinxType);
@@ -1579,10 +1570,6 @@ INPUT;
         ];
     }
 
-    /** @covers \Phinx\Db\Adapter\SqliteAdapter::getSchemaName
-     * @covers \Phinx\Db\Adapter\SqliteAdapter::getTableInfo
-     * @covers \Phinx\Db\Adapter\SqliteAdapter::getColumns
-     */
     public function testGetColumns()
     {
         $conn = $this->adapter->getConnection();

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -558,7 +558,8 @@ class PostgresAdapterTest extends TestCase
         ];
     }
 
-    #[DataProvider('providerAddColumnIdentity')] public function testAddColumnIdentity($generated, $addToColumn)
+    #[DataProvider('providerAddColumnIdentity')]
+    public function testAddColumnIdentity($generated, $addToColumn)
     {
         if (!$this->usingPostgres10()) {
             $this->markTestSkipped('Test Skipped because of PostgreSQL version is < 10.0');
@@ -651,7 +652,8 @@ class PostgresAdapterTest extends TestCase
         ];
     }
 
-    #[DataProvider('providerIgnoresLimit')] public function testAddColumnIgnoresLimit(string $column_type, ?string $actual_type = null): void
+    #[DataProvider('providerIgnoresLimit')]
+    public function testAddColumnIgnoresLimit(string $column_type, ?string $actual_type = null): void
     {
         $table = new Table('table1', [], $this->adapter);
         $table->save();
@@ -818,7 +820,8 @@ class PostgresAdapterTest extends TestCase
         ];
     }
 
-    #[DataProvider('providerArrayType')] public function testAddColumnArrayType($column_name, $column_type)
+    #[DataProvider('providerArrayType')]
+    public function testAddColumnArrayType($column_name, $column_type)
     {
         $table = new Table('table1', [], $this->adapter);
         $table->save();
@@ -896,7 +899,8 @@ class PostgresAdapterTest extends TestCase
         ];
     }
 
-    #[DataProvider('providerChangeColumnIdentity')] public function testChangeColumnIdentity($generated)
+    #[DataProvider('providerChangeColumnIdentity')]
+    public function testChangeColumnIdentity($generated)
     {
         if (!$this->usingPostgres10()) {
             $this->markTestSkipped('Test Skipped because of PostgreSQL version is < 10.0');
@@ -960,7 +964,8 @@ class PostgresAdapterTest extends TestCase
         ];
     }
 
-    #[DataProvider('integersProvider')] public function testChangeColumnFromTextToInteger($type, $value)
+    #[DataProvider('integersProvider')]
+    public function testChangeColumnFromTextToInteger($type, $value)
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'text')
@@ -1117,7 +1122,8 @@ class PostgresAdapterTest extends TestCase
         ];
     }
 
-    #[DataProvider('columnsProvider')] public function testGetColumns($colName, $type, $options, $actualType = null)
+    #[DataProvider('columnsProvider')]
+    public function testGetColumns($colName, $type, $options, $actualType = null)
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn($colName, $type, $options)->save();
@@ -1137,7 +1143,8 @@ class PostgresAdapterTest extends TestCase
         }
     }
 
-    #[DataProvider('columnsProvider')] public function testGetColumnsWithSchema($colName, $type, $options, $actualType = null)
+    #[DataProvider('columnsProvider')]
+    public function testGetColumnsWithSchema($colName, $type, $options, $actualType = null)
     {
         $this->adapter->createSchema('tschema');
 
@@ -1597,7 +1604,8 @@ class PostgresAdapterTest extends TestCase
     /**
      * @param array $columns
      */
-    #[DataProvider('nonExistentForeignKeyColumnsProvider')] public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
+    #[DataProvider('nonExistentForeignKeyColumnsProvider')]
+    public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
     {
         $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
@@ -1662,7 +1670,8 @@ class PostgresAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
     }
 
-    #[DataProvider('provideForeignKeysToCheck')] public function testHasForeignKey($tableDef, $key, $exp)
+    #[DataProvider('provideForeignKeysToCheck')]
+    public function testHasForeignKey($tableDef, $key, $exp)
     {
         $conn = $this->adapter->getConnection();
         $conn->execute('CREATE TABLE other(a int, b int, c int, unique(a), unique(b), unique(a,b), unique(a,b,c));');
@@ -2655,7 +2664,8 @@ OUTPUT;
         ];
     }
 
-    #[DataProvider('serialProvider')] public function testSerialAliases(string $columnType): void
+    #[DataProvider('serialProvider')]
+    public function testSerialAliases(string $columnType): void
     {
         $table = new Table('test', ['id' => false], $this->adapter);
         $table->addColumn('id', $columnType, ['identity' => true, 'generated' => null])->create();

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -7,7 +7,6 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\StubConsoleInput;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Database\Connection;
-use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
 use InvalidArgumentException;
 use Migrations\Db\Adapter\AbstractAdapter;
@@ -18,6 +17,7 @@ use Migrations\Db\Literal;
 use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class PostgresAdapterTest extends TestCase
@@ -557,10 +557,7 @@ class PostgresAdapterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider providerAddColumnIdentity
-     */
-    public function testAddColumnIdentity($generated, $addToColumn)
+    #[DataProvider('providerAddColumnIdentity')] public function testAddColumnIdentity($generated, $addToColumn)
     {
         if (!$this->usingPostgres10()) {
             $this->markTestSkipped('Test Skipped because of PostgreSQL version is < 10.0');
@@ -653,10 +650,7 @@ class PostgresAdapterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider providerIgnoresLimit
-     */
-    public function testAddColumnIgnoresLimit(string $column_type, ?string $actual_type = null): void
+    #[DataProvider('providerIgnoresLimit')] public function testAddColumnIgnoresLimit(string $column_type, ?string $actual_type = null): void
     {
         $table = new Table('table1', [], $this->adapter);
         $table->save();
@@ -823,10 +817,7 @@ class PostgresAdapterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider providerArrayType
-     */
-    public function testAddColumnArrayType($column_name, $column_type)
+    #[DataProvider('providerArrayType')] public function testAddColumnArrayType($column_name, $column_type)
     {
         $table = new Table('table1', [], $this->adapter);
         $table->save();
@@ -904,10 +895,7 @@ class PostgresAdapterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider providerChangeColumnIdentity
-     */
-    public function testChangeColumnIdentity($generated)
+    #[DataProvider('providerChangeColumnIdentity')] public function testChangeColumnIdentity($generated)
     {
         if (!$this->usingPostgres10()) {
             $this->markTestSkipped('Test Skipped because of PostgreSQL version is < 10.0');
@@ -971,10 +959,7 @@ class PostgresAdapterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider integersProvider
-     */
-    public function testChangeColumnFromTextToInteger($type, $value)
+    #[DataProvider('integersProvider')] public function testChangeColumnFromTextToInteger($type, $value)
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn('column1', 'text')
@@ -1131,10 +1116,7 @@ class PostgresAdapterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider columnsProvider
-     */
-    public function testGetColumns($colName, $type, $options, $actualType = null)
+    #[DataProvider('columnsProvider')] public function testGetColumns($colName, $type, $options, $actualType = null)
     {
         $table = new Table('t', [], $this->adapter);
         $table->addColumn($colName, $type, $options)->save();
@@ -1154,10 +1136,7 @@ class PostgresAdapterTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider columnsProvider
-     */
-    public function testGetColumnsWithSchema($colName, $type, $options, $actualType = null)
+    #[DataProvider('columnsProvider')] public function testGetColumnsWithSchema($colName, $type, $options, $actualType = null)
     {
         $this->adapter->createSchema('tschema');
 
@@ -1615,10 +1594,9 @@ class PostgresAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider nonExistentForeignKeyColumnsProvider
      * @param array $columns
      */
-    public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
+    #[DataProvider('nonExistentForeignKeyColumnsProvider')] public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
     {
         $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
@@ -1683,10 +1661,7 @@ class PostgresAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
     }
 
-    /**
-     * @dataProvider provideForeignKeysToCheck
-     */
-    public function testHasForeignKey($tableDef, $key, $exp)
+    #[DataProvider('provideForeignKeysToCheck')] public function testHasForeignKey($tableDef, $key, $exp)
     {
         $conn = $this->adapter->getConnection();
         $conn->execute('CREATE TABLE other(a int, b int, c int, unique(a), unique(b), unique(a,b), unique(a,b,c));');
@@ -2687,10 +2662,7 @@ OUTPUT;
         ];
     }
 
-    /**
-     * @dataProvider serialProvider
-     */
-    public function testSerialAliases(string $columnType): void
+    #[DataProvider('serialProvider')] public function testSerialAliases(string $columnType): void
     {
         $table = new Table('test', ['id' => false], $this->adapter);
         $table->addColumn('id', $columnType, ['identity' => true, 'generated' => null])->create();

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -2593,7 +2593,7 @@ OUTPUT;
             ->addColumn('int_col', 'integer')
             ->save();
 
-        $builder = $this->adapter->getQueryBuilder(Query::TYPE_INSERT);
+        $builder = $this->adapter->getInsertBuilder();
         $stm = $builder
             ->insert(['string_col', 'int_col'])
             ->into('table1')
@@ -2603,7 +2603,7 @@ OUTPUT;
 
         $this->assertEquals(2, $stm->rowCount());
 
-        $builder = $this->adapter->getQueryBuilder(query::TYPE_SELECT);
+        $builder = $this->adapter->getSelectBuilder();
         $stm = $builder
             ->select('*')
             ->from('table1')
@@ -2616,7 +2616,7 @@ OUTPUT;
             $stm->fetch('assoc')
         );
 
-        $builder = $this->adapter->getQueryBuilder(Query::TYPE_DELETE);
+        $builder = $this->adapter->getDeleteBuilder();
         $stm = $builder
             ->delete('table1')
             ->where(['int_col <' => 2])

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -18,6 +18,7 @@ use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use PDO;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
 class PostgresAdapterTest extends TestCase
@@ -1909,9 +1910,7 @@ class PostgresAdapterTest extends TestCase
         );
     }
 
-    /**
-     * @depends testCanAddColumnComment
-     */
+    #[Depends('testCanAddColumnComment')]
     public function testCanChangeColumnComment()
     {
         $table = new Table('table1', [], $this->adapter);
@@ -1938,9 +1937,7 @@ class PostgresAdapterTest extends TestCase
         $this->assertEquals($comment, $row['column_comment'], 'Dont change column comment correctly');
     }
 
-    /**
-     * @depends testCanAddColumnComment
-     */
+    #[Depends('testCanAddColumnComment')]
     public function testCanRemoveColumnComment()
     {
         $table = new Table('table1', [], $this->adapter);
@@ -1964,9 +1961,7 @@ class PostgresAdapterTest extends TestCase
         $this->assertEmpty($row['column_comment'], 'Dont remove column comment correctly');
     }
 
-    /**
-     * @depends testCanAddColumnComment
-     */
+    #[Depends('testCanAddColumnComment')]
     public function testCanAddMultipleCommentsToOneTable()
     {
         $table = new Table('table1', [], $this->adapter);
@@ -2005,9 +2000,7 @@ class PostgresAdapterTest extends TestCase
         $this->assertEquals($comment2, $row['column_comment'], 'Could not create second column comment');
     }
 
-    /**
-     * @depends testCanAddColumnComment
-     */
+    #[Depends('testCanAddColumnComment')]
     public function testColumnsAreResetBetweenTables()
     {
         $table = new Table('widgets', [], $this->adapter);

--- a/tests/TestCase/Db/Adapter/RecordingAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/RecordingAdapterTest.php
@@ -24,7 +24,7 @@ class RecordingAdapterTest extends TestCase
 
         $stub->expects($this->any())
             ->method('isValidColumnType')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->adapter = new RecordingAdapter($stub);
     }
@@ -63,7 +63,7 @@ class RecordingAdapterTest extends TestCase
             ->getAdapter()
             ->expects($this->any())
             ->method('hasTable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->adapter
             ->getAdapter()
@@ -92,7 +92,7 @@ class RecordingAdapterTest extends TestCase
             ->getAdapter()
             ->expects($this->any())
             ->method('hasTable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $table = new Table('atable', [], $this->adapter);
         $table->renameColumn('oldname', 'newname')
@@ -110,7 +110,7 @@ class RecordingAdapterTest extends TestCase
             ->getAdapter()
             ->expects($this->any())
             ->method('hasTable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $table = new Table('atable', [], $this->adapter);
         $table->addIndex(['email'])
@@ -128,7 +128,7 @@ class RecordingAdapterTest extends TestCase
             ->getAdapter()
             ->expects($this->any())
             ->method('hasTable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $table = new Table('atable', [], $this->adapter);
         $table->addForeignKey(['ref_table_id'], 'refTable')
@@ -146,7 +146,7 @@ class RecordingAdapterTest extends TestCase
             ->getAdapter()
             ->expects($this->any())
             ->method('hasTable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $table = new Table('atable', [], $this->adapter);
         $table->removeColumn('thing')

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -8,7 +8,6 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\StubConsoleInput;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Database\Connection;
-use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
 use Exception;
 use InvalidArgumentException;
@@ -20,6 +19,7 @@ use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use PDOException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 use RuntimeException;
@@ -512,10 +512,7 @@ class SqliteAdapterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider irregularCreateTableProvider
-     */
-    public function testAddColumnToIrregularCreateTableStatements(string $createTableSql, array $expectedColumns): void
+    #[DataProvider('irregularCreateTableProvider')] public function testAddColumnToIrregularCreateTableStatements(string $createTableSql, array $expectedColumns): void
     {
         $this->adapter->execute($createTableSql);
         $table = new Table('users', [], $this->adapter);
@@ -761,11 +758,10 @@ class SqliteAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider customIndexSQLDataProvider
      * @param string $indexSQL Index creation SQL
      * @param string $newIndexSQL Expected new index creation SQL
      */
-    public function testRenameColumnWithCustomIndex(string $indexSQL, string $newIndexSQL)
+    #[DataProvider('customIndexSQLDataProvider')] public function testRenameColumnWithCustomIndex(string $indexSQL, string $newIndexSQL)
     {
         $table = new Table('t', [], $this->adapter);
         $table
@@ -860,11 +856,10 @@ class SqliteAdapterTest extends TestCase
      * Index SQL is mostly returned as-is, hence custom indices can contain
      * a wide variety of formats.
      *
-     * @dataProvider customCompositeIndexSQLDataProvider
      * @param string $indexSQL Index creation SQL
      * @param string $newIndexSQL Expected new index creation SQL
      */
-    public function testRenameColumnWithCustomCompositeIndex(string $indexSQL, string $newIndexSQL)
+    #[DataProvider('customCompositeIndexSQLDataProvider')] public function testRenameColumnWithCustomCompositeIndex(string $indexSQL, string $newIndexSQL)
     {
         $table = new Table('t', [], $this->adapter);
         $table
@@ -922,9 +917,6 @@ class SqliteAdapterTest extends TestCase
         $this->assertEquals("'test1'", $rows[1]['dflt_value']);
     }
 
-    /**
-     * @group bug922
-     */
     public function testChangeColumnWithForeignKey()
     {
         $refTable = new Table('ref_table', [], $this->adapter);
@@ -1039,10 +1031,7 @@ class SqliteAdapterTest extends TestCase
         $this->assertEquals('another default', (string)$cols[1]->getDefault());
     }
 
-    /**
-     * @dataProvider columnCreationArgumentProvider
-     */
-    public function testDropColumn($columnCreationArgs)
+    #[DataProvider('columnCreationArgumentProvider')] public function testDropColumn($columnCreationArgs)
     {
         $table = new Table('t', [], $this->adapter);
         $columnName = $columnCreationArgs[0];
@@ -1163,10 +1152,9 @@ class SqliteAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider customIndexSQLDataProvider
      * @param string $indexSQL Index creation SQL
      */
-    public function testDropColumnWithCustomIndex(string $indexSQL)
+    #[DataProvider('customIndexSQLDataProvider')] public function testDropColumnWithCustomIndex(string $indexSQL)
     {
         $table = new Table('t', [], $this->adapter);
         $table
@@ -1183,10 +1171,9 @@ class SqliteAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider customCompositeIndexSQLDataProvider
      * @param string $indexSQL Index creation SQL
      */
-    public function testDropColumnWithCustomCompositeIndex(string $indexSQL)
+    #[DataProvider('customCompositeIndexSQLDataProvider')] public function testDropColumnWithCustomCompositeIndex(string $indexSQL)
     {
         $table = new Table('t', [], $this->adapter);
         $table
@@ -1509,10 +1496,9 @@ class SqliteAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider nonExistentForeignKeyColumnsProvider
      * @param array $columns
      */
-    public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
+    #[DataProvider('nonExistentForeignKeyColumnsProvider')] public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
     {
         $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
@@ -2264,13 +2250,7 @@ INPUT;
         $this->assertEquals(Literal::from('decimal'), array_pop($columns)->getType());
     }
 
-    /**
-     * @dataProvider provideTableNamesForPresenceCheck
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::hasTable
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::resolveTable
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::quoteString
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getSchemaName
-     */
+    #[DataProvider('provideTableNamesForPresenceCheck')]
     public function testHasTable($createName, $tableName, $exp)
     {
         // Test case for issue #1535
@@ -2316,14 +2296,7 @@ INPUT;
         ];
     }
 
-    /**
-     * @dataProvider provideIndexColumnsToCheck
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getSchemaName
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getTableInfo
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getIndexes
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::resolveIndex
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::hasIndex
-     */
+    #[DataProvider('provideIndexColumnsToCheck')]
     public function testHasIndex($tableDef, $cols, $exp)
     {
         $conn = $this->adapter->getConnection();
@@ -2362,13 +2335,7 @@ INPUT;
         ];
     }
 
-    /**
-     * @dataProvider provideIndexNamesToCheck
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getSchemaName
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getTableInfo
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getIndexes
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::hasIndexByName
-     */
+    #[DataProvider('provideIndexNamesToCheck')]
     public function testHasIndexByName($tableDef, $index, $exp)
     {
         $conn = $this->adapter->getConnection();
@@ -2399,13 +2366,7 @@ INPUT;
         ];
     }
 
-    /**
-     * @dataProvider providePrimaryKeysToCheck
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getSchemaName
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getTableInfo
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::hasPrimaryKey
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getPrimaryKey
-     */
+    #[DataProvider('providePrimaryKeysToCheck')]
     public function testHasPrimaryKey($tableDef, $key, $exp)
     {
         $this->assertFalse($this->adapter->hasTable('t'), 'Dirty test fixture');
@@ -2465,9 +2426,6 @@ INPUT;
         ];
     }
 
-    /**
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::hasPrimaryKey
-     */
     public function testHasNamedPrimaryKey()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -2475,13 +2433,7 @@ INPUT;
         $this->adapter->hasPrimaryKey('t', [], 'named_constraint');
     }
 
-    /**
-     * @dataProvider provideForeignKeysToCheck
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getSchemaName
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getTableInfo
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::hasForeignKey
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getForeignKeys
-     */
+    #[DataProvider('provideForeignKeysToCheck')]
     public function testHasForeignKey($tableDef, $key, $exp)
     {
         $conn = $this->adapter->getConnection();
@@ -2528,7 +2480,6 @@ INPUT;
         ];
     }
 
-    /** @covers \Migrations\Db\Adapter\SqliteAdapter::hasForeignKey */
     public function testHasNamedForeignKey()
     {
         $refTable = new Table('tbl_parent_1', [], $this->adapter);
@@ -2581,10 +2532,7 @@ INPUT;
         $this->assertFalse($this->adapter->hasForeignKey('tbl_child', [], 'check_constraint_2'));
     }
 
-    /**
-     * @dataProvider providePhinxTypes
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getSqlType
-     */
+    #[DataProvider('providePhinxTypes')]
     public function testGetSqlType($phinxType, $limit, $exp)
     {
         if ($exp instanceof Exception) {
@@ -2640,10 +2588,7 @@ INPUT;
         ];
     }
 
-    /**
-     * @dataProvider provideSqlTypes
-     * @covers \Migrations\Db\Adapter\SqliteAdapter::getPhinxType
-     */
+    #[DataProvider('provideSqlTypes')]
     public function testGetPhinxType($sqlType, $exp)
     {
         $this->assertEquals($exp, $this->adapter->getPhinxType($sqlType));
@@ -2821,7 +2766,6 @@ INPUT;
         ];
     }
 
-    /** @covers \Migrations\Db\Adapter\SqliteAdapter::getColumnTypes */
     public function testGetColumnTypes()
     {
         $columnTypes = $this->adapter->getColumnTypes();
@@ -2855,10 +2799,7 @@ INPUT;
         $this->assertEquals($expected, $columnTypes);
     }
 
-    /**
-     * @dataProvider provideColumnTypesForValidation
-     * @covers \Phinx\Db\Adapter\SqliteAdapter::isValidColumnType
-     */
+    #[DataProvider('provideColumnTypesForValidation')]
     public function testIsValidColumnType($phinxType, $exp)
     {
         $col = (new Column())->setType($phinxType);
@@ -2905,10 +2846,7 @@ INPUT;
         ];
     }
 
-    /**
-     * @dataProvider provideDatabaseVersionStrings
-     * @covers \Phinx\Db\Adapter\SqliteAdapter::databaseVersionAtLeast
-     */
+    #[DataProvider('provideDatabaseVersionStrings')]
     public function testDatabaseVersionAtLeast($ver, $exp)
     {
         $this->assertSame($exp, $this->adapter->databaseVersionAtLeast($ver));
@@ -2927,12 +2865,7 @@ INPUT;
         ];
     }
 
-    /**
-     * @dataProvider provideColumnNamesToCheck
-     * @covers \Phinx\Db\Adapter\SqliteAdapter::getSchemaName
-     * @covers \Phinx\Db\Adapter\SqliteAdapter::getTableInfo
-     * @covers \Phinx\Db\Adapter\SqliteAdapter::hasColumn
-     */
+    #[DataProvider('provideColumnNamesToCheck')]
     public function testHasColumn($tableDef, $col, $exp)
     {
         $conn = $this->adapter->getConnection();
@@ -2970,10 +2903,6 @@ INPUT;
         ];
     }
 
-    /** @covers \Phinx\Db\Adapter\SqliteAdapter::getSchemaName
-     * @covers \Phinx\Db\Adapter\SqliteAdapter::getTableInfo
-     * @covers \Phinx\Db\Adapter\SqliteAdapter::getColumns
-     */
     public function testGetColumns()
     {
         $conn = $this->adapter->getConnection();
@@ -2997,10 +2926,7 @@ INPUT;
         }
     }
 
-    /**
-     * @dataProvider provideIdentityCandidates
-     * @covers \Phinx\Db\Adapter\SqliteAdapter::resolveIdentity
-     */
+    #[DataProvider('provideIdentityCandidates')]
     public function testGetColumnsForIdentity($tableDef, $exp)
     {
         $conn = $this->adapter->getConnection();
@@ -3029,10 +2955,7 @@ INPUT;
         ];
     }
 
-    /**
-     * @dataProvider provideDefaultValues
-     * @covers \Phinx\Db\Adapter\SqliteAdapter::parseDefaultValue
-     */
+    #[DataProvider('provideDefaultValues')]
     public function testGetColumnsForDefaults($tableDef, $exp)
     {
         $conn = $this->adapter->getConnection();
@@ -3103,10 +3026,7 @@ INPUT;
         ];
     }
 
-    /**
-     * @dataProvider provideBooleanDefaultValues
-     * @covers \Phinx\Db\Adapter\SqliteAdapter::parseDefaultValue
-     */
+    #[DataProvider('provideBooleanDefaultValues')]
     public function testGetColumnsForBooleanDefaults($tableDef, $exp)
     {
         if (!$this->adapter->databaseVersionAtLeast('3.24')) {
@@ -3134,10 +3054,7 @@ INPUT;
         ];
     }
 
-    /**
-     * @dataProvider provideTablesForTruncation
-     * @covers \Phinx\Db\Adapter\SqliteAdapter::truncateTable
-     */
+    #[DataProvider('provideTablesForTruncation')]
     public function testTruncateTable($tableDef, $tableName, $tableId)
     {
         $conn = $this->adapter->getConnection();

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -1914,7 +1914,7 @@ OUTPUT;
             ->addColumn('int_col', 'integer')
             ->save();
 
-        $builder = $this->adapter->getQueryBuilder(Query::TYPE_INSERT);
+        $builder = $this->adapter->getInsertBuilder();
         $stm = $builder
             ->insert(['string_col', 'int_col'])
             ->into('table1')
@@ -1924,7 +1924,7 @@ OUTPUT;
 
         $this->assertEquals(2, $stm->rowCount());
 
-        $builder = $this->adapter->getQueryBuilder(Query::TYPE_SELECT);
+        $builder = $this->adapter->getSelectBuilder();
         $stm = $builder
             ->select('*')
             ->from('table1')
@@ -1937,7 +1937,7 @@ OUTPUT;
             $stm->fetch('assoc')
         );
 
-        $builder = $this->adapter->getQueryBuilder(Query::TYPE_DELETE);
+        $builder = $this->adapter->getDeleteBuilder();
         $stm = $builder
             ->delete('table1')
             ->where(['int_col <' => 2])

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -512,7 +512,8 @@ class SqliteAdapterTest extends TestCase
         ];
     }
 
-    #[DataProvider('irregularCreateTableProvider')] public function testAddColumnToIrregularCreateTableStatements(string $createTableSql, array $expectedColumns): void
+    #[DataProvider('irregularCreateTableProvider')]
+    public function testAddColumnToIrregularCreateTableStatements(string $createTableSql, array $expectedColumns): void
     {
         $this->adapter->execute($createTableSql);
         $table = new Table('users', [], $this->adapter);
@@ -761,7 +762,8 @@ class SqliteAdapterTest extends TestCase
      * @param string $indexSQL Index creation SQL
      * @param string $newIndexSQL Expected new index creation SQL
      */
-    #[DataProvider('customIndexSQLDataProvider')] public function testRenameColumnWithCustomIndex(string $indexSQL, string $newIndexSQL)
+    #[DataProvider('customIndexSQLDataProvider')]
+    public function testRenameColumnWithCustomIndex(string $indexSQL, string $newIndexSQL)
     {
         $table = new Table('t', [], $this->adapter);
         $table
@@ -859,7 +861,8 @@ class SqliteAdapterTest extends TestCase
      * @param string $indexSQL Index creation SQL
      * @param string $newIndexSQL Expected new index creation SQL
      */
-    #[DataProvider('customCompositeIndexSQLDataProvider')] public function testRenameColumnWithCustomCompositeIndex(string $indexSQL, string $newIndexSQL)
+    #[DataProvider('customCompositeIndexSQLDataProvider')]
+    public function testRenameColumnWithCustomCompositeIndex(string $indexSQL, string $newIndexSQL)
     {
         $table = new Table('t', [], $this->adapter);
         $table
@@ -1031,7 +1034,8 @@ class SqliteAdapterTest extends TestCase
         $this->assertEquals('another default', (string)$cols[1]->getDefault());
     }
 
-    #[DataProvider('columnCreationArgumentProvider')] public function testDropColumn($columnCreationArgs)
+    #[DataProvider('columnCreationArgumentProvider')]
+    public function testDropColumn($columnCreationArgs)
     {
         $table = new Table('t', [], $this->adapter);
         $columnName = $columnCreationArgs[0];
@@ -1154,7 +1158,8 @@ class SqliteAdapterTest extends TestCase
     /**
      * @param string $indexSQL Index creation SQL
      */
-    #[DataProvider('customIndexSQLDataProvider')] public function testDropColumnWithCustomIndex(string $indexSQL)
+    #[DataProvider('customIndexSQLDataProvider')]
+    public function testDropColumnWithCustomIndex(string $indexSQL)
     {
         $table = new Table('t', [], $this->adapter);
         $table
@@ -1173,7 +1178,8 @@ class SqliteAdapterTest extends TestCase
     /**
      * @param string $indexSQL Index creation SQL
      */
-    #[DataProvider('customCompositeIndexSQLDataProvider')] public function testDropColumnWithCustomCompositeIndex(string $indexSQL)
+    #[DataProvider('customCompositeIndexSQLDataProvider')]
+    public function testDropColumnWithCustomCompositeIndex(string $indexSQL)
     {
         $table = new Table('t', [], $this->adapter);
         $table
@@ -1498,7 +1504,8 @@ class SqliteAdapterTest extends TestCase
     /**
      * @param array $columns
      */
-    #[DataProvider('nonExistentForeignKeyColumnsProvider')] public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
+    #[DataProvider('nonExistentForeignKeyColumnsProvider')]
+    public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
     {
         $refTable = new Table('ref_table', [], $this->adapter);
         $refTable

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -8,7 +8,6 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\StubConsoleInput;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Database\Connection;
-use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
 use InvalidArgumentException;
 use Migrations\Db\Adapter\SqlserverAdapter;
@@ -16,6 +15,7 @@ use Migrations\Db\Literal;
 use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -620,10 +620,7 @@ WHERE t.name='ntable'");
         ];
     }
 
-    /**
-     * @dataProvider columnsProvider
-     */
-    public function testGetColumns($colName, $type, $options)
+    #[DataProvider('columnsProvider')] public function testGetColumns($colName, $type, $options)
     {
         $table = new Table('t', [], $this->adapter);
         $table
@@ -930,10 +927,9 @@ WHERE t.name='ntable'");
     }
 
     /**
-     * @dataProvider nonExistentForeignKeyColumnsProvider
      * @param array $columns
      */
-    public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
+    #[DataProvider('nonExistentForeignKeyColumnsProvider')] public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
     {
         $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
@@ -998,10 +994,7 @@ WHERE t.name='ntable'");
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
     }
 
-    /**
-     * @dataProvider provideForeignKeysToCheck
-     */
-    public function testHasForeignKey($tableDef, $key, $exp)
+    #[DataProvider('provideForeignKeysToCheck')] public function testHasForeignKey($tableDef, $key, $exp)
     {
         $conn = $this->adapter->getConnection();
         $conn->execute('CREATE TABLE other(a int, b int, c int, unique(a), unique(b), unique(a,b), unique(a,b,c));');

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -16,6 +16,7 @@ use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -1109,9 +1110,7 @@ WHERE t.name='ntable'");
         $this->assertEquals($comment, $resultComment, 'Dont set column comment correctly');
     }
 
-    /**
-     * @dependss testAddColumnComment
-     */
+    #[Depends('testAddColumnComment')]
     public function testChangeColumnComment()
     {
         $table = new Table('table1', [], $this->adapter);
@@ -1126,9 +1125,7 @@ WHERE t.name='ntable'");
         $this->assertEquals($comment, $resultComment, 'Dont change column comment correctly');
     }
 
-    /**
-     * @depends testAddColumnComment
-     */
+    #[Depends('testAddColumnComment')]
     public function testRemoveColumnComment()
     {
         $table = new Table('table1', [], $this->adapter);

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -1300,7 +1300,7 @@ OUTPUT;
             ->addColumn('int_col', 'integer')
             ->save();
 
-        $builder = $this->adapter->getQueryBuilder(Query::TYPE_INSERT);
+        $builder = $this->adapter->getInsertBuilder();
         $stm = $builder
             ->insert(['string_col', 'int_col'])
             ->into('table1')
@@ -1310,7 +1310,7 @@ OUTPUT;
 
         $stm->closeCursor();
 
-        $builder = $this->adapter->getQueryBuilder(Query::TYPE_SELECT);
+        $builder = $this->adapter->getSelectBuilder();
         $stm = $builder
             ->select('*')
             ->from('table1')
@@ -1325,7 +1325,7 @@ OUTPUT;
 
         $stm->closeCursor();
 
-        $builder = $this->adapter->getQueryBuilder(Query::TYPE_DELETE);
+        $builder = $this->adapter->getDeleteBuilder();
         $stm = $builder
             ->delete('table1')
             ->where(['int_col <' => 2])

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -621,7 +621,8 @@ WHERE t.name='ntable'");
         ];
     }
 
-    #[DataProvider('columnsProvider')] public function testGetColumns($colName, $type, $options)
+    #[DataProvider('columnsProvider')]
+    public function testGetColumns($colName, $type, $options)
     {
         $table = new Table('t', [], $this->adapter);
         $table
@@ -930,7 +931,8 @@ WHERE t.name='ntable'");
     /**
      * @param array $columns
      */
-    #[DataProvider('nonExistentForeignKeyColumnsProvider')] public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
+    #[DataProvider('nonExistentForeignKeyColumnsProvider')]
+    public function testDropForeignKeyByNonExistentKeyColumns(array $columns)
     {
         $refTable = new Table('ref_table', [], $this->adapter);
         $refTable
@@ -995,7 +997,8 @@ WHERE t.name='ntable'");
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
     }
 
-    #[DataProvider('provideForeignKeysToCheck')] public function testHasForeignKey($tableDef, $key, $exp)
+    #[DataProvider('provideForeignKeysToCheck')]
+    public function testHasForeignKey($tableDef, $key, $exp)
     {
         $conn = $this->adapter->getConnection();
         $conn->execute('CREATE TABLE other(a int, b int, c int, unique(a), unique(b), unique(a,b), unique(a,b,c));');

--- a/tests/TestCase/Db/Table/ColumnTest.php
+++ b/tests/TestCase/Db/Table/ColumnTest.php
@@ -5,6 +5,7 @@ namespace Migrations\Test\TestCase\Db\Table;
 
 use Cake\Core\Configure;
 use Migrations\Db\Table\Column;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -31,9 +32,7 @@ class ColumnTest extends TestCase
         $this->assertTrue($column->isIdentity());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testColumnNullFeatureFlag()
     {
         $column = new Column();

--- a/tests/TestCase/Db/Table/ForeignKeyTest.php
+++ b/tests/TestCase/Db/Table/ForeignKeyTest.php
@@ -5,6 +5,7 @@ namespace Migrations\Test\TestCase\Phinx\Db\Table;
 
 use InvalidArgumentException;
 use Migrations\Db\Table\ForeignKey;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -37,9 +38,8 @@ class ForeignKeyTest extends TestCase
     /**
      * @param string $dirtyValue
      * @param string $valueOfConstant
-     * @dataProvider actionsProvider
      */
-    public function testBothActionsCanBeSetThroughSetters($dirtyValue, $valueOfConstant)
+    #[DataProvider('actionsProvider')] public function testBothActionsCanBeSetThroughSetters($dirtyValue, $valueOfConstant)
     {
         $this->fk->setOnDelete($dirtyValue)->setOnUpdate($dirtyValue);
         $this->assertEquals($valueOfConstant, $this->fk->getOnDelete());
@@ -49,9 +49,8 @@ class ForeignKeyTest extends TestCase
     /**
      * @param string $dirtyValue
      * @param string $valueOfConstant
-     * @dataProvider actionsProvider
      */
-    public function testBothActionsCanBeSetThroughOptions($dirtyValue, $valueOfConstant)
+    #[DataProvider('actionsProvider')] public function testBothActionsCanBeSetThroughOptions($dirtyValue, $valueOfConstant)
     {
         $this->fk->setOptions([
             'delete' => $dirtyValue,

--- a/tests/TestCase/Db/Table/ForeignKeyTest.php
+++ b/tests/TestCase/Db/Table/ForeignKeyTest.php
@@ -39,7 +39,8 @@ class ForeignKeyTest extends TestCase
      * @param string $dirtyValue
      * @param string $valueOfConstant
      */
-    #[DataProvider('actionsProvider')] public function testBothActionsCanBeSetThroughSetters($dirtyValue, $valueOfConstant)
+    #[DataProvider('actionsProvider')]
+    public function testBothActionsCanBeSetThroughSetters($dirtyValue, $valueOfConstant)
     {
         $this->fk->setOnDelete($dirtyValue)->setOnUpdate($dirtyValue);
         $this->assertEquals($valueOfConstant, $this->fk->getOnDelete());
@@ -50,7 +51,8 @@ class ForeignKeyTest extends TestCase
      * @param string $dirtyValue
      * @param string $valueOfConstant
      */
-    #[DataProvider('actionsProvider')] public function testBothActionsCanBeSetThroughOptions($dirtyValue, $valueOfConstant)
+    #[DataProvider('actionsProvider')]
+    public function testBothActionsCanBeSetThroughOptions($dirtyValue, $valueOfConstant)
     {
         $this->fk->setOptions([
             'delete' => $dirtyValue,

--- a/tests/TestCase/Db/Table/TableTest.php
+++ b/tests/TestCase/Db/Table/TableTest.php
@@ -116,7 +116,8 @@ class TableTest extends TestCase
      * @param AdapterInterface $adapter
      * @param string|null      $createdAtColumnName * @param string|null      $updatedAtColumnName * @param string           $expectedCreatedAtColumnName * @param string           $expectedUpdatedAtColumnName * @param bool $withTimezone
      */
-    #[DataProvider('provideTimestampColumnNames')] public function testAddTimestamps(AdapterInterface $adapter, $createdAtColumnName, $updatedAtColumnName, $expectedCreatedAtColumnName, $expectedUpdatedAtColumnName, $withTimezone)
+    #[DataProvider('provideTimestampColumnNames')]
+    public function testAddTimestamps(AdapterInterface $adapter, $createdAtColumnName, $updatedAtColumnName, $expectedCreatedAtColumnName, $expectedUpdatedAtColumnName, $withTimezone)
     {
         $table = new Table('ntable', [], $adapter);
         $table->addTimestamps($createdAtColumnName, $updatedAtColumnName, $withTimezone);
@@ -145,7 +146,8 @@ class TableTest extends TestCase
     /**
      * @param AdapterInterface $adapter
      */
-    #[DataProvider('provideAdapters')] public function testAddTimestampsNoUpdated(AdapterInterface $adapter)
+    #[DataProvider('provideAdapters')]
+    public function testAddTimestampsNoUpdated(AdapterInterface $adapter)
     {
         $table = new Table('ntable', [], $adapter);
         $table->addTimestamps(null, false);
@@ -169,7 +171,8 @@ class TableTest extends TestCase
     /**
      * @param AdapterInterface $adapter
      */
-    #[DataProvider('provideAdapters')] public function testAddTimestampsNoCreated(AdapterInterface $adapter)
+    #[DataProvider('provideAdapters')]
+    public function testAddTimestampsNoCreated(AdapterInterface $adapter)
     {
         $table = new Table('ntable', [], $adapter);
         $table->addTimestamps(false, null);
@@ -194,7 +197,8 @@ class TableTest extends TestCase
     /**
      * @param AdapterInterface $adapter
      */
-    #[DataProvider('provideAdapters')] public function testAddTimestampsThrowsOnBothFalse(AdapterInterface $adapter)
+    #[DataProvider('provideAdapters')]
+    public function testAddTimestampsThrowsOnBothFalse(AdapterInterface $adapter)
     {
         $table = new Table('ntable', [], $adapter);
         $this->expectException(RuntimeException::class);
@@ -210,7 +214,8 @@ class TableTest extends TestCase
      * @param string           $expectedUpdatedAtColumnName
      * @param bool $withTimezone
      */
-    #[DataProvider('provideTimestampColumnNames')] public function testAddTimestampsWithTimezone(AdapterInterface $adapter, $createdAtColumnName, $updatedAtColumnName, $expectedCreatedAtColumnName, $expectedUpdatedAtColumnName, $withTimezone)
+    #[DataProvider('provideTimestampColumnNames')]
+    public function testAddTimestampsWithTimezone(AdapterInterface $adapter, $createdAtColumnName, $updatedAtColumnName, $expectedCreatedAtColumnName, $expectedUpdatedAtColumnName, $withTimezone)
     {
         $table = new Table('ntable', [], $adapter);
         $table->addTimestampsWithTimezone($createdAtColumnName, $updatedAtColumnName);
@@ -413,7 +418,8 @@ class TableTest extends TestCase
      * @param string $indexIdentifier
      * @param Index $index
      */
-    #[DataProvider('removeIndexDataprovider')] public function testRemoveIndex($indexIdentifier, Index $index)
+    #[DataProvider('removeIndexDataprovider')]
+    public function testRemoveIndex($indexIdentifier, Index $index)
     {
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
             ->setConstructorArgs([[]])

--- a/tests/TestCase/Db/Table/TableTest.php
+++ b/tests/TestCase/Db/Table/TableTest.php
@@ -13,6 +13,7 @@ use Phinx\Db\Adapter\SqlServerAdapter;
 use Phinx\Db\Table;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Index;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use RuntimeException;
@@ -112,11 +113,10 @@ class TableTest extends TestCase
     }
 
     /**
-     * @dataProvider provideTimestampColumnNames
      * @param AdapterInterface $adapter
      * @param string|null      $createdAtColumnName * @param string|null      $updatedAtColumnName * @param string           $expectedCreatedAtColumnName * @param string           $expectedUpdatedAtColumnName * @param bool $withTimezone
      */
-    public function testAddTimestamps(AdapterInterface $adapter, $createdAtColumnName, $updatedAtColumnName, $expectedCreatedAtColumnName, $expectedUpdatedAtColumnName, $withTimezone)
+    #[DataProvider('provideTimestampColumnNames')] public function testAddTimestamps(AdapterInterface $adapter, $createdAtColumnName, $updatedAtColumnName, $expectedCreatedAtColumnName, $expectedUpdatedAtColumnName, $withTimezone)
     {
         $table = new Table('ntable', [], $adapter);
         $table->addTimestamps($createdAtColumnName, $updatedAtColumnName, $withTimezone);
@@ -143,10 +143,9 @@ class TableTest extends TestCase
     }
 
     /**
-     * @dataProvider provideAdapters
      * @param AdapterInterface $adapter
      */
-    public function testAddTimestampsNoUpdated(AdapterInterface $adapter)
+    #[DataProvider('provideAdapters')] public function testAddTimestampsNoUpdated(AdapterInterface $adapter)
     {
         $table = new Table('ntable', [], $adapter);
         $table->addTimestamps(null, false);
@@ -168,10 +167,9 @@ class TableTest extends TestCase
     }
 
     /**
-     * @dataProvider provideAdapters
      * @param AdapterInterface $adapter
      */
-    public function testAddTimestampsNoCreated(AdapterInterface $adapter)
+    #[DataProvider('provideAdapters')] public function testAddTimestampsNoCreated(AdapterInterface $adapter)
     {
         $table = new Table('ntable', [], $adapter);
         $table->addTimestamps(false, null);
@@ -194,10 +192,9 @@ class TableTest extends TestCase
     }
 
     /**
-     * @dataProvider provideAdapters
      * @param AdapterInterface $adapter
      */
-    public function testAddTimestampsThrowsOnBothFalse(AdapterInterface $adapter)
+    #[DataProvider('provideAdapters')] public function testAddTimestampsThrowsOnBothFalse(AdapterInterface $adapter)
     {
         $table = new Table('ntable', [], $adapter);
         $this->expectException(RuntimeException::class);
@@ -206,7 +203,6 @@ class TableTest extends TestCase
     }
 
     /**
-     * @dataProvider provideTimestampColumnNames
      * @param AdapterInterface $adapter
      * @param string|null      $createdAtColumnName
      * @param string|null      $updatedAtColumnName
@@ -214,7 +210,7 @@ class TableTest extends TestCase
      * @param string           $expectedUpdatedAtColumnName
      * @param bool $withTimezone
      */
-    public function testAddTimestampsWithTimezone(AdapterInterface $adapter, $createdAtColumnName, $updatedAtColumnName, $expectedCreatedAtColumnName, $expectedUpdatedAtColumnName, $withTimezone)
+    #[DataProvider('provideTimestampColumnNames')] public function testAddTimestampsWithTimezone(AdapterInterface $adapter, $createdAtColumnName, $updatedAtColumnName, $expectedCreatedAtColumnName, $expectedUpdatedAtColumnName, $withTimezone)
     {
         $table = new Table('ntable', [], $adapter);
         $table->addTimestampsWithTimezone($createdAtColumnName, $updatedAtColumnName);
@@ -414,11 +410,10 @@ class TableTest extends TestCase
     }
 
     /**
-     * @dataProvider removeIndexDataprovider
      * @param string $indexIdentifier
      * @param Index $index
      */
-    public function testRemoveIndex($indexIdentifier, Index $index)
+    #[DataProvider('removeIndexDataprovider')] public function testRemoveIndex($indexIdentifier, Index $index)
     {
         $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
             ->setConstructorArgs([[]])

--- a/tests/TestCase/Migration/EnvironmentTest.php
+++ b/tests/TestCase/Migration/EnvironmentTest.php
@@ -288,10 +288,12 @@ class EnvironmentTest extends TestCase
         $upMigration = new class ('mockenv', 20110301080000) extends AbstractMigration {
             public bool $initExecuted = false;
             public bool $upExecuted = false;
+
             public function init(): void
             {
                 $this->initExecuted = true;
             }
+
             public function up(): void
             {
                 $this->upExecuted = true;
@@ -316,10 +318,12 @@ class EnvironmentTest extends TestCase
         $seed = new class ('mockenv', 20110301080000) extends AbstractSeed {
             public bool $initExecuted = false;
             public bool $runExecuted = false;
+
             public function init(): void
             {
                 $this->initExecuted = true;
             }
+
             public function run(): void
             {
                 $this->runExecuted = true;

--- a/tests/TestCase/Migration/EnvironmentTest.php
+++ b/tests/TestCase/Migration/EnvironmentTest.php
@@ -101,7 +101,7 @@ class EnvironmentTest extends TestCase
             ->getMock();
         $stub->expects($this->any())
              ->method('getVersions')
-             ->will($this->returnValue([20110301080000]));
+             ->willReturn([20110301080000]);
 
         $this->environment->setAdapter($stub);
 
@@ -121,14 +121,16 @@ class EnvironmentTest extends TestCase
         $this->environment->setAdapter($adapterStub);
 
         // up
-        $upMigration = $this->getMockBuilder(AbstractMigration::class)
-            ->setConstructorArgs(['mockenv', '20110301080000'])
-            ->addMethods(['up'])
-            ->getMock();
-        $upMigration->expects($this->once())
-                    ->method('up');
+        $upMigration = new class ('mockenv', 20110301080000) extends AbstractMigration {
+            public bool $executed = false;
+            public function up(): void
+            {
+                $this->executed = true;
+            }
+        };
 
         $this->environment->executeMigration($upMigration, MigrationInterface::UP);
+        $this->assertTrue($upMigration->executed);
     }
 
     public function testExecutingAMigrationDown()
@@ -144,14 +146,16 @@ class EnvironmentTest extends TestCase
         $this->environment->setAdapter($adapterStub);
 
         // down
-        $downMigration = $this->getMockBuilder(AbstractMigration::class)
-            ->setConstructorArgs(['mockenv', '20110301080000'])
-            ->addMethods(['down'])
-            ->getMock();
-        $downMigration->expects($this->once())
-                      ->method('down');
+        $downMigration = new class ('mockenv', 20110301080000) extends AbstractMigration {
+            public bool $executed = false;
+            public function down(): void
+            {
+                $this->executed = true;
+            }
+        };
 
         $this->environment->executeMigration($downMigration, MigrationInterface::DOWN);
+        $this->assertTrue($downMigration->executed);
     }
 
     public function testExecutingAMigrationWithTransactions()
@@ -168,19 +172,21 @@ class EnvironmentTest extends TestCase
 
         $adapterStub->expects($this->exactly(2))
                     ->method('hasTransactions')
-                    ->will($this->returnValue(true));
+                    ->willReturn(true);
 
         $this->environment->setAdapter($adapterStub);
 
         // migrate
-        $migration = $this->getMockBuilder(AbstractMigration::class)
-            ->setConstructorArgs(['mockenv', '20110301080000'])
-            ->addMethods(['up'])
-            ->getMock();
-        $migration->expects($this->once())
-                  ->method('up');
+        $migration = new class ('mockenv', 20110301080000) extends AbstractMigration {
+            public bool $executed = false;
+            public function up(): void
+            {
+                $this->executed = true;
+            }
+        };
 
         $this->environment->executeMigration($migration, MigrationInterface::UP);
+        $this->assertTrue($migration->executed);
     }
 
     public function testExecutingAChangeMigrationUp()
@@ -196,14 +202,16 @@ class EnvironmentTest extends TestCase
         $this->environment->setAdapter($adapterStub);
 
         // migration
-        $migration = $this->getMockBuilder(AbstractMigration::class)
-            ->setConstructorArgs(['mockenv', '20130301080000'])
-            ->addMethods(['change'])
-            ->getMock();
-        $migration->expects($this->once())
-                  ->method('change');
+        $migration = new class ('mockenv', 20130301080000) extends AbstractMigration {
+            public bool $executed = false;
+            public function change(): void
+            {
+                $this->executed = true;
+            }
+        };
 
         $this->environment->executeMigration($migration, MigrationInterface::UP);
+        $this->assertTrue($migration->executed);
     }
 
     public function testExecutingAChangeMigrationDown()
@@ -219,14 +227,16 @@ class EnvironmentTest extends TestCase
         $this->environment->setAdapter($adapterStub);
 
         // migration
-        $migration = $this->getMockBuilder(AbstractMigration::class)
-            ->setConstructorArgs(['mockenv', '20130301080000'])
-            ->addMethods(['change'])
-            ->getMock();
-        $migration->expects($this->once())
-                  ->method('change');
+        $migration = new class ('mockenv', 20130301080000) extends AbstractMigration {
+            public bool $executed = false;
+            public function change(): void
+            {
+                $this->executed = true;
+            }
+        };
 
         $this->environment->executeMigration($migration, MigrationInterface::DOWN);
+        $this->assertTrue($migration->executed);
     }
 
     public function testExecutingAFakeMigration()
@@ -242,14 +252,16 @@ class EnvironmentTest extends TestCase
         $this->environment->setAdapter($adapterStub);
 
         // migration
-        $migration = $this->getMockBuilder(AbstractMigration::class)
-            ->setConstructorArgs(['mockenv', '20130301080000'])
-            ->addMethods(['change'])
-            ->getMock();
-        $migration->expects($this->never())
-                  ->method('change');
+        $migration = new class ('mockenv', 20130301080000) extends AbstractMigration {
+            public bool $executed = false;
+            public function change(): void
+            {
+                $this->executed = true;
+            }
+        };
 
         $this->environment->executeMigration($migration, MigrationInterface::UP, true);
+        $this->assertFalse($migration->executed);
     }
 
     public function testGettingInputObject()
@@ -273,16 +285,22 @@ class EnvironmentTest extends TestCase
         $this->environment->setAdapter($adapterStub);
 
         // up
-        $upMigration = $this->getMockBuilder(AbstractMigration::class)
-            ->setConstructorArgs(['mockenv', '20110301080000'])
-            ->addMethods(['up', 'init'])
-            ->getMock();
-        $upMigration->expects($this->once())
-                    ->method('up');
-        $upMigration->expects($this->once())
-                    ->method('init');
+        $upMigration = new class ('mockenv', 20110301080000) extends AbstractMigration {
+            public bool $initExecuted = false;
+            public bool $upExecuted = false;
+            public function init(): void
+            {
+                $this->initExecuted = true;
+            }
+            public function up(): void
+            {
+                $this->upExecuted = true;
+            }
+        };
 
         $this->environment->executeMigration($upMigration, MigrationInterface::UP);
+        $this->assertTrue($upMigration->initExecuted);
+        $this->assertTrue($upMigration->upExecuted);
     }
 
     public function testExecuteSeedInit()
@@ -295,16 +313,21 @@ class EnvironmentTest extends TestCase
         $this->environment->setAdapter($adapterStub);
 
         // up
-        $seed = $this->getMockBuilder(AbstractSeed::class)
-            ->addMethods(['init'])
-            ->onlyMethods(['run'])
-            ->getMock();
-
-        $seed->expects($this->once())
-                    ->method('run');
-        $seed->expects($this->once())
-                    ->method('init');
+        $seed = new class ('mockenv', 20110301080000) extends AbstractSeed {
+            public bool $initExecuted = false;
+            public bool $runExecuted = false;
+            public function init(): void
+            {
+                $this->initExecuted = true;
+            }
+            public function run(): void
+            {
+                $this->runExecuted = true;
+            }
+        };
 
         $this->environment->executeSeed($seed);
+        $this->assertTrue($seed->initExecuted);
+        $this->assertTrue($seed->runExecuted);
     }
 }

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -174,7 +174,7 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
-                ->will($this->returnValue(
+                ->willReturn(
                     [
                         '20120111235330' =>
                             [
@@ -193,7 +193,7 @@ class ManagerTest extends TestCase
                                 'breakpoint' => '0',
                             ],
                     ]
-                ));
+                );
 
         $this->manager->setEnvironment($envStub);
         $return = $this->manager->printStatus();
@@ -220,7 +220,7 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
-                ->will($this->returnValue(
+                ->willReturn(
                     [
                         '20120111235330' =>
                             [
@@ -239,7 +239,7 @@ class ManagerTest extends TestCase
                                 'breakpoint' => '0',
                             ],
                     ]
-                ));
+                );
         $this->manager->setEnvironment($envStub);
         $return = $this->manager->printStatus(AbstractCommand::FORMAT_JSON);
         $expected = [
@@ -265,7 +265,7 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
-                ->will($this->returnValue(
+                ->willReturn(
                     [
                         '20120111235330' =>
                             [
@@ -284,7 +284,7 @@ class ManagerTest extends TestCase
                                 'breakpoint' => '0',
                             ],
                     ]
-                ));
+                );
 
         $this->manager->setEnvironment($envStub);
         $return = $this->manager->printStatus();
@@ -330,7 +330,7 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
-                ->will($this->returnValue(
+                ->willReturn(
                     [
                         '20120103083300' =>
                             [
@@ -349,7 +349,7 @@ class ManagerTest extends TestCase
                                 'breakpoint' => '0',
                             ],
                     ]
-                ));
+                );
 
         $this->manager->setEnvironment($envStub);
 
@@ -389,7 +389,7 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
-                ->will($this->returnValue(
+                ->willReturn(
                     [
                         '20120111235330' =>
                             [
@@ -416,7 +416,7 @@ class ManagerTest extends TestCase
                                 'breakpoint' => '0',
                             ],
                     ]
-                ));
+                );
 
         $this->manager->setEnvironment($envStub);
 
@@ -450,7 +450,7 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
-                ->will($this->returnValue(
+                ->willReturn(
                     [
                         '20120103083300' =>
                             [
@@ -469,7 +469,7 @@ class ManagerTest extends TestCase
                                 'breakpoint' => '0',
                             ],
                     ]
-                ));
+                );
 
         $this->manager->setEnvironment($envStub);
         $return = $this->manager->printStatus();
@@ -509,14 +509,15 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
-                ->will($this->returnValue([
+                ->willReturn([
                     '20120111235330' => [
                         'version' => '20120111235330',
                         'start_time' => '2012-01-16 18:35:40',
                         'end_time' => '2012-01-16 18:35:41',
                         'migration_name' => '',
                         'breakpoint' => 0,
-                    ]]));
+                    ]
+                ]);
 
         $this->manager->setEnvironment($envStub);
 
@@ -544,7 +545,7 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
-                ->will($this->returnValue([
+                ->willReturn([
                     '20120111235330' =>
                         [
                             'version' => '20120111235330',
@@ -568,7 +569,8 @@ class ManagerTest extends TestCase
                             'end_time' => '2012-01-16 18:35:41',
                             'migration_name' => 'Example',
                             'breakpoint' => 0,
-                        ]]));
+                        ]
+                ]);
 
         $this->manager->setEnvironment($envStub);
 
@@ -664,7 +666,7 @@ class ManagerTest extends TestCase
         } else {
             $envStub->expects($this->once())
                     ->method('getVersions')
-                    ->will($this->returnValue($availableMigrations));
+                    ->willReturn($availableMigrations);
         }
         $this->manager->setEnvironment($envStub);
         $this->manager->migrateToDateTime(new DateTime($dateString));
@@ -691,7 +693,7 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->any())
             ->method('getVersionLog')
-            ->will($this->returnValue($availableRollbacks));
+            ->willReturn($availableRollbacks);
 
         $this->manager->setEnvironment($envStub);
         $this->manager->rollback($version);
@@ -724,7 +726,7 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->any())
             ->method('getVersionLog')
-            ->will($this->returnValue($availableRollbacks));
+            ->willReturn($availableRollbacks);
 
         $this->manager->setEnvironment($envStub);
         $this->manager->rollback($version, false, false);
@@ -757,7 +759,7 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->any())
             ->method('getVersionLog')
-            ->will($this->returnValue($availableRollbacks));
+            ->willReturn($availableRollbacks);
 
         // get a manager with a config whose version order is set to execution time
         $configArray = $this->getConfigArray();
@@ -796,7 +798,7 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->any())
             ->method('getVersionLog')
-            ->will($this->returnValue($availableRollbacks));
+            ->willReturn($availableRollbacks);
 
         // get a manager with a config whose version order is set to execution time
         $configArray = $this->getConfigArray();
@@ -835,7 +837,7 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->any())
             ->method('getVersionLog')
-            ->will($this->returnValue($availableRollbacks));
+            ->willReturn($availableRollbacks);
 
         // get a manager with a config whose version order is set to execution time
         $configArray = $this->getConfigArray();
@@ -869,12 +871,12 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->any())
                 ->method('getVersionLog')
-                ->will($this->returnValue([
+                ->willReturn([
                     '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                ]));
+                ]);
         $envStub->expects($this->any())
                 ->method('getVersions')
-                ->will($this->returnValue([20120111235330]));
+                ->willReturn([20120111235330]);
 
         $this->manager->setEnvironment($envStub);
         $this->manager->rollback();
@@ -894,23 +896,19 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->any())
                 ->method('getVersionLog')
-                ->will(
-                    $this->returnValue(
-                        [
-                            '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                            '20120116183504' => ['version' => '20120815145812', 'migration' => '', 'breakpoint' => 0],
-                        ]
-                    )
+                ->willReturn(
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120815145812', 'migration' => '', 'breakpoint' => 0],
+                    ]
                 );
         $envStub->expects($this->any())
                 ->method('getVersions')
-                ->will(
-                    $this->returnValue(
-                        [
-                            20120111235330,
-                            20120116183504,
-                        ]
-                    )
+                ->willReturn(
+                    [
+                        20120111235330,
+                        20120116183504,
+                    ]
                 );
 
         $this->manager->setEnvironment($envStub);
@@ -933,7 +931,7 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->any())
             ->method('getVersionLog')
-            ->will($this->returnValue($availableRolbacks));
+            ->willReturn($availableRolbacks);
 
         // get a manager with a config whose version order is set to execution time
         $configArray = $this->getConfigArray();
@@ -2675,7 +2673,7 @@ class ManagerTest extends TestCase
             ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
-                ->will($this->returnValue(
+                ->willReturn(
                     [
                         '20120111235330' =>
                             [
@@ -2686,7 +2684,7 @@ class ManagerTest extends TestCase
                                 'breakpoint' => '0',
                             ],
                     ]
-                ));
+                );
 
         $this->manager->setEnvironment($envStub);
         $this->manager->setBreakpoint(20120133235330);

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -654,7 +654,8 @@ class ManagerTest extends TestCase
      * @param string $expectedMigration
      * @param string $message
      */
-    #[DataProvider('migrateDateDataProvider')] public function testMigrationsByDate(array $availableMigrations, $dateString, $expectedMigration, $message)
+    #[DataProvider('migrateDateDataProvider')]
+    public function testMigrationsByDate(array $availableMigrations, $dateString, $expectedMigration, $message)
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -683,7 +684,8 @@ class ManagerTest extends TestCase
      * Test that rollbacking to version chooses the correct
      * migration to point to.
      */
-    #[DataProvider('rollbackToVersionDataProvider')] public function testRollbackToVersion($availableRollbacks, $version, $expectedOutput)
+    #[DataProvider('rollbackToVersionDataProvider')]
+    public function testRollbackToVersion($availableRollbacks, $version, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -714,7 +716,8 @@ class ManagerTest extends TestCase
      * Test that rollbacking to date chooses the correct
      * migration to point to.
      */
-    #[DataProvider('rollbackToDateDataProvider')] public function testRollbackToDate($availableRollbacks, $version, $expectedOutput)
+    #[DataProvider('rollbackToDateDataProvider')]
+    public function testRollbackToDate($availableRollbacks, $version, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -745,7 +748,8 @@ class ManagerTest extends TestCase
      * Test that rollbacking to version by execution time chooses the correct
      * migration to point to.
      */
-    #[DataProvider('rollbackToVersionByExecutionTimeDataProvider')] public function testRollbackToVersionByExecutionTime($availableRollbacks, $version, $expectedOutput)
+    #[DataProvider('rollbackToVersionByExecutionTimeDataProvider')]
+    public function testRollbackToVersionByExecutionTime($availableRollbacks, $version, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -782,7 +786,8 @@ class ManagerTest extends TestCase
      * Test that rollbacking to version by migration name chooses the correct
      * migration to point to.
      */
-    #[DataProvider('rollbackToVersionByExecutionTimeDataProvider')] public function testRollbackToVersionByName($availableRollbacks, $version, $expectedOutput)
+    #[DataProvider('rollbackToVersionByExecutionTimeDataProvider')]
+    public function testRollbackToVersionByName($availableRollbacks, $version, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -819,7 +824,8 @@ class ManagerTest extends TestCase
      * Test that rollbacking to date by execution time chooses the correct
      * migration to point to.
      */
-    #[DataProvider('rollbackToDateByExecutionTimeDataProvider')] public function testRollbackToDateByExecutionTime($availableRollbacks, $date, $expectedOutput)
+    #[DataProvider('rollbackToDateByExecutionTimeDataProvider')]
+    public function testRollbackToDateByExecutionTime($availableRollbacks, $date, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -911,7 +917,8 @@ class ManagerTest extends TestCase
     /**
      * Test that rollbacking last migration
      */
-    #[DataProvider('rollbackLastDataProvider')] public function testRollbackLast(array $availableRolbacks, string $versionOrder, string $expectedOutput): void
+    #[DataProvider('rollbackLastDataProvider')]
+    public function testRollbackLast(array $availableRolbacks, string $versionOrder, string $expectedOutput): void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -15,6 +15,7 @@ use Migrations\Migration\Environment;
 use Migrations\Migration\Manager;
 use Migrations\Shim\OutputAdapter;
 use Phinx\Console\Command\AbstractCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
@@ -516,7 +517,7 @@ class ManagerTest extends TestCase
                         'end_time' => '2012-01-16 18:35:41',
                         'migration_name' => '',
                         'breakpoint' => 0,
-                    ]
+                    ],
                 ]);
 
         $this->manager->setEnvironment($envStub);
@@ -569,7 +570,7 @@ class ManagerTest extends TestCase
                             'end_time' => '2012-01-16 18:35:41',
                             'migration_name' => 'Example',
                             'breakpoint' => 0,
-                        ]
+                        ],
                 ]);
 
         $this->manager->setEnvironment($envStub);
@@ -648,13 +649,12 @@ class ManagerTest extends TestCase
      * Test that migrating by date chooses the correct
      * migration to point to.
      *
-     * @dataProvider migrateDateDataProvider
      * @param string[] $availableMigrations
      * @param string $dateString
      * @param string $expectedMigration
      * @param string $message
      */
-    public function testMigrationsByDate(array $availableMigrations, $dateString, $expectedMigration, $message)
+    #[DataProvider('migrateDateDataProvider')] public function testMigrationsByDate(array $availableMigrations, $dateString, $expectedMigration, $message)
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -682,10 +682,8 @@ class ManagerTest extends TestCase
     /**
      * Test that rollbacking to version chooses the correct
      * migration to point to.
-     *
-     * @dataProvider rollbackToVersionDataProvider
      */
-    public function testRollbackToVersion($availableRollbacks, $version, $expectedOutput)
+    #[DataProvider('rollbackToVersionDataProvider')] public function testRollbackToVersion($availableRollbacks, $version, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -715,10 +713,8 @@ class ManagerTest extends TestCase
     /**
      * Test that rollbacking to date chooses the correct
      * migration to point to.
-     *
-     * @dataProvider rollbackToDateDataProvider
      */
-    public function testRollbackToDate($availableRollbacks, $version, $expectedOutput)
+    #[DataProvider('rollbackToDateDataProvider')] public function testRollbackToDate($availableRollbacks, $version, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -748,10 +744,8 @@ class ManagerTest extends TestCase
     /**
      * Test that rollbacking to version by execution time chooses the correct
      * migration to point to.
-     *
-     * @dataProvider rollbackToVersionByExecutionTimeDataProvider
      */
-    public function testRollbackToVersionByExecutionTime($availableRollbacks, $version, $expectedOutput)
+    #[DataProvider('rollbackToVersionByExecutionTimeDataProvider')] public function testRollbackToVersionByExecutionTime($availableRollbacks, $version, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -787,10 +781,8 @@ class ManagerTest extends TestCase
     /**
      * Test that rollbacking to version by migration name chooses the correct
      * migration to point to.
-     *
-     * @dataProvider rollbackToVersionByExecutionTimeDataProvider
      */
-    public function testRollbackToVersionByName($availableRollbacks, $version, $expectedOutput)
+    #[DataProvider('rollbackToVersionByExecutionTimeDataProvider')] public function testRollbackToVersionByName($availableRollbacks, $version, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -826,10 +818,8 @@ class ManagerTest extends TestCase
     /**
      * Test that rollbacking to date by execution time chooses the correct
      * migration to point to.
-     *
-     * @dataProvider rollbackToDateByExecutionTimeDataProvider
      */
-    public function testRollbackToDateByExecutionTime($availableRollbacks, $date, $expectedOutput)
+    #[DataProvider('rollbackToDateByExecutionTimeDataProvider')] public function testRollbackToDateByExecutionTime($availableRollbacks, $date, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)
@@ -920,10 +910,8 @@ class ManagerTest extends TestCase
 
     /**
      * Test that rollbacking last migration
-     *
-     * @dataProvider rollbackLastDataProvider
      */
-    public function testRollbackLast(array $availableRolbacks, string $versionOrder, string $expectedOutput): void
+    #[DataProvider('rollbackLastDataProvider')] public function testRollbackLast(array $availableRolbacks, string $versionOrder, string $expectedOutput): void
     {
         // stub environment
         $envStub = $this->getMockBuilder(Environment::class)

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -22,6 +22,7 @@ use Exception;
 use InvalidArgumentException;
 use Migrations\Migrations;
 use Phinx\Db\Adapter\WrapperInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use function Cake\Core\env;
 
 /**
@@ -130,10 +131,9 @@ class MigrationsTest extends TestCase
     /**
      * Tests the status method
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testStatus(string $backend)
+    #[DataProvider('backendProvider')] public function testStatus(string $backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -166,10 +166,9 @@ class MigrationsTest extends TestCase
     /**
      * Tests the migrations and rollbacks
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testMigrateAndRollback($backend)
+    #[DataProvider('backendProvider')] public function testMigrateAndRollback($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -255,10 +254,9 @@ class MigrationsTest extends TestCase
     /**
      * Tests the collation table behavior when using MySQL
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testCreateWithEncoding($backend)
+    #[DataProvider('backendProvider')] public function testCreateWithEncoding($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -284,10 +282,9 @@ class MigrationsTest extends TestCase
      * Tests calling Migrations::markMigrated without params marks everything
      * as migrated
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedAll($backend)
+    #[DataProvider('backendProvider')] public function testMarkMigratedAll($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -324,10 +321,9 @@ class MigrationsTest extends TestCase
      * string 'all' marks everything
      * as migrated
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedAllAsVersion($backend)
+    #[DataProvider('backendProvider')] public function testMarkMigratedAllAsVersion($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -363,10 +359,9 @@ class MigrationsTest extends TestCase
      * Tests calling Migrations::markMigrated with the target option will mark
      * only up to that one
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedTarget($backend)
+    #[DataProvider('backendProvider')] public function testMarkMigratedTarget($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -408,10 +403,9 @@ class MigrationsTest extends TestCase
      * Tests calling Migrations::markMigrated with the target option set to a
      * non-existent target will throw an exception
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedTargetError($backend)
+    #[DataProvider('backendProvider')] public function testMarkMigratedTargetError($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -424,10 +418,9 @@ class MigrationsTest extends TestCase
      * Tests calling Migrations::markMigrated with the target option with the exclude
      * option will mark only up to that one, excluding it
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedTargetExclude($backend)
+    #[DataProvider('backendProvider')] public function testMarkMigratedTargetExclude($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -469,10 +462,9 @@ class MigrationsTest extends TestCase
      * Tests calling Migrations::markMigrated with the target option with the only
      * option will mark only that specific migrations
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedTargetOnly($backend)
+    #[DataProvider('backendProvider')] public function testMarkMigratedTargetOnly($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -514,10 +506,9 @@ class MigrationsTest extends TestCase
      * Tests calling Migrations::markMigrated with the target option, the only option
      * and the exclude option will throw an exception
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedTargetExcludeOnly($backend)
+    #[DataProvider('backendProvider')] public function testMarkMigratedTargetExcludeOnly($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -530,10 +521,9 @@ class MigrationsTest extends TestCase
      * Tests calling Migrations::markMigrated with the target option with the exclude
      * option will mark only up to that one, excluding it
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testMarkMigratedVersion($backend)
+    #[DataProvider('backendProvider')] public function testMarkMigratedVersion($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -575,10 +565,9 @@ class MigrationsTest extends TestCase
      * Tests that calling the migrations methods while passing
      * parameters will override the default ones
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testOverrideOptions($backend)
+    #[DataProvider('backendProvider')] public function testOverrideOptions($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -646,10 +635,9 @@ class MigrationsTest extends TestCase
      * Tests that calling the migrations methods while passing the ``date``
      * parameter works as expected
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testMigrateDateOption($backend)
+    #[DataProvider('backendProvider')] public function testMigrateDateOption($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -825,10 +813,9 @@ class MigrationsTest extends TestCase
     /**
      * Tests seeding the database
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testSeed($backend)
+    #[DataProvider('backendProvider')] public function testSeed($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -904,10 +891,9 @@ class MigrationsTest extends TestCase
     /**
      * Tests seeding the database with seeder
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testSeedOneSeeder($backend)
+    #[DataProvider('backendProvider')] public function testSeedOneSeeder($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -956,10 +942,9 @@ class MigrationsTest extends TestCase
     /**
      * Tests seeding the database with seeder
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testSeedCallSeeder($backend)
+    #[DataProvider('backendProvider')] public function testSeedCallSeeder($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -1020,10 +1005,9 @@ class MigrationsTest extends TestCase
     /**
      * Tests that requesting a unexistant seed throws an exception
      *
-     * @dataProvider backendProvider
      * @return void
      */
-    public function testSeedWrongSeed($backend)
+    #[DataProvider('backendProvider')] public function testSeedWrongSeed($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -1035,13 +1019,12 @@ class MigrationsTest extends TestCase
     /**
      * Tests migrating the baked snapshots with builtin backend
      *
-     * @dataProvider snapshotMigrationsProvider
      * @param string $basePath Snapshot file path
      * @param string $filename Snapshot file name
      * @param array $flags Feature flags
      * @return void
      */
-    public function testMigrateSnapshotsBuiltin(string $basePath, string $filename, array $flags = []): void
+    #[DataProvider('snapshotMigrationsProvider')] public function testMigrateSnapshotsBuiltin(string $basePath, string $filename, array $flags = []): void
     {
         Configure::write('Migrations.backend', 'builtin');
         $this->runMigrateSnapshots($basePath, $filename, $flags);
@@ -1050,13 +1033,12 @@ class MigrationsTest extends TestCase
     /**
      * Tests migrating the baked snapshots
      *
-     * @dataProvider snapshotMigrationsProvider
      * @param string $basePath Snapshot file path
      * @param string $filename Snapshot file name
      * @param array $flags Feature flags
      * @return void
      */
-    public function testMigrateSnapshotsPhinx(string $basePath, string $filename, array $flags = []): void
+    #[DataProvider('snapshotMigrationsProvider')] public function testMigrateSnapshotsPhinx(string $basePath, string $filename, array $flags = []): void
     {
         $this->runMigrateSnapshots($basePath, $filename, $flags);
     }
@@ -1108,10 +1090,8 @@ class MigrationsTest extends TestCase
 
     /**
      * Tests that migrating in case of error throws an exception
-     *
-     * @dataProvider backendProvider
      */
-    public function testMigrateErrors($backend)
+    #[DataProvider('backendProvider')] public function testMigrateErrors($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -1122,10 +1102,8 @@ class MigrationsTest extends TestCase
 
     /**
      * Tests that rolling back in case of error throws an exception
-     *
-     * @dataProvider backendProvider
      */
-    public function testRollbackErrors($backend)
+    #[DataProvider('backendProvider')] public function testRollbackErrors($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -1137,10 +1115,8 @@ class MigrationsTest extends TestCase
     /**
      * Tests that marking migrated a non-existant migrations returns an error
      * and can return a error message
-     *
-     * @dataProvider backendProvider
      */
-    public function testMarkMigratedErrors($backend)
+    #[DataProvider('backendProvider')] public function testMarkMigratedErrors($backend)
     {
         Configure::write('Migrations.backend', $backend);
 

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -133,7 +133,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testStatus(string $backend)
+    #[DataProvider('backendProvider')]
+    public function testStatus(string $backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -168,7 +169,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testMigrateAndRollback($backend)
+    #[DataProvider('backendProvider')]
+    public function testMigrateAndRollback($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -256,7 +258,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testCreateWithEncoding($backend)
+    #[DataProvider('backendProvider')]
+    public function testCreateWithEncoding($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -284,7 +287,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testMarkMigratedAll($backend)
+    #[DataProvider('backendProvider')]
+    public function testMarkMigratedAll($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -323,7 +327,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testMarkMigratedAllAsVersion($backend)
+    #[DataProvider('backendProvider')]
+    public function testMarkMigratedAllAsVersion($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -361,7 +366,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testMarkMigratedTarget($backend)
+    #[DataProvider('backendProvider')]
+    public function testMarkMigratedTarget($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -405,7 +411,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testMarkMigratedTargetError($backend)
+    #[DataProvider('backendProvider')]
+    public function testMarkMigratedTargetError($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -420,7 +427,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testMarkMigratedTargetExclude($backend)
+    #[DataProvider('backendProvider')]
+    public function testMarkMigratedTargetExclude($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -464,7 +472,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testMarkMigratedTargetOnly($backend)
+    #[DataProvider('backendProvider')]
+    public function testMarkMigratedTargetOnly($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -508,7 +517,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testMarkMigratedTargetExcludeOnly($backend)
+    #[DataProvider('backendProvider')]
+    public function testMarkMigratedTargetExcludeOnly($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -523,7 +533,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testMarkMigratedVersion($backend)
+    #[DataProvider('backendProvider')]
+    public function testMarkMigratedVersion($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -567,7 +578,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testOverrideOptions($backend)
+    #[DataProvider('backendProvider')]
+    public function testOverrideOptions($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -637,7 +649,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testMigrateDateOption($backend)
+    #[DataProvider('backendProvider')]
+    public function testMigrateDateOption($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -815,7 +828,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testSeed($backend)
+    #[DataProvider('backendProvider')]
+    public function testSeed($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -893,7 +907,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testSeedOneSeeder($backend)
+    #[DataProvider('backendProvider')]
+    public function testSeedOneSeeder($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -944,7 +959,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testSeedCallSeeder($backend)
+    #[DataProvider('backendProvider')]
+    public function testSeedCallSeeder($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -1007,7 +1023,8 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
-    #[DataProvider('backendProvider')] public function testSeedWrongSeed($backend)
+    #[DataProvider('backendProvider')]
+    public function testSeedWrongSeed($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -1024,7 +1041,8 @@ class MigrationsTest extends TestCase
      * @param array $flags Feature flags
      * @return void
      */
-    #[DataProvider('snapshotMigrationsProvider')] public function testMigrateSnapshotsBuiltin(string $basePath, string $filename, array $flags = []): void
+    #[DataProvider('snapshotMigrationsProvider')]
+    public function testMigrateSnapshotsBuiltin(string $basePath, string $filename, array $flags = []): void
     {
         Configure::write('Migrations.backend', 'builtin');
         $this->runMigrateSnapshots($basePath, $filename, $flags);
@@ -1038,7 +1056,8 @@ class MigrationsTest extends TestCase
      * @param array $flags Feature flags
      * @return void
      */
-    #[DataProvider('snapshotMigrationsProvider')] public function testMigrateSnapshotsPhinx(string $basePath, string $filename, array $flags = []): void
+    #[DataProvider('snapshotMigrationsProvider')]
+    public function testMigrateSnapshotsPhinx(string $basePath, string $filename, array $flags = []): void
     {
         $this->runMigrateSnapshots($basePath, $filename, $flags);
     }
@@ -1091,7 +1110,8 @@ class MigrationsTest extends TestCase
     /**
      * Tests that migrating in case of error throws an exception
      */
-    #[DataProvider('backendProvider')] public function testMigrateErrors($backend)
+    #[DataProvider('backendProvider')]
+    public function testMigrateErrors($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -1103,7 +1123,8 @@ class MigrationsTest extends TestCase
     /**
      * Tests that rolling back in case of error throws an exception
      */
-    #[DataProvider('backendProvider')] public function testRollbackErrors($backend)
+    #[DataProvider('backendProvider')]
+    public function testRollbackErrors($backend)
     {
         Configure::write('Migrations.backend', $backend);
 
@@ -1116,7 +1137,8 @@ class MigrationsTest extends TestCase
      * Tests that marking migrated a non-existant migrations returns an error
      * and can return a error message
      */
-    #[DataProvider('backendProvider')] public function testMarkMigratedErrors($backend)
+    #[DataProvider('backendProvider')]
+    public function testMarkMigratedErrors($backend)
     {
         Configure::write('Migrations.backend', $backend);
 

--- a/tests/TestCase/TestSuite/MigratorTest.php
+++ b/tests/TestCase/TestSuite/MigratorTest.php
@@ -19,6 +19,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\ConnectionHelper;
 use Cake\TestSuite\TestCase;
 use Migrations\TestSuite\Migrator;
+use PHPUnit\Framework\Attributes\Depends;
 use RuntimeException;
 
 class MigratorTest extends TestCase
@@ -139,9 +140,7 @@ class MigratorTest extends TestCase
         }
     }
 
-    /**
-     * @depends testMigrateDropNoTruncate
-     */
+    #[Depends('testMigrateDropNoTruncate')]
     public function testTruncateAfterMigrations(): void
     {
         $this->testMigrateDropNoTruncate();

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -18,8 +18,6 @@ use Migrations\Util\ColumnParser;
 
 /**
  * Tests the ColumnParser
- *
- * @covers \Migrations\Util\ColumnParser
  */
 class ColumnParserTest extends TestCase
 {
@@ -39,9 +37,6 @@ class ColumnParserTest extends TestCase
         $this->columnParser = new ColumnParser();
     }
 
-    /**
-     * @covers \Migrations\Util\ColumnParser::parseFields()
-     */
     public function testParseFields()
     {
         $this->assertEquals([
@@ -232,9 +227,6 @@ class ColumnParserTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @covers \Migrations\Util\ColumnParser::parseIndexes()
-     */
     public function testParseIndexes()
     {
         $this->assertEquals(['UNIQUE_ID' => [
@@ -255,9 +247,6 @@ class ColumnParserTest extends TestCase
         ]));
     }
 
-    /**
-     * @covers \Migrations\Util\ColumnParser::parsePrimaryKey()
-     */
     public function testParsePrimaryKey()
     {
         $this->assertEquals(['id'], $this->columnParser->parsePrimaryKey(['id:primary']));
@@ -269,9 +258,6 @@ class ColumnParserTest extends TestCase
         );
     }
 
-    /**
-     * @covers \Migrations\Util\ColumnParser::validArguments()
-     */
     public function testValidArguments()
     {
         $this->assertEquals(
@@ -324,9 +310,6 @@ class ColumnParserTest extends TestCase
         );
     }
 
-    /**
-     * @covers \Migrations\Util\ColumnParser::getType()
-     */
     public function testGetType()
     {
         $this->assertSame('integer', $this->columnParser->getType('id', null));
@@ -349,9 +332,6 @@ class ColumnParserTest extends TestCase
         $this->assertSame('decimal', $this->columnParser->getType('longitude', null));
     }
 
-    /**
-     * @covers \Migrations\Util\ColumnParser::getTypeAndLength()
-     */
     public function testGetTypeAndLength()
     {
         $this->assertEquals(['string', 255], $this->columnParser->getTypeAndLength('name', 'string'));
@@ -366,9 +346,6 @@ class ColumnParserTest extends TestCase
         $this->assertEquals(['decimal', [10, 6]], $this->columnParser->getTypeAndLength('latitude', 'decimal[10,6]'));
     }
 
-    /**
-     * @covers \Migrations\Util\ColumnParser::getLength()
-     */
     public function testGetLength()
     {
         $this->assertSame(255, $this->columnParser->getLength('string'));
@@ -378,9 +355,6 @@ class ColumnParserTest extends TestCase
         $this->assertNull($this->columnParser->getLength('text'));
     }
 
-    /**
-     * @covers \Migrations\Util\ColumnParser::getIndexName()
-     */
     public function testGetIndexName()
     {
         $this->assertSame('SOME_INDEX', $this->columnParser->getIndexName('id', null, 'SOME_INDEX', true));

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -134,9 +134,6 @@ class MigrationHelperTest extends TestCase
         unset($this->helper, $this->view, $this->collection, $this->connection);
     }
 
-    /**
-     * @covers \Migrations\View\Helper\MigrationHelper::tableMethod()
-     */
     public function testTableMethod()
     {
         $this->assertSame('drop', $this->helper->tableMethod('drop_table'));
@@ -144,9 +141,6 @@ class MigrationHelperTest extends TestCase
         $this->assertSame('update', $this->helper->tableMethod('other_method'));
     }
 
-    /**
-     * @covers \Migrations\View\Helper\MigrationHelper::indexMethod()
-     */
     public function testIndexMethod()
     {
         $this->assertSame('removeIndex', $this->helper->indexMethod('drop_field'));
@@ -154,9 +148,6 @@ class MigrationHelperTest extends TestCase
         $this->assertSame('addIndex', $this->helper->indexMethod('alter_field'));
     }
 
-    /**
-     * @covers \Migrations\View\Helper\MigrationHelper::columnMethod()
-     */
     public function testColumnMethod()
     {
         $this->assertSame('removeColumn', $this->helper->columnMethod('drop_field'));
@@ -164,9 +155,6 @@ class MigrationHelperTest extends TestCase
         $this->assertSame('changeColumn', $this->helper->columnMethod('alter_field'));
     }
 
-    /**
-     * @covers \Migrations\View\Helper\MigrationHelper::columns()
-     */
     public function testColumns()
     {
         $extra = [];
@@ -217,9 +205,6 @@ class MigrationHelperTest extends TestCase
         ], $this->helper->columns('users'));
     }
 
-    /**
-     * @covers \Migrations\View\Helper\MigrationHelper::column()
-     */
     public function testColumn()
     {
         $tableSchema = $this->collection->describe('users');
@@ -291,9 +276,6 @@ class MigrationHelperTest extends TestCase
         ], $this->helper->column($tableSchema, 'updated'));
     }
 
-    /**
-     * @covers \Migrations\View\Helper\MigrationHelper::value()
-     */
     public function testValue()
     {
         $this->assertSame('null', $this->helper->value(null));
@@ -314,9 +296,6 @@ class MigrationHelperTest extends TestCase
         $this->assertSame("'o\\\"ne'", $this->helper->value('o"ne'));
     }
 
-    /**
-     * @covers \Migrations\View\Helper\MigrationHelper::attributes()
-     */
     public function testAttributes()
     {
         $attributes = [
@@ -389,9 +368,6 @@ class MigrationHelperTest extends TestCase
         $this->assertEquals($attributes, $result);
     }
 
-    /**
-     * @covers \Migrations\View\Helper\MigrationHelper::stringifyList()
-     */
     public function testStringifyList()
     {
         $this->assertSame('', $this->helper->stringifyList([]));


### PR DESCRIPTION
This is a huge PR, so i tried to split things up via the commits:

Part 1: Fix PHPUnit Deprecations and convert mock classes to anonymous classes
Part 2: Fix small Migration specific deprecations 
Part 3: Transform DataProviders and remove all `Covers` annotations
Part 4: Fix `Depends` annotations

I also noticed, that our CS fixer doesn't care / automatically fix annotations if they are written like this so this is something for our CS-Fixer
```
#[DataProvider('defaultsCastAsExpressions')] public function testDefaultsCastAsExpressionsForCertainTypes
```