### PR TITLE
4.next - Add base seed

### DIFF
--- a/src/AbstractSeed.php
+++ b/src/AbstractSeed.php
@@ -23,6 +23,8 @@ use function Cake\Core\pluginSplit;
  * Class AbstractSeed
  * Extends Phinx base AbstractSeed class in order to extend the features the seed class
  * offers.
+ *
+ * @deprecated 4.5.0 You should use Migrations\BaseSeed for new seeds.
  */
 abstract class AbstractSeed extends BaseAbstractSeed
 {

--- a/src/BaseSeed.php
+++ b/src/BaseSeed.php
@@ -168,7 +168,7 @@ class BaseSeed implements SeedInterface
     /**
      * {@inheritDoc}
      */
-    public function table(string $tableName, array $options): Table
+    public function table(string $tableName, array $options = []): Table
     {
         return new Table($tableName, $options, $this->getAdapter());
     }

--- a/src/BaseSeed.php
+++ b/src/BaseSeed.php
@@ -1,0 +1,233 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Migrations;
+
+use Cake\Console\ConsoleIo;
+use Migrations\Config\ConfigInterface;
+use Migrations\Db\Adapter\AdapterInterface;
+use Migrations\Db\Table;
+use Migrations\Migration\ManagerFactory;
+use RuntimeException;
+use function Cake\Core\pluginSplit;
+
+/**
+ * Base seed implementation
+ *
+ * Provides base functionality for seeds to extend.
+ */
+class BaseSeed implements SeedInterface
+{
+    protected ?AdapterInterface $adapter = null;
+    protected ?ConsoleIo $io = null;
+    protected ?ConfigInterface $config;
+
+    /**
+     * No-op constructor.
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function run(): void
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setAdapter(AdapterInterface $adapter)
+    {
+        $this->adapter = $adapter;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAdapter(): AdapterInterface
+    {
+        if (!$this->adapter) {
+            throw new RuntimeException('Adapter not set.');
+        }
+
+        return $this->adapter;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setIo(ConsoleIo $io)
+    {
+        $this->io = $io;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIo(): ?ConsoleIo
+    {
+        return $this->io;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfig(): ?ConfigInterface
+    {
+        return $this->config;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setConfig(ConfigInterface $config)
+    {
+        $this->config = $config;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName(): string
+    {
+        return static::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute(string $sql, array $params = []): int
+    {
+        return $this->getAdapter()->execute($sql, $params);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function query(string $sql, array $params = []): mixed
+    {
+        return $this->getAdapter()->query($sql, $params);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchRow(string $sql): array|false
+    {
+        return $this->getAdapter()->fetchRow($sql);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchAll(string $sql): array
+    {
+        return $this->getAdapter()->fetchAll($sql);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function insert(string $tableName, array $data): void
+    {
+        // convert to table object
+        $table = new Table($tableName, [], $this->getAdapter());
+        $table->insert($data)->save();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasTable(string $tableName): bool
+    {
+        return $this->getAdapter()->hasTable($tableName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function table(string $tableName, array $options): Table
+    {
+        return new Table($tableName, $options, $this->getAdapter());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function shouldExecute(): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function call(string $seeder, array $options = []): void
+    {
+        $io = $this->getIo();
+        assert($io !== null, 'Requires ConsoleIo');
+        $io->out('');
+        $io->out(
+            ' ====' .
+            ' <info>' . $seeder . ':</info>' .
+            ' <comment>seeding</comment>'
+        );
+
+        $start = microtime(true);
+        $this->runCall($seeder, $options);
+        $end = microtime(true);
+
+        $io->out(
+            ' ====' .
+            ' <info>' . $seeder . ':</info>' .
+            ' <comment>seeded' .
+            ' ' . sprintf('%.4fs', $end - $start) . '</comment>'
+        );
+        $io->out('');
+    }
+
+    /**
+     * Calls another seeder from this seeder.
+     * It will load the Seed class you are calling and run it.
+     *
+     * @param string $seeder Name of the seeder to call from the current seed
+     * @param array $options The CLI options passed to ManagerFactory.
+     * @return void
+     */
+    protected function runCall(string $seeder, array $options = []): void
+    {
+        [$pluginName, $seeder] = pluginSplit($seeder);
+
+        $factory = new ManagerFactory([
+            'plugin' => $options['plugin'] ?? $pluginName ?? null,
+            'source' => $options['source'] ?? null,
+            'connection' => $options['connection'] ?? null,
+        ]);
+        $io = $this->getIo();
+        assert($io !== null, 'Missing ConsoleIo instance');
+        $manager = $factory->createManager($io);
+        $manager->seed($seeder);
+    }
+}

--- a/src/BaseSeed.php
+++ b/src/BaseSeed.php
@@ -219,11 +219,13 @@ class BaseSeed implements SeedInterface
     protected function runCall(string $seeder, array $options = []): void
     {
         [$pluginName, $seeder] = pluginSplit($seeder);
+        $adapter = $this->getAdapter();
+        $connection = $adapter->getConnection()->configName();
 
         $factory = new ManagerFactory([
             'plugin' => $options['plugin'] ?? $pluginName ?? null,
             'source' => $options['source'] ?? null,
-            'connection' => $options['connection'] ?? null,
+            'connection' => $options['connection'] ?? $connection,
         ]);
         $io = $this->getIo();
         assert($io !== null, 'Missing ConsoleIo instance');

--- a/src/SeedInterface.php
+++ b/src/SeedInterface.php
@@ -161,7 +161,7 @@ interface SeedInterface
      * @param array<string, mixed> $options Options
      * @return \Migrations\Db\Table
      */
-    public function table(string $tableName, array $options): Table;
+    public function table(string $tableName, array $options = []): Table;
 
     /**
      * Checks to see if the seed should be executed.

--- a/src/SeedInterface.php
+++ b/src/SeedInterface.php
@@ -180,7 +180,8 @@ interface SeedInterface
      * for instance to respect foreign key constraints.
      *
      * @param string $seeder Name of the seeder to call from the current seed
+     * @param array $options The CLI options for the seeder.
      * @return void
      */
-    public function call(string $seeder): void;
+    public function call(string $seeder, array $options = []): void;
 }

--- a/src/Shim/SeedAdapter.php
+++ b/src/Shim/SeedAdapter.php
@@ -245,7 +245,7 @@ class SeedAdapter implements SeedInterface
     /**
      * {@inheritDoc}
      */
-    public function call(string $seeder): void
+    public function call(string $seeder, array $options = []): void
     {
         throw new RuntimeException('Not implemented');
     }

--- a/src/Shim/SeedAdapter.php
+++ b/src/Shim/SeedAdapter.php
@@ -229,7 +229,7 @@ class SeedAdapter implements SeedInterface
     /**
      * {@inheritDoc}
      */
-    public function table(string $tableName, array $options): Table
+    public function table(string $tableName, array $options = []): Table
     {
         throw new RuntimeException('Not implemented');
     }

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -132,6 +132,7 @@ class SeedCommandTest extends TestCase
         $this->assertOutputContains('radix=10');
         $this->assertOutputContains('fetchRow=121');
         $this->assertOutputContains('hasTable=1');
+        $this->assertOutputContains('fetchAll=121');
         $this->assertOutputContains('All Done');
 
         $connection = ConnectionManager::get('test');

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -128,7 +128,16 @@ class SeedCommandTest extends TestCase
         $this->exec('migrations seed -c test --source BaseSeeds --seed MigrationSeedNumbers');
         $this->assertExitSuccess();
         $this->assertOutputContains('MigrationSeedNumbers:</info> <comment>seeding');
+        $this->assertOutputContains('AnotherNumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('radix=10');
+        $this->assertOutputContains('fetchRow=121');
+        $this->assertOutputContains('hasTable=1');
         $this->assertOutputContains('All Done');
+
+        $connection = ConnectionManager::get('test');
+        $query = $connection->execute('SELECT COUNT(*) FROM numbers');
+        // Two seeders run == 2 rows
+        $this->assertEquals(2, $query->fetchColumn(0));
     }
 
     public function testSeederImplictAll(): void

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -122,6 +122,15 @@ class SeedCommandTest extends TestCase
         $this->assertEquals(1, $query->fetchColumn(0));
     }
 
+    public function testSeederBaseSeed(): void
+    {
+        $this->createTables();
+        $this->exec('migrations seed -c test --source BaseSeeds --seed MigrationSeedNumbers');
+        $this->assertExitSuccess();
+        $this->assertOutputContains('MigrationSeedNumbers:</info> <comment>seeding');
+        $this->assertOutputContains('All Done');
+    }
+
     public function testSeederImplictAll(): void
     {
         $this->createTables();

--- a/tests/test_app/config/BaseSeeds/MigrationSeedNumbers.php
+++ b/tests/test_app/config/BaseSeeds/MigrationSeedNumbers.php
@@ -35,11 +35,11 @@ class MigrationSeedNumbers extends BaseSeed
         $query = $this->query('SELECT radix FROM numbers');
         $io->out('radix=' . $query->fetchColumn(0));
 
-        $row = $this->fetchRow('SELECT 121 as key');
-        $io->out('fetchRow=' . $row['key']);
+        $row = $this->fetchRow('SELECT 121 as row_val');
+        $io->out('fetchRow=' . $row['row_val']);
         $io->out('hasTable=' . $this->hasTable('numbers'));
 
-        $row = $this->fetchAll('SELECT 121 as key');
-        $io->out('fetchAll=' . $row[0]['key']);
+        $rows = $this->fetchAll('SELECT 121 as row_val');
+        $io->out('fetchAll=' . $rows[0]['row_val']);
     }
 }

--- a/tests/test_app/config/BaseSeeds/MigrationSeedNumbers.php
+++ b/tests/test_app/config/BaseSeeds/MigrationSeedNumbers.php
@@ -24,7 +24,22 @@ class MigrationSeedNumbers extends BaseSeed
             ],
         ];
 
-        $table = $this->table('numbers');
-        $table->insert($data)->save();
+        // Call various methods on the seeder for runtime checks
+        // and generate output to assert behavior with in an integration test.
+        $this->table('numbers');
+        $this->insert('numbers', $data);
+
+        $this->call('AnotherNumbersSeed', ['source' => 'AltSeeds']);
+
+        $io = $this->getIo();
+        $query = $this->query('SELECT radix FROM numbers');
+        $io->out('radix=' . $query->fetchColumn(0));
+
+        $row = $this->fetchRow('SELECT 121 as key');
+        $io->out('fetchRow=' . $row['key']);
+        $io->out('hasTable=' . $this->hasTable('numbers'));
+
+        $row = $this->fetchAll('SELECT 121 as key');
+        $io->out('fetchAll=' . $row[0]['key']);
     }
 }

--- a/tests/test_app/config/BaseSeeds/MigrationSeedNumbers.php
+++ b/tests/test_app/config/BaseSeeds/MigrationSeedNumbers.php
@@ -1,0 +1,30 @@
+<?php
+
+use Migrations\BaseSeed;
+
+/**
+ * NumbersSeed seed.
+ */
+class MigrationSeedNumbers extends BaseSeed
+{
+    /**
+     * Run Method.
+     *
+     * Write your database seeder using this method.
+     *
+     * More information on writing seeders is available here:
+     * https://book.cakephp.org/phinx/0/en/seeding.html
+     */
+    public function run(): void
+    {
+        $data = [
+            [
+                'number' => '5',
+                'radix' => '10',
+            ],
+        ];
+
+        $table = $this->table('numbers');
+        $table->insert($data)->save();
+    }
+}


### PR DESCRIPTION
Add a migrations 'native' base class for Seeds. I'm also planning on adding a similar base class for Migration classes. Having these base classes will allow us to also update `bake migration` to generate new migrations with these base classes. My hope is that this provides an easy transition to the new backend.