### PR TITLE
Migrations adapter

### DIFF
--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -18,7 +18,7 @@ use Cake\Database\Query\UpdateQuery;
 use Migrations\Db\Literal;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\Table;
-use Phinx\Migration\MigrationInterface;
+use Migrations\MigrationInterface;
 
 /**
  * Adapter Interface.
@@ -138,7 +138,7 @@ interface AdapterInterface
     /**
      * Records a migration being run.
      *
-     * @param \Phinx\Migration\MigrationInterface $migration Migration
+     * @param \Migrations\MigrationInterface $migration Migration
      * @param string $direction Direction
      * @param string $startTime Start Time
      * @param string $endTime End Time
@@ -149,7 +149,7 @@ interface AdapterInterface
     /**
      * Toggle a migration breakpoint.
      *
-     * @param \Phinx\Migration\MigrationInterface $migration Migration
+     * @param \Migrations\MigrationInterface $migration Migration
      * @return $this
      */
     public function toggleBreakpoint(MigrationInterface $migration);
@@ -164,7 +164,7 @@ interface AdapterInterface
     /**
      * Set a migration breakpoint.
      *
-     * @param \Phinx\Migration\MigrationInterface $migration The migration target for the breakpoint set
+     * @param \Migrations\MigrationInterface $migration The migration target for the breakpoint set
      * @return $this
      */
     public function setBreakpoint(MigrationInterface $migration);
@@ -172,7 +172,7 @@ interface AdapterInterface
     /**
      * Unset a migration breakpoint.
      *
-     * @param \Phinx\Migration\MigrationInterface $migration The migration target for the breakpoint unset
+     * @param \Migrations\MigrationInterface $migration The migration target for the breakpoint unset
      * @return $this
      */
     public function unsetBreakpoint(MigrationInterface $migration);

--- a/src/Db/Adapter/AdapterWrapper.php
+++ b/src/Db/Adapter/AdapterWrapper.php
@@ -18,7 +18,7 @@ use Cake\Database\Query\UpdateQuery;
 use Migrations\Db\Literal;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\Table;
-use Phinx\Migration\MigrationInterface;
+use Migrations\MigrationInterface;
 
 /**
  * Adapter Wrapper.

--- a/src/Db/Adapter/PdoAdapter.php
+++ b/src/Db/Adapter/PdoAdapter.php
@@ -36,10 +36,10 @@ use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use Migrations\Db\Table\Table;
+use Migrations\MigrationInterface;
 use PDO;
 use PDOException;
 use Phinx\Config\Config;
-use Phinx\Migration\MigrationInterface;
 use Phinx\Util\Literal as PhinxLiteral;
 use ReflectionMethod;
 use RuntimeException;
@@ -570,7 +570,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * Mark a migration breakpoint.
      *
-     * @param \Phinx\Migration\MigrationInterface $migration The migration target for the breakpoint
+     * @param \Migrations\MigrationInterface $migration The migration target for the breakpoint
      * @param bool $state The required state of the breakpoint
      * @return \Migrations\Db\Adapter\AdapterInterface
      */

--- a/src/Db/Adapter/PhinxAdapter.php
+++ b/src/Db/Adapter/PhinxAdapter.php
@@ -33,6 +33,7 @@ use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use Migrations\Db\Table\Table;
+use Migrations\Shim\MigrationAdapter;
 use Phinx\Db\Action\Action as PhinxAction;
 use Phinx\Db\Action\AddColumn as PhinxAddColumn;
 use Phinx\Db\Action\AddForeignKey as PhinxAddForeignKey;
@@ -52,7 +53,7 @@ use Phinx\Db\Table\Column as PhinxColumn;
 use Phinx\Db\Table\ForeignKey as PhinxForeignKey;
 use Phinx\Db\Table\Index as PhinxIndex;
 use Phinx\Db\Table\Table as PhinxTable;
-use Phinx\Migration\MigrationInterface;
+use Phinx\Migration\MigrationInterface as PhinxMigrationInterface;
 use Phinx\Util\Literal as PhinxLiteral;
 use RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
@@ -491,9 +492,10 @@ class PhinxAdapter implements PhinxAdapterInterface
     /**
      * @inheritDoc
      */
-    public function migrated(MigrationInterface $migration, string $direction, string $startTime, string $endTime): PhinxAdapterInterface
+    public function migrated(PhinxMigrationInterface $migration, string $direction, string $startTime, string $endTime): PhinxAdapterInterface
     {
-        $this->adapter->migrated($migration, $direction, $startTime, $endTime);
+        $wrapped = new MigrationAdapter($migration, $migration->getVersion());
+        $this->adapter->migrated($wrapped, $direction, $startTime, $endTime);
 
         return $this;
     }
@@ -501,9 +503,10 @@ class PhinxAdapter implements PhinxAdapterInterface
     /**
      * @inheritDoc
      */
-    public function toggleBreakpoint(MigrationInterface $migration): PhinxAdapterInterface
+    public function toggleBreakpoint(PhinxMigrationInterface $migration): PhinxAdapterInterface
     {
-        $this->adapter->toggleBreakpoint($migration);
+        $wrapped = new MigrationAdapter($migration, $migration->getVersion());
+        $this->adapter->toggleBreakpoint($wrapped);
 
         return $this;
     }
@@ -519,9 +522,10 @@ class PhinxAdapter implements PhinxAdapterInterface
     /**
      * @inheritDoc
      */
-    public function setBreakpoint(MigrationInterface $migration): PhinxAdapterInterface
+    public function setBreakpoint(PhinxMigrationInterface $migration): PhinxAdapterInterface
     {
-        $this->adapter->setBreakpoint($migration);
+        $wrapped = new MigrationAdapter($migration, $migration->getVersion());
+        $this->adapter->setBreakpoint($wrapped);
 
         return $this;
     }
@@ -529,9 +533,10 @@ class PhinxAdapter implements PhinxAdapterInterface
     /**
      * @inheritDoc
      */
-    public function unsetBreakpoint(MigrationInterface $migration): PhinxAdapterInterface
+    public function unsetBreakpoint(PhinxMigrationInterface $migration): PhinxAdapterInterface
     {
-        $this->adapter->unsetBreakpoint($migration);
+        $wrapped = new MigrationAdapter($migration, $migration->getVersion());
+        $this->adapter->unsetBreakpoint($wrapped);
 
         return $this;
     }

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -16,7 +16,7 @@ use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use Migrations\Db\Table\Table;
-use Phinx\Migration\MigrationInterface;
+use Migrations\MigrationInterface;
 
 /**
  * Migrations SqlServer Adapter.
@@ -1238,7 +1238,7 @@ SQL;
     /**
      * Records a migration being run.
      *
-     * @param \Phinx\Migration\MigrationInterface $migration Migration
+     * @param \Migrations\MigrationInterface $migration Migration
      * @param string $direction Direction
      * @param string $startTime Start Time
      * @param string $endTime End Time

--- a/src/Migration/Environment.php
+++ b/src/Migration/Environment.php
@@ -12,9 +12,8 @@ use Cake\Console\ConsoleIo;
 use Cake\Datasource\ConnectionManager;
 use Migrations\Db\Adapter\AdapterFactory;
 use Migrations\Db\Adapter\AdapterInterface;
-use Migrations\Db\Adapter\PhinxAdapter;
-use Migrations\SeedInterface;
 use Migrations\MigrationInterface;
+use Migrations\SeedInterface;
 use Migrations\Shim\MigrationAdapter;
 use RuntimeException;
 

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -46,7 +46,7 @@ class Manager
     protected ?Environment $environment;
 
     /**
-     * @var \Phinx\Migration\MigrationInterface[]|null
+     * @var \Migrations\MigrationInterface[]|null
      */
     protected ?array $migrations = null;
 
@@ -254,16 +254,16 @@ class Manager
         }
 
         $migrationFile = $migrationFile[0];
-        /** @var class-string<\Phinx\Migration\MigrationInterface> $className */
+        /** @var class-string<\Phinx\Migration\MigrationInterface|\Migrations\MigrationInterface> $className */
         $className = $this->getMigrationClassName($migrationFile);
         require_once $migrationFile;
 
-        /** @var \Migrations\MigrationInterface $migration */
         if (is_subclass_of($className, PhinxMigrationInterface::class)) {
             $migration = new MigrationAdapter($className, $version);
         } else {
             $migration = new $className($version);
         }
+        /** @var \Migrations\MigrationInterface $migration */
         $config = $this->getConfig();
         $migration->setConfig($config);
 
@@ -448,7 +448,7 @@ class Manager
     /**
      * Execute a migration against the specified environment.
      *
-     * @param \Phinx\Migration\MigrationInterface $migration Migration
+     * @param \Migrations\MigrationInterface $migration Migration
      * @param string $direction Direction
      * @param bool $fake flag that if true, we just record running the migration, but not actually do the migration
      * @return void
@@ -512,7 +512,7 @@ class Manager
     /**
      * Print Migration Status
      *
-     * @param \Phinx\Migration\MigrationInterface $migration Migration
+     * @param \Migrations\MigrationInterface $migration Migration
      * @param string $status Status of the migration
      * @param string|null $duration Duration the migration took the be executed
      * @return void
@@ -813,7 +813,7 @@ class Manager
 
             // filter the files to only get the ones that match our naming scheme
             $fileNames = [];
-            /** @var \Migration\MigrationInterface[] $versions */
+            /** @var \Migrations\MigrationInterface[] $versions */
             $versions = [];
 
             $io = $this->getIo();
@@ -857,12 +857,12 @@ class Manager
                     }
 
                     $io->verbose("Constructing <info>$class</info>.");
-                    /** @var \Migrations\MigrationInterface $migration */
                     if (is_subclass_of($class, PhinxMigrationInterface::class)) {
                         $migration = new MigrationAdapter($class, $version);
                     } else {
                         $migration = new $class($version);
                     }
+                    /** @var \Migrations\MigrationInterface $migration */
                     $config = $this->getConfig();
                     $migration->setConfig($config);
                     $migration->setIo($io);

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -257,11 +257,19 @@ class Manager
         /** @var class-string<\Phinx\Migration\MigrationInterface> $className */
         $className = $this->getMigrationClassName($migrationFile);
         require_once $migrationFile;
-        $Migration = new $className('default', $version);
+
+        /** @var \Migrations\MigrationInterface $migration */
+        if (is_subclass_of($className, PhinxMigrationInterface::class)) {
+            $migration = new MigrationAdapter($className, $version);
+        } else {
+            $migration = new $className($version);
+        }
+        $config = $this->getConfig();
+        $migration->setConfig($config);
 
         $time = date('Y-m-d H:i:s', time());
 
-        $adapter->migrated($Migration, 'up', $time, $time);
+        $adapter->migrated($migration, 'up', $time, $time);
 
         return true;
     }

--- a/src/MigrationInterface.php
+++ b/src/MigrationInterface.php
@@ -17,8 +17,6 @@ use Cake\Database\Query\UpdateQuery;
 use Migrations\Config\ConfigInterface;
 use Migrations\Db\Adapter\AdapterInterface;
 use Migrations\Db\Table;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Migration interface.

--- a/src/MigrationInterface.php
+++ b/src/MigrationInterface.php
@@ -80,9 +80,9 @@ interface MigrationInterface
     /**
      * Gets the config.
      *
-     * @return \Migrations\Config\ConfigInterface
+     * @return \Migrations\Config\ConfigInterface|null
      */
-    public function getConfig(): ConfigInterface;
+    public function getConfig(): ?ConfigInterface;
 
     /**
      * Sets the config.
@@ -91,26 +91,6 @@ interface MigrationInterface
      * @return $this
      */
     public function setConfig(ConfigInterface $config);
-
-    /**
-     * Gets the input object to be used in migration object
-     *
-     * A new InputInterface will be generated each time `getOutput` is called.
-     *
-     * @return \Symfony\Component\Console\Input\InputInterface|null
-     * @deprecated 4.5.0 Use getIo() instead.
-     */
-    public function getInput(): ?InputInterface;
-
-    /**
-     * Gets the output object to be used in migration object
-     *
-     * A new OutputInterface will be generated each time `getOutput` is called.
-     *
-     * @return \Symfony\Component\Console\Output\OutputInterface|null
-     * @deprecated 4.5.0 Use getIo() instead.
-     */
-    public function getOutput(): ?OutputInterface;
 
     /**
      * Gets the name.

--- a/src/Shim/MigrationAdapter.php
+++ b/src/Shim/MigrationAdapter.php
@@ -64,7 +64,6 @@ class MigrationAdapter implements MigrationInterface
      *
      * @param string|object $migrationClass The phinx migration to adapt
      * @param int $version The migration version
-     * @param \Cake\Console\ConsoleIo $io The io
      */
     public function __construct(
         string|object $migrationClass,

--- a/src/Shim/MigrationAdapter.php
+++ b/src/Shim/MigrationAdapter.php
@@ -1,0 +1,430 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Migrations\Shim;
+
+use Cake\Console\ConsoleIo;
+use Cake\Database\Query;
+use Cake\Database\Query\DeleteQuery;
+use Cake\Database\Query\InsertQuery;
+use Cake\Database\Query\SelectQuery;
+use Cake\Database\Query\UpdateQuery;
+use Migrations\Config\ConfigInterface;
+use Migrations\Db\Adapter\AdapterInterface;
+use Migrations\Db\Adapter\PhinxAdapter;
+use Migrations\Db\Table;
+use Migrations\MigrationInterface;
+use Phinx\Migration\MigrationInterface as PhinxMigrationInterface;
+use RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+
+/**
+ * Migration interface.
+ *
+ * Implements the same methods as phinx but with Migrations classes.
+ */
+class MigrationAdapter implements MigrationInterface
+{
+    /**
+     * A migrations adapter instance
+     *
+     * @var \Migrations\Db\Adapter\AdapterInterface|null
+     */
+    protected ?AdapterInterface $adapter = null;
+
+    /**
+     * A migrations configuration instance
+     *
+     * @var \Migrations\Config\ConfigInterface|null
+     */
+    protected ?ConfigInterface $config = null;
+
+    /**
+     * A ConsoleIo instance
+     *
+     * @var \Cake\Console\ConsoleIo|null
+     */
+    protected ?ConsoleIo $io = null;
+
+    /**
+     * The wrapped phinx Migration
+     *
+     * @var \Phinx\Migration\MigrationInterface
+     */
+    protected PhinxMigrationInterface $migration;
+
+    /**
+     * Constructor
+     *
+     * @param string|object $migrationClass The phinx migration to adapt
+     * @param int $version The migration version
+     * @param \Cake\Console\ConsoleIo $io The io
+     */
+    public function __construct(
+        string|object $migrationClass,
+        int $version,
+    ) {
+        if (is_string($migrationClass)) {
+            if (!is_subclass_of($migrationClass, PhinxMigrationInterface::class)) {
+                throw new RuntimeException(
+                    'The provided $migrationClass must be a ' .
+                    'subclass of Phinx\Migration\MigrationInterface'
+                );
+            }
+            $this->migration = new $migrationClass('default', $version);
+        } else {
+            if (!is_subclass_of($migrationClass, PhinxMigrationInterface::class)) {
+                throw new RuntimeException(
+                    'The provided $migrationClass must be a ' .
+                    'subclass of Phinx\Migration\MigrationInterface'
+                );
+            }
+            $this->migration = $migrationClass;
+        }
+    }
+
+    /**
+     * Because we're a compatibility shim, we implement this hook
+     * so that it can be conditionally called when it is implemented.
+     *
+     * @return void
+     */
+    public function init(): void
+    {
+        if (method_exists($this->migration, MigrationInterface::INIT)) {
+            $this->migration->{MigrationInterface::INIT}();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setAdapter(AdapterInterface $adapter)
+    {
+        $phinxAdapter = new PhinxAdapter($adapter);
+        $this->migration->setAdapter($phinxAdapter);
+        $this->adapter = $adapter;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAdapter(): AdapterInterface
+    {
+        if (!$this->adapter) {
+            throw new RuntimeException('Cannot call getAdapter() until after setAdapter().');
+        }
+
+        return $this->adapter;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setIo(ConsoleIo $io)
+    {
+        $this->io = $io;
+        $this->migration->setOutput(new OutputAdapter($io));
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIo(): ?ConsoleIo
+    {
+        return $this->io;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfig(): ?ConfigInterface
+    {
+        return $this->config;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setConfig(ConfigInterface $config)
+    {
+        $input = new ArrayInput([
+            '--plugin' => $config['plugin'] ?? null,
+            '--source' => $config['source'] ?? null,
+            '--connection' => $config->getConnection(),
+        ]);
+
+        $this->migration->setInput($input);
+        $this->config = $config;
+
+        return $this;
+    }
+
+    /**
+     * Gets the name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->migration->getName();
+    }
+
+    /**
+     * Sets the migration version number.
+     *
+     * @param int $version Version
+     * @return $this
+     */
+    public function setVersion(int $version)
+    {
+        $this->migration->setVersion($version);
+
+        return $this;
+    }
+
+    /**
+     * Gets the migration version number.
+     *
+     * @return int
+     */
+    public function getVersion(): int
+    {
+        return $this->migration->getVersion();
+    }
+
+    /**
+     * Sets whether this migration is being applied or reverted
+     *
+     * @param bool $isMigratingUp True if the migration is being applied
+     * @return $this
+     */
+    public function setMigratingUp(bool $isMigratingUp)
+    {
+        $this->migration->setMigratingUp($isMigratingUp);
+
+        return $this;
+    }
+
+    /**
+     * Gets whether this migration is being applied or reverted.
+     * True means that the migration is being applied.
+     *
+     * @return bool
+     */
+    public function isMigratingUp(): bool
+    {
+        return $this->migration->isMigratingUp();
+    }
+
+    /**
+     * Executes a SQL statement and returns the number of affected rows.
+     *
+     * @param string $sql SQL
+     * @param array $params parameters to use for prepared query
+     * @return int
+     */
+    public function execute(string $sql, array $params = []): int
+    {
+        return $this->migration->execute($sql, $params);
+    }
+
+    /**
+     * Executes a SQL statement.
+     *
+     * The return type depends on the underlying adapter being used. To improve
+     * IDE auto-completion possibility, you can overwrite the query method
+     * phpDoc in your (typically custom abstract parent) migration class, where
+     * you can set the return type by the adapter in your current use.
+     *
+     * @param string $sql SQL
+     * @param array $params parameters to use for prepared query
+     * @return mixed
+     */
+    public function query(string $sql, array $params = []): mixed
+    {
+        return $this->migration->query($sql, $params);
+    }
+
+    /**
+     * Returns a new Query object that can be used to build complex SELECT, UPDATE, INSERT or DELETE
+     * queries and execute them against the current database.
+     *
+     * Queries executed through the query builder are always sent to the database, regardless of the
+     * the dry-run settings.
+     *
+     * @see https://api.cakephp.org/3.6/class-Cake.Database.Query.html
+     * @param string $type Query
+     * @return \Cake\Database\Query
+     */
+    public function getQueryBuilder(string $type): Query
+    {
+        return $this->migration->getQueryBuilder($type);
+    }
+
+    /**
+     * Returns a new SelectQuery object that can be used to build complex
+     * SELECT queries and execute them against the current database.
+     *
+     * Queries executed through the query builder are always sent to the database, regardless of the
+     * the dry-run settings.
+     *
+     * @return \Cake\Database\Query\SelectQuery
+     */
+    public function getSelectBuilder(): SelectQuery
+    {
+        return $this->migration->getSelectBuilder();
+    }
+
+    /**
+     * Returns a new InsertQuery object that can be used to build complex
+     * INSERT queries and execute them against the current database.
+     *
+     * Queries executed through the query builder are always sent to the database, regardless of the
+     * the dry-run settings.
+     *
+     * @return \Cake\Database\Query\InsertQuery
+     */
+    public function getInsertBuilder(): InsertQuery
+    {
+        return $this->migration->getInsertBuilder();
+    }
+
+    /**
+     * Returns a new UpdateQuery object that can be used to build complex
+     * UPDATE queries and execute them against the current database.
+     *
+     * Queries executed through the query builder are always sent to the database, regardless of the
+     * the dry-run settings.
+     *
+     * @return \Cake\Database\Query\UpdateQuery
+     */
+    public function getUpdateBuilder(): UpdateQuery
+    {
+        return $this->migration->getUpdateBuilder();
+    }
+
+    /**
+     * Returns a new DeleteQuery object that can be used to build complex
+     * DELETE queries and execute them against the current database.
+     *
+     * Queries executed through the query builder are always sent to the database, regardless of the
+     * the dry-run settings.
+     *
+     * @return \Cake\Database\Query\DeleteQuery
+     */
+    public function getDeleteBuilder(): DeleteQuery
+    {
+        return $this->migration->getDeleteBuilder();
+    }
+
+    /**
+     * Executes a query and returns only one row as an array.
+     *
+     * @param string $sql SQL
+     * @return array|false
+     */
+    public function fetchRow(string $sql): array|false
+    {
+        return $this->migration->fetchRow($sql);
+    }
+
+    /**
+     * Executes a query and returns an array of rows.
+     *
+     * @param string $sql SQL
+     * @return array
+     */
+    public function fetchAll(string $sql): array
+    {
+        return $this->migration->fetchAll($sql);
+    }
+
+    /**
+     * Create a new database.
+     *
+     * @param string $name Database Name
+     * @param array<string, mixed> $options Options
+     * @return void
+     */
+    public function createDatabase(string $name, array $options): void
+    {
+        $this->migration->createDatabase($name, $options);
+    }
+
+    /**
+     * Drop a database.
+     *
+     * @param string $name Database Name
+     * @return void
+     */
+    public function dropDatabase(string $name): void
+    {
+        $this->migration->dropDatabase($name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createSchema(string $name): void
+    {
+        $this->migration->createSchema($name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function dropSchema(string $name): void
+    {
+        $this->migration->dropSchema($name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasTable(string $tableName): bool
+    {
+        return $this->migration->hasTable($tableName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function table(string $tableName, array $options): Table
+    {
+        throw new RuntimeException('MigrationAdapter::table is not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function preFlightCheck(): void
+    {
+        $this->migration->preFlightCheck();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function postFlightCheck(): void
+    {
+        $this->migration->postFlightCheck();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function shouldExecute(): bool
+    {
+        return $this->migration->shouldExecute();
+    }
+}

--- a/src/Shim/SeedAdapter.php
+++ b/src/Shim/SeedAdapter.php
@@ -38,7 +38,7 @@ use Symfony\Component\Console\Input\InputOption;
 class SeedAdapter implements SeedInterface
 {
     /**
-     * A ConsoleIo instance
+     * A migrations adapter instance
      *
      * @var \Migrations\Db\Adapter\AdapterInterface|null
      */
@@ -98,10 +98,7 @@ class SeedAdapter implements SeedInterface
     }
 
     /**
-     * Sets the database adapter.
-     *
-     * @param \Migrations\Db\Adapter\AdapterInterface $adapter Database Adapter
-     * @return $this
+     * {@inheritDoc}
      */
     public function setAdapter(AdapterInterface $adapter)
     {
@@ -113,9 +110,7 @@ class SeedAdapter implements SeedInterface
     }
 
     /**
-     * Gets the database adapter.
-     *
-     * @return \Migrations\Db\Adapter\AdapterInterface
+     * {@inheritDoc}
      */
     public function getAdapter(): AdapterInterface
     {
@@ -146,9 +141,7 @@ class SeedAdapter implements SeedInterface
     }
 
     /**
-     * Gets the config.
-     *
-     * @return ?\Migrations\Config\ConfigInterface
+     * {@inheritDoc}
      */
     public function getConfig(): ?ConfigInterface
     {
@@ -156,10 +149,7 @@ class SeedAdapter implements SeedInterface
     }
 
     /**
-     * Sets the config.
-     *
-     * @param \Migrations\Config\ConfigInterface $config Configuration Object
-     * @return $this
+     * {@inheritDoc}
      */
     public function setConfig(ConfigInterface $config)
     {
@@ -181,9 +171,7 @@ class SeedAdapter implements SeedInterface
     }
 
     /**
-     * Gets the name.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getName(): string
     {
@@ -191,11 +179,7 @@ class SeedAdapter implements SeedInterface
     }
 
     /**
-     * Executes a SQL statement and returns the number of affected rows.
-     *
-     * @param string $sql SQL
-     * @param array $params parameters to use for prepared query
-     * @return int
+     * {@inheritDoc}
      */
     public function execute(string $sql, array $params = []): int
     {
@@ -203,75 +187,47 @@ class SeedAdapter implements SeedInterface
     }
 
     /**
-     * Executes a SQL statement.
-     *
-     * The return type depends on the underlying adapter being used. To improve
-     * IDE auto-completion possibility, you can overwrite the query method
-     * phpDoc in your (typically custom abstract parent) seed class, where
-     * you can set the return type by the adapter in your current use.
-     *
-     * @param string $sql SQL
-     * @param array $params parameters to use for prepared query
-     * @return mixed
+     * {@inheritDoc}
      */
     public function query(string $sql, array $params = []): mixed
     {
-        return $this->query($sql, $params);
+        return $this->seed->query($sql, $params);
     }
 
     /**
-     * Executes a query and returns only one row as an array.
-     *
-     * @param string $sql SQL
-     * @return array|false
+     * {@inheritDoc}
      */
     public function fetchRow(string $sql): array|false
     {
-        return $this->fetchRow($sql);
+        return $this->seed->fetchRow($sql);
     }
 
     /**
-     * Executes a query and returns an array of rows.
-     *
-     * @param string $sql SQL
-     * @return array
+     * {@inheritDoc}
      */
     public function fetchAll(string $sql): array
     {
-        return $this->fetchAll($sql);
+        return $this->seed->fetchAll($sql);
     }
 
     /**
-     * Insert data into a table.
-     *
-     * @param string $tableName Table name
-     * @param array $data Data
-     * @return void
+     * {@inheritDoc}
      */
     public function insert(string $tableName, array $data): void
     {
-        $this->insert($tableName, $data);
+        $this->seed->insert($tableName, $data);
     }
 
     /**
-     * Checks to see if a table exists.
-     *
-     * @param string $tableName Table name
-     * @return bool
+     * {@inheritDoc}
      */
     public function hasTable(string $tableName): bool
     {
-        return $this->hasTable($tableName);
+        return $this->seed->hasTable($tableName);
     }
 
     /**
-     * Returns an instance of the <code>\Table</code> class.
-     *
-     * You can use this class to create and manipulate tables.
-     *
-     * @param string $tableName Table name
-     * @param array<string, mixed> $options Options
-     * @return \Migrations\Db\Table
+     * {@inheritDoc}
      */
     public function table(string $tableName, array $options): Table
     {
@@ -279,13 +235,7 @@ class SeedAdapter implements SeedInterface
     }
 
     /**
-     * Checks to see if the seed should be executed.
-     *
-     * Returns true by default.
-     *
-     * You can use this to prevent a seed from executing.
-     *
-     * @return bool
+     * {@inheritDoc}
      */
     public function shouldExecute(): bool
     {
@@ -293,12 +243,7 @@ class SeedAdapter implements SeedInterface
     }
 
     /**
-     * Gives the ability to a seeder to call another seeder.
-     * This is particularly useful if you need to run the seeders of your applications in a specific sequences,
-     * for instance to respect foreign key constraints.
-     *
-     * @param string $seeder Name of the seeder to call from the current seed
-     * @return void
+     * {@inheritDoc}
      */
     public function call(string $seeder): void
     {

--- a/tests/TestCase/Migration/EnvironmentTest.php
+++ b/tests/TestCase/Migration/EnvironmentTest.php
@@ -131,7 +131,8 @@ class EnvironmentTest extends TestCase
             }
         };
 
-        $this->environment->executeMigration($upMigration, MigrationInterface::UP);
+        $migrationWrapper = new MigrationAdapter($upMigration, $upMigration->getVersion());
+        $this->environment->executeMigration($migrationWrapper, MigrationInterface::UP);
         $this->assertTrue($upMigration->executed);
     }
 
@@ -156,7 +157,8 @@ class EnvironmentTest extends TestCase
             }
         };
 
-        $this->environment->executeMigration($downMigration, MigrationInterface::DOWN);
+        $migrationWrapper = new MigrationAdapter($downMigration, $downMigration->getVersion());
+        $this->environment->executeMigration($migrationWrapper, MigrationInterface::DOWN);
         $this->assertTrue($downMigration->executed);
     }
 
@@ -187,7 +189,8 @@ class EnvironmentTest extends TestCase
             }
         };
 
-        $this->environment->executeMigration($migration, MigrationInterface::UP);
+        $migrationWrapper = new MigrationAdapter($migration, $migration->getVersion());
+        $this->environment->executeMigration($migrationWrapper, MigrationInterface::UP);
         $this->assertTrue($migration->executed);
     }
 
@@ -212,7 +215,8 @@ class EnvironmentTest extends TestCase
             }
         };
 
-        $this->environment->executeMigration($migration, MigrationInterface::UP);
+        $migrationWrapper = new MigrationAdapter($migration, $migration->getVersion());
+        $this->environment->executeMigration($migrationWrapper, MigrationInterface::UP);
         $this->assertTrue($migration->executed);
     }
 
@@ -237,7 +241,8 @@ class EnvironmentTest extends TestCase
             }
         };
 
-        $this->environment->executeMigration($migration, MigrationInterface::DOWN);
+        $migrationWrapper = new MigrationAdapter($migration, $migration->getVersion());
+        $this->environment->executeMigration($migrationWrapper, MigrationInterface::DOWN);
         $this->assertTrue($migration->executed);
     }
 
@@ -262,7 +267,8 @@ class EnvironmentTest extends TestCase
             }
         };
 
-        $this->environment->executeMigration($migration, MigrationInterface::UP, true);
+        $migrationWrapper = new MigrationAdapter($migration, $migration->getVersion());
+        $this->environment->executeMigration($migrationWrapper, MigrationInterface::UP, true);
         $this->assertFalse($migration->executed);
     }
 

--- a/tests/TestCase/Migration/EnvironmentTest.php
+++ b/tests/TestCase/Migration/EnvironmentTest.php
@@ -8,6 +8,7 @@ use Cake\Datasource\ConnectionManager;
 use Migrations\Db\Adapter\AdapterWrapper;
 use Migrations\Db\Adapter\PdoAdapter;
 use Migrations\Migration\Environment;
+use Migrations\Shim\MigrationAdapter;
 use Migrations\Shim\SeedAdapter;
 use Phinx\Migration\AbstractMigration;
 use Phinx\Migration\MigrationInterface;
@@ -300,8 +301,8 @@ class EnvironmentTest extends TestCase
                 $this->upExecuted = true;
             }
         };
-
-        $this->environment->executeMigration($upMigration, MigrationInterface::UP);
+        $migrationWrapper = new MigrationAdapter($upMigration, $upMigration->getVersion());
+        $this->environment->executeMigration($migrationWrapper, MigrationInterface::UP);
         $this->assertTrue($upMigration->initExecuted);
         $this->assertTrue($upMigration->upExecuted);
     }

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -13,12 +13,10 @@ use Migrations\Config\Config;
 use Migrations\Db\Adapter\AdapterInterface;
 use Migrations\Migration\Environment;
 use Migrations\Migration\Manager;
-use Migrations\Shim\OutputAdapter;
 use Phinx\Console\Command\AbstractCommand;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Symfony\Component\Console\Input\InputInterface;
 
 class ManagerTest extends TestCase
 {

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -2205,18 +2205,6 @@ class ManagerTest extends TestCase
         $this->assertStringContainsString('skipped', $output);
     }
 
-    public function testGettingInputObject(): void
-    {
-        $migrations = $this->manager->getMigrations();
-        $seeds = $this->manager->getSeeds();
-        foreach ($migrations as $migration) {
-            $this->assertInstanceOf(InputInterface::class, $migration->getInput());
-        }
-        foreach ($seeds as $seed) {
-            $this->assertInstanceOf(InputInterface::class, $migration->getInput());
-        }
-    }
-
     public function testGettingIo(): void
     {
         $migrations = $this->manager->getMigrations();
@@ -2225,7 +2213,7 @@ class ManagerTest extends TestCase
         $this->assertInstanceOf(ConsoleIo::class, $io);
 
         foreach ($migrations as $migration) {
-            $this->assertInstanceOf(OutputAdapter::class, $migration->getOutput());
+            $this->assertInstanceOf(ConsoleIo::class, $migration->getIo());
         }
         foreach ($seeds as $seed) {
             $this->assertInstanceOf(ConsoleIo::class, $seed->getIo());


### PR DESCRIPTION
Move phinx compatibility into a `MigrationInterface` that provides a shim between phinx implementations and migrations internals.

I also fixed up some gaps in the `SeedAdapter` code.