### PR TITLE
Disable foreign key checks when removing temp tables

### DIFF
--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1046,13 +1046,14 @@ PCRE_PATTERN;
                 $state['selectColumns']
             );
 
-            $foreignKeysEnabled = (bool)$this->fetchRow('PRAGMA foreign_keys')['foreign_keys'] ?? false;
+            $result = $this->fetchRow('PRAGMA foreign_keys');
+            $foreignKeysEnabled = $result ? (bool)$result['foreign_keys'] : false;
             if ($foreignKeysEnabled) {
-                // $this->execute('PRAGMA foreign_keys = OFF');
+                $this->execute('PRAGMA foreign_keys = OFF');
             }
             $this->execute(sprintf('DROP TABLE %s', $this->quoteTableName($tableName)));
             if ($foreignKeysEnabled) {
-                // $this->execute('PRAGMA foreign_keys = ON');
+                $this->execute('PRAGMA foreign_keys = ON');
             }
             $this->execute(sprintf(
                 'ALTER TABLE %s RENAME TO %s',

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1046,7 +1046,14 @@ PCRE_PATTERN;
                 $state['selectColumns']
             );
 
+            $foreignKeysEnabled = (bool)$this->fetchRow('PRAGMA foreign_keys')['foreign_keys'] ?? false;
+            if ($foreignKeysEnabled) {
+                // $this->execute('PRAGMA foreign_keys = OFF');
+            }
             $this->execute(sprintf('DROP TABLE %s', $this->quoteTableName($tableName)));
+            if ($foreignKeysEnabled) {
+                // $this->execute('PRAGMA foreign_keys = ON');
+            }
             $this->execute(sprintf(
                 'ALTER TABLE %s RENAME TO %s',
                 $this->quoteTableName($state['tmpTableName']),

--- a/src/Db/Table/Table.php
+++ b/src/Db/Table/Table.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 
 /**
  * @internal
+ * @TODO rename this to `TableMetadata` having two classes with very similar names is confusing for me.
  */
 class Table
 {


### PR DESCRIPTION
Attempt to reproduce the problem reported in #741 but added a test that covers the scenario based on current information. Perhaps the problem can be reproduced in CI. There is also a chance that the test suite harness makes this challenging to reproduce because of wrapping transactions.