### PR TITLE
Add hook method for migrations to skip creating a transaction

### DIFF
--- a/src/AbstractMigration.php
+++ b/src/AbstractMigration.php
@@ -30,6 +30,19 @@ class AbstractMigration extends BaseAbstractMigration
     public bool $autoId = true;
 
     /**
+     * Hook method to decide if this migration should use transactions
+     *
+     * By default if your driver supports transactions, a transaction will be opened
+     * before the migration begins, and commit when the migration completes.
+     *
+     * @return bool
+     */
+    public function useTransactions(): bool
+    {
+        return $this->getAdapter()->hasTransactions();
+    }
+
+    /**
      * Returns an instance of the Table class.
      *
      * You can use this class to create and manipulate tables.

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1046,15 +1046,7 @@ PCRE_PATTERN;
                 $state['selectColumns']
             );
 
-            $result = $this->fetchRow('PRAGMA foreign_keys');
-            $foreignKeysEnabled = $result ? (bool)$result['foreign_keys'] : false;
-            if ($foreignKeysEnabled) {
-                $this->execute('PRAGMA foreign_keys = OFF');
-            }
             $this->execute(sprintf('DROP TABLE %s', $this->quoteTableName($tableName)));
-            if ($foreignKeysEnabled) {
-                $this->execute('PRAGMA foreign_keys = ON');
-            }
             $this->execute(sprintf(
                 'ALTER TABLE %s RENAME TO %s',
                 $this->quoteTableName($state['tmpTableName']),

--- a/src/Migration/Environment.php
+++ b/src/Migration/Environment.php
@@ -85,8 +85,12 @@ class Environment
             $migration->{MigrationInterface::INIT}();
         }
 
+        $atomic = $adapter->hasTransactions();
+        if (method_exists($migration, 'useTransactions')) {
+            $atomic = $migration->useTransactions();
+        }
         // begin the transaction if the adapter supports it
-        if ($adapter->hasTransactions()) {
+        if ($atomic) {
             $adapter->beginTransaction();
         }
 
@@ -121,7 +125,7 @@ class Environment
         $adapter->migrated($migration, $direction, date('Y-m-d H:i:s', $startTime), date('Y-m-d H:i:s', time()));
 
         // commit the transaction if the adapter supports it
-        if ($adapter->hasTransactions()) {
+        if ($atomic) {
             $adapter->commitTransaction();
         }
 
@@ -143,9 +147,9 @@ class Environment
         if (method_exists($seed, SeedInterface::INIT)) {
             $seed->{SeedInterface::INIT}();
         }
-
         // begin the transaction if the adapter supports it
-        if ($adapter->hasTransactions()) {
+        $atomic = $adapter->hasTransactions();
+        if ($atomic) {
             $adapter->beginTransaction();
         }
 
@@ -155,7 +159,7 @@ class Environment
         }
 
         // commit the transaction if the adapter supports it
-        if ($adapter->hasTransactions()) {
+        if ($atomic) {
             $adapter->commitTransaction();
         }
     }

--- a/tests/TestCase/Migration/EnvironmentTest.php
+++ b/tests/TestCase/Migration/EnvironmentTest.php
@@ -210,10 +210,12 @@ class EnvironmentTest extends TestCase
         // migrate
         $migration = new class ('mockenv', 20110301080000) extends AbstractMigration {
             public bool $executed = false;
+
             public function useTransactions(): bool
             {
                 return false;
             }
+
             public function up(): void
             {
                 $this->executed = true;


### PR DESCRIPTION
There are schema operations that you don't want a wrapping transaction, like if you're modifying a sqlite database. This new method allows migrations to opt-out of having a transaction wrapped around each migration automatically.

Refs #741