### PR TITLE
Prevent fatal error on reserved keywords as migration names.

### DIFF
--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -126,9 +126,9 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
         $this->io = $io;
         $this->args = $args;
         if ($this->isReservedKeyword($name)) {
-            $prefix = $io->ask('Reserved keywords cannot be used for class names. What prefix would you like to use, defaults to `Migration`', 'Migration');
+            $prefix = $io->ask('Reserved keywords cannot be used for class names. What prefix would you like to use? Defaults to `Migration`.', 'Migration');
             if (!$prefix) {
-                $io->err('You must provide a prefix when using a reserved keyword as name');
+                $io->err('You must provide a prefix when using a reserved keyword as name.');
                 $this->abort();
             }
 

--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -30,6 +30,14 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
 {
     public const DEFAULT_MIGRATION_FOLDER = 'Migrations';
 
+    protected const RESERVED_KEYWORDS = [
+        'abstract', 'and', 'array', 'as', 'break', 'callable', 'case', 'catch', 'class', 'clone', 'const',
+        'continue', 'declare', 'default', 'die', 'do', 'echo', 'else', 'elseif', 'empty', 'enddeclare', 'endfor',
+        'endforeach', 'endif', 'endswitch', 'endwhile', 'eval', 'exit', 'extends', 'final', 'finally', 'for', 'foreach',
+        'function', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof', 'insteadof', 'interface',
+        'isset', 'list', 'namespace', 'new', 'or', 'parent', 'private', 'protected', 'public', 'return','static',
+    ];
+
     /**
      * path to Migration directory
      *
@@ -117,8 +125,18 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
     {
         $this->io = $io;
         $this->args = $args;
+        if ($this->isReservedKeyword($name)) {
+            $prefix = $io->ask('Reserved keywords cannot be used for class names. What prefix would you like to use, defaults to `Migration`', 'Migration');
+            if (!$prefix) {
+                $io->err('You must provide a prefix when using a reserved keyword as name');
+                $this->abort();
+            }
+
+            $name = $prefix . ucfirst($name);
+        }
+
         $migrationWithSameName = glob($this->getPath($args) . '*_' . $name . '.php');
-        if (!empty($migrationWithSameName)) {
+        if ($migrationWithSameName) {
             $force = $args->getOption('force');
             if (!$force) {
                 $io->abort(
@@ -217,5 +235,16 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
         ]);
 
         return $parser;
+    }
+
+    /**
+     * If reserved PHP keyword.
+     *
+     * @param string $name
+     * @return bool
+     */
+    protected function isReservedKeyword(string $name): bool
+    {
+        return in_array(strtolower($name), static::RESERVED_KEYWORDS);
     }
 }

--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -127,11 +127,6 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
         $this->args = $args;
         if ($this->isReservedKeyword($name)) {
             $prefix = $io->ask('Reserved keywords cannot be used for class names. What prefix would you like to use? Defaults to `Migration`.', 'Migration');
-            if (!$prefix) {
-                $io->err('You must provide a prefix when using a reserved keyword as name.');
-                $this->abort();
-            }
-
             $name = $prefix . ucfirst($name);
         }
 

--- a/tests/TestCase/Command/BakeMigrationCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationCommandTest.php
@@ -43,9 +43,16 @@ class BakeMigrationCommandTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        $createUsers = glob(ROOT . DS . 'config' . DS . 'Migrations' . DS . '*_*Users.php');
-        if ($createUsers) {
-            foreach ($createUsers as $file) {
+        $files = glob(ROOT . DS . 'config' . DS . 'Migrations' . DS . '*_*Users.php');
+        if ($files) {
+            foreach ($files as $file) {
+                unlink($file);
+            }
+        }
+
+        $files = glob(ROOT . DS . 'config' . DS . 'Migrations' . DS . '*_PrefixNew.php');
+        if ($files) {
+            foreach ($files as $file) {
                 unlink($file);
             }
         }
@@ -128,6 +135,17 @@ class BakeMigrationCommandTest extends TestCase
         $this->exec('bake migration CreateUsers --connection test');
         $this->assertExitCode(BaseCommand::CODE_ERROR);
         $this->assertErrorContains('A migration with the name `CreateUsers` already exists. Please use a different name.');
+    }
+
+    /**
+     * Tests that baking a migration with the name as reserved keyword triggers prefixing.
+     */
+    public function testCreateWithReservedKeyword()
+    {
+        $this->exec('bake migration New --connection test', ['Prefix']);
+
+        $this->assertExitCode(BaseCommand::CODE_SUCCESS);
+        $this->assertOutputRegExp('/Wrote.*?PrefixNew\.php/');
     }
 
     public function testCreateBuiltinAlias()

--- a/tests/TestCase/Command/MigrationCommandTest.php
+++ b/tests/TestCase/Command/MigrationCommandTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\NullOutput;
 class MigrationCommandTest extends TestCase
 {
     /**
-     * @var \Migrations\MigrationsMigrateCommand
+     * @var \Migrations\Command\MigrationsMigrateCommand
      */
     protected $command;
 


### PR DESCRIPTION
Resolves https://github.com/cakephp/migrations/issues/693

![reservd](https://github.com/user-attachments/assets/6db0d476-056a-4e5c-8efb-b7fc877371bc)
