### PR TITLE
Update Bake migration diff to generate with builtin base classes

### DIFF
--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -493,6 +493,7 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
 
         $newArgs = array_merge($newArgs, $this->parseOptions($args));
 
+        // TODO(mark) This nested command call always uses phinx backend.
         $exitCode = $this->executeCommand(BakeMigrationSnapshotCommand::class, $newArgs, $io);
 
         if ($exitCode === 1) {
@@ -521,6 +522,7 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             $inputArgs['--plugin'] = $args->getOption('plugin');
         }
 
+        // TODO(mark) This has to change for the built-in backend
         $className = Dump::class;
         $definition = (new $className())->getDefinition();
 

--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -18,6 +18,7 @@ namespace Migrations\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
+use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Schema\CollectionInterface;
 use Cake\Database\Schema\TableSchema;
@@ -199,6 +200,7 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             'data' => $this->templateData,
             'dumpSchema' => $this->dumpSchema,
             'currentSchema' => $this->currentSchema,
+            'backend' => Configure::read('Migrations.backend', 'builtin'),
         ];
     }
 

--- a/templates/bake/config/diff.twig
+++ b/templates/bake/config/diff.twig
@@ -20,9 +20,15 @@
 <?php
 declare(strict_types=1);
 
+{% if backend == "builtin" %}
+use Migrations\BaseMigration;
+
+class {{ name }} extends BaseMigration
+{% else %}
 use Migrations\AbstractMigration;
 
 class {{ name }} extends AbstractMigration
+{% endif %}
 {
 {% if not autoId %}
     public bool $autoId = false;
@@ -32,7 +38,11 @@ class {{ name }} extends AbstractMigration
      * Up Method.
      *
      * More information on this method is available here:
+{% if backend == "builtin" %}
+     * https://book.cakephp.org/migrations/4/en/migrations.html#the-up-method
+{% else %}
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+{% endif %}
      * @return void
      */
     public function up(): void

--- a/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
  */
 namespace Migrations\Test\TestCase\Command;
 
+use Cake\Cache\Cache;
 use Cake\Console\BaseCommand;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
@@ -54,6 +55,15 @@ class BakeMigrationDiffCommandTest extends TestCase
             if (file_exists($file)) {
                 unlink($file);
             }
+        }
+        if (env('DB_URL_COMPARE')) {
+            // Clean up the comparison database each time. Table order is important.
+            $connection = ConnectionManager::get('test_comparisons');
+            $tables = ['articles', 'categories', 'comments', 'users', 'phinxlog'];
+            foreach ($tables as $table) {
+                $connection->execute("DROP TABLE IF EXISTS $table");
+            }
+            Cache::clear('_cake_model_');
         }
     }
 
@@ -206,7 +216,8 @@ class BakeMigrationDiffCommandTest extends TestCase
             $destinationDumpPath,
         ];
 
-        $this->getMigrations("MigrationsDiff$scenario")->migrate();
+        $migrations = $this->getMigrations("MigrationsDiff$scenario");
+        $migrations->migrate();
 
         unlink($destination);
         copy($diffDumpPath, $destinationDumpPath);

--- a/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
+++ b/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
@@ -1,15 +1,15 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class TheDiffAddRemoveMysql extends AbstractMigration
+class TheDiffAddRemoveMysql extends BaseMigration
 {
     /**
      * Up Method.
      *
      * More information on this method is available here:
-     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * https://book.cakephp.org/migrations/4/en/migrations.html#the-up-method
      * @return void
      */
     public function up(): void

--- a/tests/comparisons/Diff/default/the_diff_default_mysql.php
+++ b/tests/comparisons/Diff/default/the_diff_default_mysql.php
@@ -1,15 +1,15 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class TheDiffDefaultMysql extends AbstractMigration
+class TheDiffDefaultMysql extends BaseMigration
 {
     /**
      * Up Method.
      *
      * More information on this method is available here:
-     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * https://book.cakephp.org/migrations/4/en/migrations.html#the-up-method
      * @return void
      */
     public function up(): void

--- a/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
@@ -1,15 +1,15 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class TheDiffSimpleMysql extends AbstractMigration
+class TheDiffSimpleMysql extends BaseMigration
 {
     /**
      * Up Method.
      *
      * More information on this method is available here:
-     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * https://book.cakephp.org/migrations/4/en/migrations.html#the-up-method
      * @return void
      */
     public function up(): void

--- a/tests/comparisons/Diff/withAutoIdCompatibleSignedPrimaryKeys/the_diff_with_auto_id_compatible_signed_primary_keys_mysql.php
+++ b/tests/comparisons/Diff/withAutoIdCompatibleSignedPrimaryKeys/the_diff_with_auto_id_compatible_signed_primary_keys_mysql.php
@@ -1,15 +1,15 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class TheDiffWithAutoIdCompatibleSignedPrimaryKeysMysql extends AbstractMigration
+class TheDiffWithAutoIdCompatibleSignedPrimaryKeysMysql extends BaseMigration
 {
     /**
      * Up Method.
      *
      * More information on this method is available here:
-     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * https://book.cakephp.org/migrations/4/en/migrations.html#the-up-method
      * @return void
      */
     public function up(): void

--- a/tests/comparisons/Diff/withAutoIdIncompatibleSignedPrimaryKeys/the_diff_with_auto_id_incompatible_signed_primary_keys_mysql.php
+++ b/tests/comparisons/Diff/withAutoIdIncompatibleSignedPrimaryKeys/the_diff_with_auto_id_incompatible_signed_primary_keys_mysql.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class TheDiffWithAutoIdIncompatibleSignedPrimaryKeysMysql extends AbstractMigration
+class TheDiffWithAutoIdIncompatibleSignedPrimaryKeysMysql extends BaseMigration
 {
     public bool $autoId = false;
 
@@ -11,7 +11,7 @@ class TheDiffWithAutoIdIncompatibleSignedPrimaryKeysMysql extends AbstractMigrat
      * Up Method.
      *
      * More information on this method is available here:
-     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * https://book.cakephp.org/migrations/4/en/migrations.html#the-up-method
      * @return void
      */
     public function up(): void

--- a/tests/comparisons/Diff/withAutoIdIncompatibleUnsignedPrimaryKeys/the_diff_with_auto_id_incompatible_unsigned_primary_keys_mysql.php
+++ b/tests/comparisons/Diff/withAutoIdIncompatibleUnsignedPrimaryKeys/the_diff_with_auto_id_incompatible_unsigned_primary_keys_mysql.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class TheDiffWithAutoIdIncompatibleUnsignedPrimaryKeysMysql extends AbstractMigration
+class TheDiffWithAutoIdIncompatibleUnsignedPrimaryKeysMysql extends BaseMigration
 {
     public bool $autoId = false;
 
@@ -11,7 +11,7 @@ class TheDiffWithAutoIdIncompatibleUnsignedPrimaryKeysMysql extends AbstractMigr
      * Up Method.
      *
      * More information on this method is available here:
-     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * https://book.cakephp.org/migrations/4/en/migrations.html#the-up-method
      * @return void
      */
     public function up(): void


### PR DESCRIPTION
Update `bake migration_diff` to use the builtin backend base classes when enabled. There is more to do here though as diff generation delegates to other commands.