### PR TITLE
Added nativeuuid type for databases with a native uuid type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Setup MariaDB (part 2)
         if: matrix.db-type == 'mariadb'
         run: |
-          mariadb -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_comparisons;'
-          mariadb -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_snapshot;'
+          mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_comparisons;'
+          mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_snapshot;'
 
       - name: Setup MySQL
         if: matrix.db-type == 'mysql'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
           mariadb version: '10.11.10'
           mysql database: 'cakephp_test'
           mysql root password: 'root'
+      - name: Setup MariaDB (part 2)
+        if: matrix.db-type == 'mariadb'
         run: |
           mariadb -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_comparisons;'
           mariadb -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_snapshot;'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ['8.1', '8.2', '8.3', '8.4']
-        db-type: [mysql, pgsql, sqlite]
+        db-type: [mariadb, mysql, pgsql, sqlite]
         prefer-lowest: ['']
         cake_version: ['']
         include:
@@ -49,6 +49,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup MariaDB
+        uses: getong/mariadb-action@v1.11
+        if: matrix.db-type == 'mariadb'
+        with:
+          mariadb version: '10.11.10'
+          mysql database: 'cakephp_test'
+          mysql root password: 'root'
+        run: |
+          mariadb -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_comparisons;'
+          mariadb -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp_snapshot;'
 
       - name: Setup MySQL
         if: matrix.db-type == 'mysql'
@@ -105,6 +116,12 @@ jobs:
         run: |
           if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then
             export DB='sqlite'
+          fi
+          if [[ ${{ matrix.db-type }} == 'mariadb' ]]; then
+            export DB='mysql'
+            export DB_URL='mysql://root:root@127.0.0.1/cakephp_test'
+            export DB_URL_COMPARE='mysql://root:root@127.0.0.1/cakephp_comparisons'
+            export DB_URL_SNAPSHOT='mysql://root:root@127.0.0.1/cakephp_snapshot'
           fi
           if [[ ${{ matrix.db-type }} == 'mysql' ]]; then
             export DB='mysql'

--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -51,6 +51,7 @@ interface AdapterInterface
     public const PHINX_TYPE_JSON = 'json';
     public const PHINX_TYPE_JSONB = 'jsonb';
     public const PHINX_TYPE_UUID = 'uuid';
+    public const PHINX_TYPE_NATIVEUUID = 'nativeuuid';
     public const PHINX_TYPE_FILESTREAM = 'filestream';
 
     // Geospatial database types

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -32,7 +32,6 @@ class MysqlAdapter extends PdoAdapter
         self::PHINX_TYPE_YEAR,
         self::PHINX_TYPE_JSON,
         self::PHINX_TYPE_BINARYUUID,
-        self::PHINX_TYPE_NATIVEUUID,
         self::PHINX_TYPE_TINYBLOB,
         self::PHINX_TYPE_MEDIUMBLOB,
         self::PHINX_TYPE_LONGBLOB,
@@ -1494,6 +1493,15 @@ class MysqlAdapter extends PdoAdapter
      */
     public function getColumnTypes(): array
     {
-        return array_merge(parent::getColumnTypes(), static::$specificColumnTypes);
+        $connection = $this->getConnection();
+        $version = $connection->getDriver()->version();
+
+        $types = array_merge(parent::getColumnTypes(), static::$specificColumnTypes);
+
+        if (version_compare($version, '10.7', '>=')) {
+            $types[] = self::PHINX_TYPE_NATIVEUUID;
+        }
+
+        return $types;
     }
 }

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -32,6 +32,7 @@ class MysqlAdapter extends PdoAdapter
         self::PHINX_TYPE_YEAR,
         self::PHINX_TYPE_JSON,
         self::PHINX_TYPE_BINARYUUID,
+        self::PHINX_TYPE_NATIVEUUID,
         self::PHINX_TYPE_TINYBLOB,
         self::PHINX_TYPE_MEDIUMBLOB,
         self::PHINX_TYPE_LONGBLOB,

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -1067,6 +1067,7 @@ class MysqlAdapter extends PdoAdapter
                         'Column type "' . $type . '" is not supported by this version of MySQL.'
                     );
                 }
+
                 return ['name' => 'uuid'];
             case static::PHINX_TYPE_YEAR:
                 if (!$limit || in_array($limit, [2, 4])) {
@@ -1510,6 +1511,7 @@ class MysqlAdapter extends PdoAdapter
     /**
      * Whether the server has a native uuid type.
      * (MariaDB 10.7.0+)
+     *
      * @return bool
      */
     protected function hasNativeUuid(): bool

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -1187,6 +1187,10 @@ class MysqlAdapter extends PdoAdapter
                     $type = static::PHINX_TYPE_BINARYUUID;
                 }
                 break;
+            case 'uuid':
+                $type = static::PHINX_TYPE_NATIVEUUID;
+                $limit = null;
+                break;
         }
 
         try {

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -1062,6 +1062,11 @@ class MysqlAdapter extends PdoAdapter
             case static::PHINX_TYPE_UUID:
                 return ['name' => 'char', 'limit' => 36];
             case static::PHINX_TYPE_NATIVEUUID:
+                if (!$this->hasNativeUuid()) {
+                    throw new UnsupportedColumnTypeException(
+                        'Column type "' . $type . '" is not supported by this version of MySQL.'
+                    );
+                }
                 return ['name' => 'uuid'];
             case static::PHINX_TYPE_YEAR:
                 if (!$limit || in_array($limit, [2, 4])) {
@@ -1493,15 +1498,25 @@ class MysqlAdapter extends PdoAdapter
      */
     public function getColumnTypes(): array
     {
-        $connection = $this->getConnection();
-        $version = $connection->getDriver()->version();
-
         $types = array_merge(parent::getColumnTypes(), static::$specificColumnTypes);
 
-        if (version_compare($version, '10.7', '>=')) {
+        if ($this->hasNativeUuid()) {
             $types[] = self::PHINX_TYPE_NATIVEUUID;
         }
 
         return $types;
+    }
+
+    /**
+     * Whether the server has a native uuid type.
+     * (MariaDB 10.7.0+)
+     * @return bool
+     */
+    protected function hasNativeUuid(): bool
+    {
+        $connection = $this->getConnection();
+        $version = $connection->getDriver()->version();
+
+        return version_compare($version, '10.7', '>=');
     }
 }

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -1061,6 +1061,8 @@ class MysqlAdapter extends PdoAdapter
                 return ['name' => 'tinyint', 'limit' => 1];
             case static::PHINX_TYPE_UUID:
                 return ['name' => 'char', 'limit' => 36];
+            case static::PHINX_TYPE_NATIVEUUID:
+                return ['name' => 'uuid'];
             case static::PHINX_TYPE_YEAR:
                 if (!$limit || in_array($limit, [2, 4])) {
                     $limit = 4;

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -424,8 +424,9 @@ class MysqlAdapter extends PdoAdapter
 
             if ($columnInfo['Extra'] === 'auto_increment') {
                 $column->setIdentity(true);
-            }
-            if ($columnInfo['Extra'] === 'on update CURRENT_TIMESTAMP') {
+            } elseif ($columnInfo['Extra'] === 'on update CURRENT_TIMESTAMP') {
+                $column->setUpdate('CURRENT_TIMESTAMP');
+            } elseif ($columnInfo['Extra'] === 'on update current_timestamp()') {
                 $column->setUpdate('CURRENT_TIMESTAMP');
             }
 

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -549,7 +549,7 @@ class PostgresAdapter extends PdoAdapter
                 $quotedColumnName
             );
         }
-        if ($newColumn->getType() === 'uuid') {
+        if (in_array($newColumn->getType(), ['uuid', 'nativeuuid', 'binaryuuid'])) {
             $sql .= sprintf(
                 ' USING (%s::uuid)',
                 $quotedColumnName

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -1023,6 +1023,7 @@ class PostgresAdapter extends PdoAdapter
             case static::PHINX_TYPE_DATETIME:
                 return ['name' => 'timestamp'];
             case static::PHINX_TYPE_BINARYUUID:
+            case static::PHINX_TYPE_NATIVEUUID:
                 return ['name' => 'uuid'];
             case static::PHINX_TYPE_BLOB:
             case static::PHINX_TYPE_BINARY:

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -39,6 +39,7 @@ class PostgresAdapter extends PdoAdapter
         self::PHINX_TYPE_MACADDR,
         self::PHINX_TYPE_INTERVAL,
         self::PHINX_TYPE_BINARYUUID,
+        self::PHINX_TYPE_NATIVEUUID,
     ];
 
     private const GIN_INDEX_TYPE = 'gin';

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -1025,6 +1025,7 @@ ORDER BY T.[name], I.[index_id];",
                 return ['name' => 'bit'];
             case static::PHINX_TYPE_BINARYUUID:
             case static::PHINX_TYPE_UUID:
+            case static::PHINX_TYPE_NATIVEUUID:
                 return ['name' => 'uniqueidentifier'];
             case static::PHINX_TYPE_FILESTREAM:
                 return ['name' => 'varbinary', 'limit' => 'max'];

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -29,6 +29,7 @@ class SqlserverAdapter extends PdoAdapter
     protected static array $specificColumnTypes = [
         self::PHINX_TYPE_FILESTREAM,
         self::PHINX_TYPE_BINARYUUID,
+        self::PHINX_TYPE_NATIVEUUID,
     ];
 
     /**

--- a/src/Db/Table/Column.php
+++ b/src/Db/Table/Column.php
@@ -36,6 +36,7 @@ class Column
     public const TIMESTAMP = AdapterInterface::PHINX_TYPE_TIMESTAMP;
     public const UUID = AdapterInterface::PHINX_TYPE_UUID;
     public const BINARYUUID = AdapterInterface::PHINX_TYPE_BINARYUUID;
+    public const NATIVEUUID = AdapterInterface::PHINX_TYPE_NATIVEUUID;
     /** MySQL-only column type */
     public const MEDIUMINTEGER = AdapterInterface::PHINX_TYPE_MEDIUM_INTEGER;
     /** MySQL-only column type */

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -531,11 +531,11 @@ class MysqlAdapterTest extends TestCase
         $this->assertEquals('datetime', $columns[1]->getType());
         $this->assertEquals('', $columns[1]->getUpdate());
         $this->assertFalse($columns[1]->isNull());
-        $this->assertEquals('CURRENT_TIMESTAMP', $columns[1]->getDefault());
+        $this->assertContains($columns[1]->getDefault(), ['CURRENT_TIMESTAMP', 'current_timestamp()']);
 
         $this->assertEquals('updated', $columns[2]->getName());
         $this->assertEquals('datetime', $columns[2]->getType());
-        $this->assertEquals('CURRENT_TIMESTAMP', $columns[2]->getUpdate());
+        $this->assertContains($columns[2]->getUpdate(), ['CURRENT_TIMESTAMP', 'current_timestamp()']);
         $this->assertTrue($columns[2]->isNull());
         $this->assertNull($columns[2]->getDefault());
     }

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -2493,12 +2493,14 @@ INPUT;
     #[DataProvider('defaultsCastAsExpressions')]
     public function testDefaultsCastAsExpressionsForCertainTypes(string $type, string $default): void
     {
-        if ($this->usingMariaDbWithUuid() && in_array($type, [
+        if (
+            $this->usingMariaDbWithUuid() && in_array($type, [
             MysqlAdapter::PHINX_TYPE_GEOMETRY,
             MysqlAdapter::PHINX_TYPE_POINT,
             MysqlAdapter::PHINX_TYPE_LINESTRING,
             MysqlAdapter::PHINX_TYPE_POLYGON,
-        ])) {
+            ])
+        ) {
             $this->markTestSkipped('GIS is broken with MariaDB');
         }
 

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -12,6 +12,7 @@ use Cake\Datasource\ConnectionManager;
 use InvalidArgumentException;
 use Migrations\Db\Adapter\AdapterInterface;
 use Migrations\Db\Adapter\MysqlAdapter;
+use Migrations\Db\Adapter\UnsupportedColumnTypeException;
 use Migrations\Db\Literal;
 use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
@@ -80,6 +81,13 @@ class MysqlAdapterTest extends TestCase
         $version = $this->adapter->getConnection()->getDriver()->version();
 
         return version_compare($version, '8.0.0', '>=');
+    }
+
+    private function usingMariaDbWithUuid(): bool
+    {
+        $version = $this->adapter->getConnection()->getDriver()->version();
+
+        return version_compare($version, '10.7.0', '>=');
     }
 
     public function testConnection()
@@ -323,6 +331,27 @@ class MysqlAdapterTest extends TestCase
         ];
         $table = new Table('ztable', $options, $this->adapter);
         $table->addColumn('id', 'binaryuuid', ['null' => false])->save();
+        $table->addColumn('user_id', 'integer')->save();
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'user_id'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateTableWithPrimaryKeyAsNativeUuid()
+    {
+        if (!$this->usingMariaDbWithUuid()) {
+            $this->markTestSkipped('Database does not have a native uuid type');
+        }
+
+        $options = [
+            'id' => false,
+            'primary_key' => 'id',
+        ];
+        $table = new Table('ztable', $options, $this->adapter);
+        $table->addColumn('id', 'nativeuuid', ['null' => false])->save();
         $table->addColumn('user_id', 'integer')->save();
         $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
         $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
@@ -2521,5 +2550,13 @@ INPUT;
 
         $this->assertSame($expectedResponse['name'], $result['name'], "Type mismatch - got '{$result['name']}' when expecting '{$expectedResponse['name']}'");
         $this->assertSame($expectedResponse['limit'], $result['limit'], "Field upper boundary mismatch - got '{$result['limit']}' when expecting '{$expectedResponse['limit']}'");
+    }
+
+    public function testGetPhinxType()
+    {
+        if (!$this->usingMariaDbWithUuid()) {
+            $this->expectException(UnsupportedColumnTypeException::class);
+        }
+        $this->assertSame('uuid', $this->adapter->getSqlType('nativeuuid'));
     }
 }

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -426,7 +426,7 @@ class MysqlAdapterTest extends TestCase
               ->save();
         $this->assertTrue($adapter->hasTable('table_with_default_collation'));
         $row = $adapter->fetchRow(sprintf("SHOW TABLE STATUS WHERE Name = '%s'", 'table_with_default_collation'));
-        $this->assertEquals('utf8mb4_0900_ai_ci', $row['Collation']);
+        $this->assertContains($row['Collation'], ['utf8mb4_0900_ai_ci', 'utf8mb4_unicode_520_ci']);
     }
 
     public function testCreateTableWithLatin1Collate()
@@ -2181,8 +2181,14 @@ class MysqlAdapterTest extends TestCase
             ->addColumn('column3', 'string', ['default' => 'test', 'null' => false])
             ->save();
 
-        $expectedOutput = <<<'OUTPUT'
-CREATE TABLE `table1` (`id` INT(11) unsigned NOT NULL AUTO_INCREMENT, `column1` VARCHAR(255) NOT NULL, `column2` INT(11) NULL, `column3` VARCHAR(255) NOT NULL DEFAULT 'test', PRIMARY KEY (`id`)) ENGINE = InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+        if ($this->usingMariaDbWithUuid()) {
+            $collation = 'utf8mb4_unicode_520_ci';
+        } else {
+            $collation = 'utf8mb4_0900_ai_ci';
+        }
+
+        $expectedOutput = <<<OUTPUT
+CREATE TABLE `table1` (`id` INT(11) unsigned NOT NULL AUTO_INCREMENT, `column1` VARCHAR(255) NOT NULL, `column2` INT(11) NULL, `column3` VARCHAR(255) NOT NULL DEFAULT 'test', PRIMARY KEY (`id`)) ENGINE = InnoDB CHARACTER SET utf8mb4 COLLATE {$collation};
 OUTPUT;
         $actualOutput = join("\n", $this->out->messages());
         $this->assertStringContainsString($expectedOutput, $actualOutput, 'Passing the --dry-run option does not dump create table query to the output');
@@ -2286,8 +2292,14 @@ OUTPUT;
             'column2' => 1,
         ])->save();
 
-        $expectedOutput = <<<'OUTPUT'
-CREATE TABLE `table1` (`column1` VARCHAR(255) NOT NULL, `column2` INT(11) NULL, PRIMARY KEY (`column1`)) ENGINE = InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+        if ($this->usingMariaDbWithUuid()) {
+            $collation = 'utf8mb4_unicode_520_ci';
+        } else {
+            $collation = 'utf8mb4_0900_ai_ci';
+        }
+
+        $expectedOutput = <<<OUTPUT
+CREATE TABLE `table1` (`column1` VARCHAR(255) NOT NULL, `column2` INT(11) NULL, PRIMARY KEY (`column1`)) ENGINE = InnoDB CHARACTER SET utf8mb4 COLLATE {$collation};
 INSERT INTO `table1` (`column1`, `column2`) VALUES ('id1', 1);
 OUTPUT;
         $actualOutput = join("\n", $this->out->messages());

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -2557,6 +2557,6 @@ INPUT;
         if (!$this->usingMariaDbWithUuid()) {
             $this->expectException(UnsupportedColumnTypeException::class);
         }
-        $this->assertSame('uuid', $this->adapter->getSqlType('nativeuuid'));
+        $this->assertSame(['name' => 'uuid'], $this->adapter->getSqlType('nativeuuid'));
     }
 }

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -76,6 +76,13 @@ class MysqlAdapterTest extends TestCase
         unset($this->adapter, $this->out, $this->io);
     }
 
+    private function getDefaultCollation(): string
+    {
+        return $this->usingMariaDbWithUuid() ?
+            'utf8mb4_general_ci' :
+            'utf8mb4_0900_ai_ci';
+    }
+
     private function usingMysql8(): bool
     {
         $version = $this->adapter->getConnection()->getDriver()->version();
@@ -427,7 +434,7 @@ class MysqlAdapterTest extends TestCase
               ->save();
         $this->assertTrue($adapter->hasTable('table_with_default_collation'));
         $row = $adapter->fetchRow(sprintf("SHOW TABLE STATUS WHERE Name = '%s'", 'table_with_default_collation'));
-        $this->assertContains($row['Collation'], ['utf8mb4_0900_ai_ci', 'utf8mb4_unicode_520_ci']);
+        $this->assertEquals($row['Collation'], $this->getDefaultCollation());
     }
 
     public function testCreateTableWithLatin1Collate()
@@ -2182,11 +2189,7 @@ class MysqlAdapterTest extends TestCase
             ->addColumn('column3', 'string', ['default' => 'test', 'null' => false])
             ->save();
 
-        if ($this->usingMariaDbWithUuid()) {
-            $collation = 'utf8mb4_unicode_520_ci';
-        } else {
-            $collation = 'utf8mb4_0900_ai_ci';
-        }
+        $collation = $this->getDefaultCollation();
 
         $expectedOutput = <<<OUTPUT
 CREATE TABLE `table1` (`id` INT(11) unsigned NOT NULL AUTO_INCREMENT, `column1` VARCHAR(255) NOT NULL, `column2` INT(11) NULL, `column3` VARCHAR(255) NOT NULL DEFAULT 'test', PRIMARY KEY (`id`)) ENGINE = InnoDB CHARACTER SET utf8mb4 COLLATE {$collation};
@@ -2293,11 +2296,7 @@ OUTPUT;
             'column2' => 1,
         ])->save();
 
-        if ($this->usingMariaDbWithUuid()) {
-            $collation = 'utf8mb4_unicode_520_ci';
-        } else {
-            $collation = 'utf8mb4_0900_ai_ci';
-        }
+        $collation = $this->getDefaultCollation();
 
         $expectedOutput = <<<OUTPUT
 CREATE TABLE `table1` (`column1` VARCHAR(255) NOT NULL, `column2` INT(11) NULL, PRIMARY KEY (`column1`)) ENGINE = InnoDB CHARACTER SET utf8mb4 COLLATE {$collation};

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -2493,6 +2493,15 @@ INPUT;
     #[DataProvider('defaultsCastAsExpressions')]
     public function testDefaultsCastAsExpressionsForCertainTypes(string $type, string $default): void
     {
+        if ($this->usingMariaDbWithUuid() && in_array($type, [
+            MysqlAdapter::PHINX_TYPE_GEOMETRY,
+            MysqlAdapter::PHINX_TYPE_POINT,
+            MysqlAdapter::PHINX_TYPE_LINESTRING,
+            MysqlAdapter::PHINX_TYPE_POLYGON,
+        ])) {
+            $this->markTestSkipped('GIS is broken with MariaDB');
+        }
+
         $this->adapter->connect();
 
         $table = new Table('table1', ['id' => false], $this->adapter);

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -2552,7 +2552,7 @@ INPUT;
         $this->assertSame($expectedResponse['limit'], $result['limit'], "Field upper boundary mismatch - got '{$result['limit']}' when expecting '{$expectedResponse['limit']}'");
     }
 
-    public function testGetPhinxType()
+    public function testGetSqlType()
     {
         if (!$this->usingMariaDbWithUuid()) {
             $this->expectException(UnsupportedColumnTypeException::class);

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -80,7 +80,8 @@ class MysqlAdapterTest extends TestCase
     {
         $version = $this->adapter->getConnection()->getDriver()->version();
 
-        return version_compare($version, '8.0.0', '>=');
+        return version_compare($version, '8.0.0', '>=')
+            && version_compare($version, '10.0.0', '<');
     }
 
     private function usingMariaDbWithUuid(): bool
@@ -2495,7 +2496,7 @@ INPUT;
         $this->adapter->connect();
 
         $table = new Table('table1', ['id' => false], $this->adapter);
-        if (!$this->usingMysql8()) {
+        if (!$this->usingMysql8() && !$this->usingMariaDbWithUuid()) {
             $this->expectException(PDOException::class);
         }
         $table
@@ -2505,7 +2506,12 @@ INPUT;
         $columns = $this->adapter->getColumns('table1');
         $this->assertCount(1, $columns);
         $this->assertSame('col_1', $columns[0]->getName());
-        $this->assertSame($default, $columns[0]->getDefault());
+
+        if ($this->usingMariaDbWithUuid()) {
+            $this->assertSame("'{$default}'", $columns[0]->getDefault());
+        } else {
+            $this->assertSame($default, $columns[0]->getDefault());
+        }
     }
 
     public function testCreateTableWithPrecisionCurrentTimestamp()

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -1910,7 +1910,6 @@ class PostgresAdapterTest extends TestCase
         $this->assertEquals('datetime', $this->adapter->getPhinxType('timestamp without time zone'));
 
         $this->assertEquals('uuid', $this->adapter->getPhinxType('uuid'));
-        $this->assertEquals('uuid', $this->adapter->getPhinxType('nativeuuid'));
 
         $this->assertEquals('interval', $this->adapter->getPhinxType('interval'));
     }

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -343,6 +343,23 @@ class PostgresAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasColumn('ztable', 'user_id'));
     }
 
+    /**
+     * @return void
+     */
+    public function testCreateTableWithPrimaryKeyAsNativeUuid()
+    {
+        $options = [
+            'id' => false,
+            'primary_key' => 'id',
+        ];
+        $table = new Table('ztable', $options, $this->adapter);
+        $table->addColumn('id', 'nativeuuid')->save();
+        $table->addColumn('user_id', 'integer')->save();
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasIndex('ztable', 'id'));
+        $this->assertTrue($this->adapter->hasColumn('ztable', 'user_id'));
+    }
+
     public function testCreateTableWithMultipleIndexes()
     {
         $table = new Table('table1', [], $this->adapter);
@@ -1054,6 +1071,24 @@ class PostgresAdapterTest extends TestCase
         $table->addColumn('column1', 'char', ['default' => null, 'limit' => 36])
               ->save();
         $table->changeColumn('column1', 'uuid', ['default' => null, 'null' => true])
+        ->save();
+        $columns = $this->adapter->getColumns('t');
+        foreach ($columns as $column) {
+            if ($column->getName() === 'column1') {
+                $this->assertTrue($column->isNull());
+                $this->assertNull($column->getDefault());
+                $columnType = $table->getColumn('column1')->getType();
+                $this->assertSame($columnType, 'uuid');
+            }
+        }
+    }
+
+    public function testChangeColumnCharToNativeUuid()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'char', ['default' => null, 'limit' => 36])
+              ->save();
+        $table->changeColumn('column1', 'nativeuuid', ['default' => null, 'null' => true])
         ->save();
         $columns = $this->adapter->getColumns('t');
         foreach ($columns as $column) {
@@ -1875,6 +1910,7 @@ class PostgresAdapterTest extends TestCase
         $this->assertEquals('datetime', $this->adapter->getPhinxType('timestamp without time zone'));
 
         $this->assertEquals('uuid', $this->adapter->getPhinxType('uuid'));
+        $this->assertEquals('uuid', $this->adapter->getPhinxType('nativeuuid'));
 
         $this->assertEquals('interval', $this->adapter->getPhinxType('interval'));
     }

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -15,6 +15,7 @@ namespace Migrations\Test\TestCase;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
+use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
@@ -232,7 +233,10 @@ class MigrationsTest extends TestCase
         $this->assertEquals($expected, $columns);
         $createdColumn = $storesTable->getSchema()->getColumn('created');
         $expected = 'CURRENT_TIMESTAMP';
-        if ($this->Connection->getDriver() instanceof Sqlserver) {
+        $driver = $this->Connection->getDriver();
+        if ($driver instanceof Mysql && $driver->isMariadb()) {
+            $expected = 'current_timestamp()';
+        } elseif ($driver instanceof Sqlserver) {
             $expected = 'getdate()';
         }
         $this->assertEquals($expected, $createdColumn['default']);

--- a/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
+++ b/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
@@ -5,6 +5,13 @@ use Migrations\BaseMigration;
 
 class TheDiffAddRemoveMysql extends BaseMigration
 {
+    private function isMariaDB(): bool
+    {
+        $version = $this->adapter->getConnection()->getDriver()->version();
+
+        return version_compare($version, '10.0', '>=');
+    }
+
     /**
      * Up Method.
      *
@@ -29,7 +36,7 @@ class TheDiffAddRemoveMysql extends BaseMigration
         $this->table('articles')
             ->addColumn('the_text', 'text', [
                 'after' => 'title',
-                'collation' => 'utf8mb4_0900_ai_ci',
+                'collation' => $this->isMariaDB() ? 'utf8mb4_unicode_520_ci' : 'utf8mb4_0900_ai_ci',
                 'default' => null,
                 'length' => null,
                 'null' => false,

--- a/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
+++ b/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
@@ -5,13 +5,6 @@ use Migrations\BaseMigration;
 
 class TheDiffAddRemoveMysql extends BaseMigration
 {
-    private function isMariaDB(): bool
-    {
-        $version = $this->adapter->getConnection()->getDriver()->version();
-
-        return version_compare($version, '10.0', '>=');
-    }
-
     /**
      * Up Method.
      *
@@ -36,7 +29,7 @@ class TheDiffAddRemoveMysql extends BaseMigration
         $this->table('articles')
             ->addColumn('the_text', 'text', [
                 'after' => 'title',
-                'collation' => $this->isMariaDB() ? 'utf8mb4_unicode_520_ci' : 'utf8mb4_0900_ai_ci',
+                'collation' => 'utf8mb4_0900_ai_ci',
                 'default' => null,
                 'length' => null,
                 'null' => false,

--- a/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
+++ b/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
@@ -29,7 +29,7 @@ class TheDiffAddRemoveMysql extends BaseMigration
         $this->table('articles')
             ->addColumn('the_text', 'text', [
                 'after' => 'title',
-                'collation' => 'utf8mb4_0900_ai_ci',
+                'collation' => 'utf8mb4_unicode_520_ci',
                 'default' => null,
                 'length' => null,
                 'null' => false,


### PR DESCRIPTION
This is to allow the use of the native uuid for mariadb 10.7+ users. For other databases it's simply an alias to the existing uuid type. Sqlite is explicitly not supported because it doesnt have a native type.

Related Issue: https://github.com/cakephp/phinx/issues/2256

Note: To test this you need an to add 'nativeuuid' to Cake\Database\TypeFactory $_types.

Once this is accepted I can also do the change in CakePHP.

## MariaDB in CI ##
To actually test this, MariaDB was added to the CI and some MariaDB-specific issues were uncovered:

- GIS types are not working for default values (The tests are skipped for MariadB)
- on update for timestamps was not properly detected from the schema. FIXED