### PR TITLE
Make builtin the default migrations backend

### DIFF
--- a/src/Command/EntryCommand.php
+++ b/src/Command/EntryCommand.php
@@ -83,7 +83,7 @@ class EntryCommand extends Command implements CommandCollectionAwareInterface
 
         // This is the variance from Command::run()
         if (!$args->getArgumentAt(0) && $args->getOption('help')) {
-            $backend = Configure::read('Migrations.backend', 'phinx');
+            $backend = Configure::read('Migrations.backend', 'builtin');
             $io->out([
                 '<info>Migrations</info>',
                 '',

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -80,6 +80,7 @@ class MigrateCommand extends Command
             'help' => "Mark any migrations selected as run, but don't actually execute them",
             'boolean' => true,
         ])->addOption('dry-run', [
+            'short' => 'x',
             'help' => 'Dump queries to stdout instead of executing them',
             'boolean' => true,
         ])->addOption('no-lock', [

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -133,7 +133,7 @@ class Migrations
      */
     protected function getBackend(): BuiltinBackend|PhinxBackend
     {
-        $backend = (string)(Configure::read('Migrations.backend') ?? 'phinx');
+        $backend = (string)(Configure::read('Migrations.backend') ?? 'builtin');
         if ($backend === 'builtin') {
             return new BuiltinBackend($this->default);
         }

--- a/src/MigrationsPlugin.php
+++ b/src/MigrationsPlugin.php
@@ -83,7 +83,7 @@ class MigrationsPlugin extends BasePlugin
         parent::bootstrap($app);
 
         if (!Configure::check('Migrations.backend')) {
-            Configure::write('Migrations.backend', 'phinx');
+            Configure::write('Migrations.backend', 'builtin');
         }
     }
 

--- a/tests/TestCase/Command/CompletionTest.php
+++ b/tests/TestCase/Command/CompletionTest.php
@@ -44,31 +44,10 @@ class CompletionTest extends TestCase
     {
         $this->exec('completion subcommands migrations.migrations');
         $expected = [
-            'dump mark_migrated migrate orm-cache-build orm-cache-clear create rollback seed status',
+            'dump mark_migrated migrate rollback seed status',
         ];
         $actual = $this->_out->messages();
         $this->assertEquals($expected, $actual);
-    }
-
-    /**
-     * Test that subcommands from the Migrations shell are correctly returned
-     * if needed with the autocompletion feature
-     *
-     * @return void
-     */
-    public function testMigrationsOptionsCreate()
-    {
-        $this->exec('completion options migrations.migrations create');
-        $this->assertCount(1, $this->_out->messages());
-        $output = $this->_out->messages()[0];
-        $expected = '--class -l --connection -c --help -h --path --plugin -p --quiet';
-        $expected .= ' -q --source -s --template -t --verbose -v';
-        $outputExplode = explode(' ', trim($output));
-        sort($outputExplode);
-        $expectedExplode = explode(' ', $expected);
-        sort($expectedExplode);
-
-        $this->assertEquals($outputExplode, $expectedExplode);
     }
 
     /**


### PR DESCRIPTION
The 4.3 branch has been out for a few months and there haven't been any showstopping bugs reported yet. Changing the default backend to builtin and retaining the phinx backend as an escape hatch until a fix can be released seems like a decent compromise on moving forwards and retaining compatibility.