### PR TITLE
adjust ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup MySQL
         if: matrix.db-type == 'mysql'
@@ -137,6 +139,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Get date part for cache key
       id: key-date


### PR DESCRIPTION
I ran https://github.com/woodruffw/zizmor on the current CI config and got the following output:
```
🌈 completed ci.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/kevin/Documents/CakePHP/Org/migrations/.github/workflows/ci.yml:51:9
   |
51 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> /Users/kevin/Documents/CakePHP/Org/migrations/.github/workflows/ci.yml:139:7
    |
139 |     - uses: actions/checkout@v4
    |       ------------------------- does not set persist-credentials: false
    |
    = note: audit confidence → Low

14 findings (12 suppressed): 0 unknown, 0 informational, 0 low, 2 medium, 0 high
```