### PR TITLE
4.next - Revise the migrations interfaces

### DIFF
--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -853,13 +853,17 @@ class Manager
                     $io->verbose("Constructing <info>$class</info>.");
 
                     $config = $this->getConfig();
+                    // TODO Subset config and pass forward.
+                    // Move this to the Migration/phinx shim
                     $input = new ArrayInput([
                         '--plugin' => $config['plugin'] ?? null,
                         '--source' => $config['source'] ?? null,
                         '--connection' => $config->getConnection(),
                     ]);
+                    // TODO move this to the migration/phinx shim
                     $output = new OutputAdapter($io);
 
+                    // TODO constructor should take $io and $config
                     // instantiate it
                     $migration = new $class('default', $version, $input, $output);
 
@@ -967,16 +971,20 @@ class Manager
             $seeds = [];
 
             $config = $this->getConfig();
+            // TODO Subset config and pass forward.
+            // TODO move this to the migration/phinx shim
             $optionDef = new InputDefinition([
                 new InputOption('plugin', mode: InputOption::VALUE_OPTIONAL, default: ''),
                 new InputOption('connection', mode: InputOption::VALUE_OPTIONAL, default: ''),
                 new InputOption('source', mode: InputOption::VALUE_OPTIONAL, default: ''),
             ]);
+            // TODO move this to the migration/phinx shim
             $input = new ArrayInput([
                 '--plugin' => $config['plugin'] ?? null,
                 '--source' => $config['source'] ?? null,
                 '--connection' => $config->getConnection(),
             ], $optionDef);
+            // TODO move this to the migration/phinx shim
             $output = new OutputAdapter($this->io);
 
             foreach ($phpFiles as $filePath) {
@@ -1003,6 +1011,7 @@ class Manager
                     } else {
                         $seed = new $class();
                     }
+                    // TODO Replace with with setIo and setConfig
                     $seed->setEnvironment('default');
                     $seed->setInput($input);
                     $seed->setOutput($output);
@@ -1027,6 +1036,7 @@ class Manager
             return [];
         }
 
+        // TODO remove this
         foreach ($this->seeds as $instance) {
             if (isset($input) && $instance instanceof AbstractSeed) {
                 $instance->setInput($input);

--- a/src/MigrationInterface.php
+++ b/src/MigrationInterface.php
@@ -8,11 +8,13 @@ declare(strict_types=1);
 
 namespace Migrations;
 
+use Cake\Console\ConsoleIo;
 use Cake\Database\Query;
 use Cake\Database\Query\DeleteQuery;
 use Cake\Database\Query\InsertQuery;
 use Cake\Database\Query\SelectQuery;
 use Cake\Database\Query\UpdateQuery;
+use Migrations\Config\ConfigInterface;
 use Migrations\Db\Adapter\AdapterInterface;
 use Migrations\Db\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -61,32 +63,52 @@ interface MigrationInterface
     public function getAdapter(): ?AdapterInterface;
 
     /**
-     * Sets the input object to be used in migration object
+     * Set the Console IO object to be used.
      *
-     * @param \Symfony\Component\Console\Input\InputInterface $input Input
+     * @param \Cake\Console\ConsoleIo $io The Io
      * @return $this
      */
-    public function setInput(InputInterface $input);
+    public function setIo(ConsoleIo $io);
+
+    /**
+     * Get the Console IO object to be used.
+     *
+     * @return \Cake\Console\ConsoleIo|null
+     */
+    public function getIo(): ?ConsoleIo;
+
+    /**
+     * Gets the config.
+     *
+     * @return \Migrations\Config\ConfigInterface
+     */
+    public function getConfig(): ConfigInterface;
+
+    /**
+     * Sets the config.
+     *
+     * @param \Migrations\Config\ConfigInterface $config Configuration Object
+     * @return $this
+     */
+    public function setConfig(ConfigInterface $config);
 
     /**
      * Gets the input object to be used in migration object
      *
+     * A new InputInterface will be generated each time `getOutput` is called.
+     *
      * @return \Symfony\Component\Console\Input\InputInterface|null
+     * @deprecated 4.5.0 Use getIo() instead.
      */
     public function getInput(): ?InputInterface;
 
     /**
-     * Sets the output object to be used in migration object
-     *
-     * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     * @return $this
-     */
-    public function setOutput(OutputInterface $output);
-
-    /**
      * Gets the output object to be used in migration object
      *
+     * A new OutputInterface will be generated each time `getOutput` is called.
+     *
      * @return \Symfony\Component\Console\Output\OutputInterface|null
+     * @deprecated 4.5.0 Use getIo() instead.
      */
     public function getOutput(): ?OutputInterface;
 
@@ -96,13 +118,6 @@ interface MigrationInterface
      * @return string
      */
     public function getName(): string;
-
-    /**
-     * Gets the detected environment
-     *
-     * @return string
-     */
-    public function getEnvironment(): string;
 
     /**
      * Sets the migration version number.

--- a/src/SeedInterface.php
+++ b/src/SeedInterface.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Migrations;
 
+use Cake\Console\ConsoleIo;
+use Migrations\Config\ConfigInterface;
 use Migrations\Db\Adapter\AdapterInterface;
 use Migrations\Db\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -45,20 +47,6 @@ interface SeedInterface
     public function getDependencies(): array;
 
     /**
-     * Sets the environment.
-     *
-     * @return $this
-     */
-    public function setEnvironment(string $environment);
-
-    /**
-     * Gets the environment.
-     *
-     * @return string
-     */
-    public function getEnvironment(): string;
-
-    /**
      * Sets the database adapter.
      *
      * @param \Migrations\Db\Adapter\AdapterInterface $adapter Database Adapter
@@ -74,32 +62,52 @@ interface SeedInterface
     public function getAdapter(): AdapterInterface;
 
     /**
-     * Sets the input object to be used in migration object
+     * Set the Console IO object to be used.
      *
-     * @param \Symfony\Component\Console\Input\InputInterface $input Input
+     * @param \Cake\Console\ConsoleIo $io The Io
      * @return $this
      */
-    public function setInput(InputInterface $input);
+    public function setIo(ConsoleIo $io);
+
+    /**
+     * Get the Console IO object to be used.
+     *
+     * @return \Cake\Console\ConsoleIo|null
+     */
+    public function getIo(): ?ConsoleIo;
+
+    /**
+     * Gets the config.
+     *
+     * @return \Migrations\Config\ConfigInterface
+     */
+    public function getConfig(): ConfigInterface;
+
+    /**
+     * Sets the config.
+     *
+     * @param \Migrations\Config\ConfigInterface $config Configuration Object
+     * @return $this
+     */
+    public function setConfig(ConfigInterface $config);
 
     /**
      * Gets the input object to be used in migration object
      *
+     * A new InputInteface will be generated each time `getOutput` is called.
+     *
      * @return \Symfony\Component\Console\Input\InputInterface
+     * @deprecated 4.5.0 Use getIo() instead.
      */
     public function getInput(): InputInterface;
 
     /**
-     * Sets the output object to be used in migration object
-     *
-     * @param \Symfony\Component\Console\Output\OutputInterface $output Output
-     * @return $this
-     */
-    public function setOutput(OutputInterface $output);
-
-    /**
      * Gets the output object to be used in migration object
      *
+     * A new OutputInteface will be generated each time `getOutput` is called.
+     *
      * @return \Symfony\Component\Console\Output\OutputInterface
+     * @deprecated 4.5.0 Use getIo() instead.
      */
     public function getOutput(): OutputInterface;
 


### PR DESCRIPTION
- Add methods that will allow symfony support to be dropped in the next major
- Add better intergration with CakePHP abstractions.
- Put some TODOs in for the next set of changes.
