### PR TITLE
Less sprintf in adapters

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -97,6 +97,12 @@ parameters:
 			path: src/Db/Adapter/SqliteAdapter.php
 
 		-
+			message: '#^Strict comparison using \!\=\= between Cake\\Database\\StatementInterface and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: src/Db/Adapter/SqliteAdapter.php
+
+		-
 			message: '#^PHPDoc tag @return with type Phinx\\Db\\Adapter\\AdapterInterface is not subtype of native type Migrations\\Db\\Adapter\\AdapterInterface\.$#'
 			identifier: return.phpDocType
 			count: 1

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -830,6 +830,8 @@ class MysqlAdapter extends PdoAdapter
         if ($schema) {
             $query .= ' AND TABLE_SCHEMA = ?';
             $params[] = $schema;
+        } else {
+            $query .= ' AND TABLE_SCHEMA = DATABASE()';
         }
 
         $query .= ' AND TABLE_NAME = ? ORDER BY POSITION_IN_UNIQUE_CONSTRAINT';

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -751,19 +751,22 @@ class MysqlAdapter extends PdoAdapter
     public function getPrimaryKey(string $tableName): array
     {
         $options = $this->getOptions();
-        $rows = $this->fetchAll(sprintf(
+        $params = [
+            $options['database'],
+            $tableName,
+        ];
+        $rows = $this->query(
             "SELECT
                 k.CONSTRAINT_NAME,
                 k.COLUMN_NAME
             FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS t
             JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE k
                 USING(CONSTRAINT_NAME,TABLE_SCHEMA,TABLE_NAME)
-            WHERE t.CONSTRAINT_TYPE='PRIMARY KEY'
-                AND t.TABLE_SCHEMA='%s'
-                AND t.TABLE_NAME='%s'",
-            $options['database'],
-            $tableName
-        ));
+            WHERE t.CONSTRAINT_TYPE = 'PRIMARY KEY'
+                AND t.TABLE_SCHEMA = ?
+                AND t.TABLE_NAME = ?",
+            $params
+        )->fetchAll('assoc');
 
         $primaryKey = [
             'columns' => [],
@@ -814,7 +817,11 @@ class MysqlAdapter extends PdoAdapter
         }
 
         $foreignKeys = [];
-        $rows = $this->fetchAll(sprintf(
+        $params = [
+            empty($schema) ? 'DATABASE()' : "'$schema'",
+            $tableName,
+        ];
+        $rows = $this->query(
             "SELECT
               CONSTRAINT_NAME,
               CONCAT(TABLE_SCHEMA, '.', TABLE_NAME) AS TABLE_NAME,
@@ -826,9 +833,8 @@ class MysqlAdapter extends PdoAdapter
               AND TABLE_SCHEMA = %s
               AND TABLE_NAME = '%s'
             ORDER BY POSITION_IN_UNIQUE_CONSTRAINT",
-            empty($schema) ? 'DATABASE()' : "'$schema'",
-            $tableName
-        ));
+            $params
+        )->fetchAll('assoc');
         foreach ($rows as $row) {
             $foreignKeys[$row['CONSTRAINT_NAME']]['table'] = $row['TABLE_NAME'];
             $foreignKeys[$row['CONSTRAINT_NAME']]['columns'][] = $row['COLUMN_NAME'];
@@ -1270,12 +1276,10 @@ class MysqlAdapter extends PdoAdapter
      */
     public function hasDatabase(string $name): bool
     {
-        $rows = $this->fetchAll(
-            sprintf(
-                'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \'%s\'',
-                $name
-            )
-        );
+        $rows = $this->query(
+            'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?',
+            [$name]
+        )->fetchAll('assoc');
 
         foreach ($rows as $row) {
             if (!empty($row)) {
@@ -1470,16 +1474,13 @@ class MysqlAdapter extends PdoAdapter
         $options = $this->getOptions();
 
         // mysql specific
-        $sql = sprintf(
-            "SELECT *
+        $sql = "SELECT *
              FROM information_schema.tables
-             WHERE table_schema = '%s'
-             AND table_name = '%s'",
-            $options['database'],
-            $tableName
-        );
+             WHERE table_schema = ?
+             AND table_name = ?";
+        $params = [$options['database'], $tableName];
 
-        $table = $this->fetchRow($sql);
+        $table = $this->query($sql, $params)->fetch('assoc');
 
         return $table !== false ? $table : [];
     }

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -812,29 +812,31 @@ class MysqlAdapter extends PdoAdapter
      */
     protected function getForeignKeys(string $tableName): array
     {
+        $schema = null;
         if (strpos($tableName, '.') !== false) {
             [$schema, $tableName] = explode('.', $tableName);
         }
 
-        $foreignKeys = [];
-        $params = [
-            empty($schema) ? 'DATABASE()' : "'$schema'",
-            $tableName,
-        ];
-        $rows = $this->query(
-            "SELECT
+        $params = [];
+        $query = "SELECT
               CONSTRAINT_NAME,
               CONCAT(TABLE_SCHEMA, '.', TABLE_NAME) AS TABLE_NAME,
               COLUMN_NAME,
               CONCAT(REFERENCED_TABLE_SCHEMA, '.', REFERENCED_TABLE_NAME) AS REFERENCED_TABLE_NAME,
               REFERENCED_COLUMN_NAME
             FROM information_schema.KEY_COLUMN_USAGE
-            WHERE REFERENCED_TABLE_NAME IS NOT NULL
-              AND TABLE_SCHEMA = ?
-              AND TABLE_NAME = ?
-            ORDER BY POSITION_IN_UNIQUE_CONSTRAINT",
-            $params
-        )->fetchAll('assoc');
+            WHERE REFERENCED_TABLE_NAME IS NOT NULL";
+
+        if ($schema) {
+            $query .= ' AND TABLE_SCHEMA = ?';
+            $params[] = $schema;
+        }
+
+        $query .= ' AND TABLE_NAME = ? ORDER BY POSITION_IN_UNIQUE_CONSTRAINT';
+        $params[] = $tableName;
+
+        $foreignKeys = [];
+        $rows = $this->query($query, $params)->fetchAll('assoc');
         foreach ($rows as $row) {
             $foreignKeys[$row['CONSTRAINT_NAME']]['table'] = $row['TABLE_NAME'];
             $foreignKeys[$row['CONSTRAINT_NAME']]['columns'][] = $row['COLUMN_NAME'];

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -830,8 +830,8 @@ class MysqlAdapter extends PdoAdapter
               REFERENCED_COLUMN_NAME
             FROM information_schema.KEY_COLUMN_USAGE
             WHERE REFERENCED_TABLE_NAME IS NOT NULL
-              AND TABLE_SCHEMA = %s
-              AND TABLE_NAME = '%s'
+              AND TABLE_SCHEMA = ?
+              AND TABLE_NAME = ?
             ORDER BY POSITION_IN_UNIQUE_CONSTRAINT",
             $params
         )->fetchAll('assoc');

--- a/src/Db/Adapter/PdoAdapter.php
+++ b/src/Db/Adapter/PdoAdapter.php
@@ -580,7 +580,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     {
         $params = [
             $this->castToBool($state),
-                $migration->getVersion()
+            $migration->getVersion(),
         ];
         $this->query(
             sprintf(

--- a/src/Db/Adapter/PdoAdapter.php
+++ b/src/Db/Adapter/PdoAdapter.php
@@ -479,31 +479,33 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
         if (strcasecmp($direction, MigrationInterface::UP) === 0) {
             // up
             $sql = sprintf(
-                "INSERT INTO %s (%s, %s, %s, %s, %s) VALUES ('%s', '%s', '%s', '%s', %s);",
+                "INSERT INTO %s (%s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?);",
                 $this->quoteTableName($this->getSchemaTableName()),
                 $this->quoteColumnName('version'),
                 $this->quoteColumnName('migration_name'),
                 $this->quoteColumnName('start_time'),
                 $this->quoteColumnName('end_time'),
                 $this->quoteColumnName('breakpoint'),
+            );
+            $params = [
                 $migration->getVersion(),
                 substr($migration->getName(), 0, 100),
                 $startTime,
                 $endTime,
-                $this->castToBool(false)
-            );
+                $this->castToBool(false),
+            ];
 
-            $this->execute($sql);
+            $this->execute($sql, $params);
         } else {
             // down
             $sql = sprintf(
-                "DELETE FROM %s WHERE %s = '%s'",
+                'DELETE FROM %s WHERE %s = ?',
                 $this->quoteTableName($this->getSchemaTableName()),
                 $this->quoteColumnName('version'),
-                $migration->getVersion()
             );
+            $params = [$migration->getVersion()];
 
-            $this->execute($sql);
+            $this->execute($sql, $params);
         }
 
         return $this;
@@ -514,17 +516,18 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      */
     public function toggleBreakpoint(MigrationInterface $migration): AdapterInterface
     {
+        $params = [
+            $migration->getVersion(),
+        ];
         $this->query(
             sprintf(
-                'UPDATE %1$s SET %2$s = CASE %2$s WHEN %3$s THEN %4$s ELSE %3$s END, %7$s = %7$s WHERE %5$s = \'%6$s\';',
+                'UPDATE %1$s SET %2$s = CASE %2$s WHEN true THEN false ELSE true END, %4$s = %4$s WHERE %3$s = ?;',
                 $this->quoteTableName($this->getSchemaTableName()),
                 $this->quoteColumnName('breakpoint'),
-                $this->castToBool(true),
-                $this->castToBool(false),
                 $this->quoteColumnName('version'),
-                $migration->getVersion(),
                 $this->quoteColumnName('start_time')
-            )
+            ),
+            $params
         );
 
         return $this;
@@ -575,16 +578,19 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      */
     protected function markBreakpoint(MigrationInterface $migration, bool $state): AdapterInterface
     {
+        $params = [
+            $this->castToBool($state),
+                $migration->getVersion()
+        ];
         $this->query(
             sprintf(
-                'UPDATE %1$s SET %2$s = %3$s, %4$s = %4$s WHERE %5$s = \'%6$s\';',
+                'UPDATE %1$s SET %2$s = ?, %3$s = %3$s WHERE %4$s = ?;',
                 $this->quoteTableName($this->getSchemaTableName()),
                 $this->quoteColumnName('breakpoint'),
-                $this->castToBool($state),
                 $this->quoteColumnName('start_time'),
                 $this->quoteColumnName('version'),
-                $migration->getVersion()
-            )
+            ),
+            $params
         );
 
         return $this;

--- a/src/Db/Adapter/PdoAdapter.php
+++ b/src/Db/Adapter/PdoAdapter.php
@@ -479,7 +479,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
         if (strcasecmp($direction, MigrationInterface::UP) === 0) {
             // up
             $sql = sprintf(
-                "INSERT INTO %s (%s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?);",
+                'INSERT INTO %s (%s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?);',
                 $this->quoteTableName($this->getSchemaTableName()),
                 $this->quoteColumnName('version'),
                 $this->quoteColumnName('migration_name'),

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -496,16 +496,15 @@ class PostgresAdapter extends PdoAdapter
         string $newColumnName
     ): AlterInstructions {
         $parts = $this->getSchemaName($tableName);
-        $sql = sprintf(
-            'SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END AS column_exists
+        $sql = 'SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END AS column_exists
              FROM information_schema.columns
-             WHERE table_schema = %s AND table_name = %s AND column_name = %s',
-            $this->quoteString($parts['schema']),
-            $this->quoteString($parts['table']),
-            $this->quoteString($columnName)
-        );
-
-        $result = $this->fetchRow($sql);
+             WHERE table_schema = ? AND table_name = ? AND column_name = ?';
+        $params = [
+            $parts['schema'],
+            $parts['table'],
+            $columnName,
+        ];
+        $result = $this->query($sql, $params)->fetch('assoc');
         if (!$result || !(bool)$result['column_exists']) {
             throw new InvalidArgumentException("The specified column does not exist: $columnName");
         }
@@ -833,7 +832,11 @@ class PostgresAdapter extends PdoAdapter
     public function getPrimaryKey(string $tableName): array
     {
         $parts = $this->getSchemaName($tableName);
-        $rows = $this->fetchAll(sprintf(
+        $params = [
+            $parts['schema'],
+            $parts['table'],
+        ];
+        $rows = $this->query(
             "SELECT
                     tc.constraint_name,
                     kcu.column_name
@@ -841,12 +844,11 @@ class PostgresAdapter extends PdoAdapter
                 JOIN information_schema.key_column_usage AS kcu
                     ON tc.constraint_name = kcu.constraint_name
                 WHERE constraint_type = 'PRIMARY KEY'
-                    AND tc.table_schema = %s
-                    AND tc.table_name = %s
+                    AND tc.table_schema = ?
+                    AND tc.table_name = ?
                 ORDER BY kcu.position_in_unique_constraint",
-            $this->quoteString($parts['schema']),
-            $this->quoteString($parts['table'])
-        ));
+            $params,
+        )->fetchAll('assoc');
 
         $primaryKey = [
             'columns' => [],
@@ -896,7 +898,11 @@ class PostgresAdapter extends PdoAdapter
     {
         $parts = $this->getSchemaName($tableName);
         $foreignKeys = [];
-        $rows = $this->fetchAll(sprintf(
+        $params = [
+            $parts['schema'],
+            $parts['table'],
+        ];
+        $rows = $this->query(
             "SELECT
                     tc.constraint_name,
                     tc.table_name, kcu.column_name,
@@ -906,11 +912,10 @@ class PostgresAdapter extends PdoAdapter
                     information_schema.table_constraints AS tc
                     JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name
                     JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name
-                WHERE constraint_type = 'FOREIGN KEY' AND tc.table_schema = %s AND tc.table_name = %s
+                WHERE constraint_type = 'FOREIGN KEY' AND tc.table_schema = ? AND tc.table_name = ?
                 ORDER BY kcu.ordinal_position",
-            $this->quoteString($parts['schema']),
-            $this->quoteString($parts['table'])
-        ));
+            $params,
+        )->fetchAll('assoc');
         foreach ($rows as $row) {
             $foreignKeys[$row['constraint_name']]['table'] = $row['table_name'];
             $foreignKeys[$row['constraint_name']]['columns'][] = $row['column_name'];
@@ -1384,13 +1389,8 @@ class PostgresAdapter extends PdoAdapter
      */
     public function hasSchema(string $schemaName): bool
     {
-        $sql = sprintf(
-            'SELECT count(*)
-             FROM pg_namespace
-             WHERE nspname = %s',
-            $this->quoteString($schemaName)
-        );
-        $result = $this->fetchRow($sql);
+        $sql = 'SELECT count(*) FROM pg_namespace WHERE nspname = ?';
+        $result = $this->query($sql, [$schemaName])->fetch('assoc');
         if (!$result) {
             return false;
         }

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -327,7 +327,11 @@ class SqliteAdapter extends PdoAdapter
                 $master = sprintf('%s.%s', $this->quoteColumnName($schema), 'sqlite_master');
             }
             try {
-                $rows = $this->fetchAll(sprintf("SELECT name FROM %s WHERE type='table' AND lower(name) = %s", $master, $this->quoteString($table)));
+                $params = [$table];
+                $rows = $this->query(
+                    "SELECT name FROM {$master} WHERE type = 'table' AND lower(name) = ?",
+                    $params
+                )->fetchAll('assoc');
             } catch (PDOException $e) {
                 // an exception can occur if the schema part of the table refers to a database which is not attached
                 break;
@@ -797,19 +801,17 @@ PCRE_PATTERN;
             $state['indices'] = [];
             $state['triggers'] = [];
 
-            $rows = $this->fetchAll(
-                sprintf(
-                    "
-                        SELECT *
-                        FROM sqlite_master
-                        WHERE
-                            (`type` = 'index' OR `type` = 'trigger')
-                            AND tbl_name = %s
-                            AND sql IS NOT NULL
-                    ",
-                    $this->quoteValue($tableName)
-                )
-            );
+            $params = [$tableName];
+            $rows = $this->query(
+                "SELECT *
+                FROM sqlite_master
+                WHERE
+                    (`type` = 'index' OR `type` = 'trigger')
+                    AND tbl_name = ?
+                    AND sql IS NOT NULL
+                ",
+                $params
+            )->fetchAll('assoc');
 
             $schema = $this->getSchemaName($tableName, true)['schema'];
 

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -332,7 +332,10 @@ class SqliteAdapter extends PdoAdapter
                     "SELECT name FROM {$master} WHERE type = 'table' AND lower(name) = ?",
                     [$table]
                 );
-                $rows = $result->fetchAll('assoc');
+                // null on error
+                if ($result !== null) {
+                    $rows = $result->fetchAll('assoc');
+                }
             } catch (PDOException $e) {
                 // an exception can occur if the schema part of the table refers to a database which is not attached
                 break;

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -332,9 +332,7 @@ class SqliteAdapter extends PdoAdapter
                     "SELECT name FROM {$master} WHERE type = 'table' AND lower(name) = ?",
                     [$table]
                 );
-                if ($result) {
-                    $rows = $result->fetchAll('assoc');
-                }
+                $rows = $result->fetchAll('assoc');
             } catch (PDOException $e) {
                 // an exception can occur if the schema part of the table refers to a database which is not attached
                 break;

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -326,12 +326,15 @@ class SqliteAdapter extends PdoAdapter
             } else {
                 $master = sprintf('%s.%s', $this->quoteColumnName($schema), 'sqlite_master');
             }
+            $rows = [];
             try {
-                $params = [$table];
-                $rows = $this->query(
+                $result = $this->query(
                     "SELECT name FROM {$master} WHERE type = 'table' AND lower(name) = ?",
-                    $params
-                )->fetchAll('assoc');
+                    [$table]
+                );
+                if ($result) {
+                    $rows = $result->fetchAll('assoc');
+                }
             } catch (PDOException $e) {
                 // an exception can occur if the schema part of the table refers to a database which is not attached
                 break;

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -124,7 +124,10 @@ class SqlserverAdapter extends PdoAdapter
         }
 
         /** @var array<string, mixed> $result */
-        $result = $this->fetchRow(sprintf("SELECT count(*) as [count] FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '%s';", $tableName));
+        $result = $this->query(
+            "SELECT count(*) as [count] FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = ?",
+            [$tableName]
+        )->fetch('assoc');
 
         return $result['count'] > 0;
     }
@@ -322,7 +325,7 @@ class SqlserverAdapter extends PdoAdapter
      */
     public function getColumnComment(string $tableName, ?string $columnName): ?string
     {
-        $sql = sprintf("SELECT cast(extended_properties.[value] as nvarchar(4000)) comment
+        $sql = "SELECT cast(extended_properties.[value] as nvarchar(4000)) comment
   FROM sys.schemas
  INNER JOIN sys.tables
     ON schemas.schema_id = tables.schema_id
@@ -332,8 +335,9 @@ class SqlserverAdapter extends PdoAdapter
     ON tables.object_id = extended_properties.major_id
    AND columns.column_id = extended_properties.minor_id
    AND extended_properties.name = 'MS_Description'
-   WHERE schemas.[name] = '%s' AND tables.[name] = '%s' AND columns.[name] = '%s'", $this->schema, $tableName, (string)$columnName);
-        $row = $this->fetchRow($sql);
+   WHERE schemas.[name] = ? AND tables.[name] = ? AND columns.[name] = ?";
+        $params  = [ $this->schema, $tableName, (string)$columnName];
+        $row = $this->query($sql, $params)->fetch('assoc');
 
         if ($row) {
             return trim($row['comment']);
@@ -348,19 +352,16 @@ class SqlserverAdapter extends PdoAdapter
     public function getColumns(string $tableName): array
     {
         $columns = [];
-        $sql = sprintf(
-            "SELECT DISTINCT TABLE_SCHEMA AS [schema], TABLE_NAME as [table_name], COLUMN_NAME AS [name], DATA_TYPE AS [type],
+        $sql = "SELECT DISTINCT TABLE_SCHEMA AS [schema], TABLE_NAME as [table_name], COLUMN_NAME AS [name], DATA_TYPE AS [type],
             IS_NULLABLE AS [null], COLUMN_DEFAULT AS [default],
             CHARACTER_MAXIMUM_LENGTH AS [char_length],
             NUMERIC_PRECISION AS [precision],
             NUMERIC_SCALE AS [scale], ORDINAL_POSITION AS [ordinal_position],
             COLUMNPROPERTY(object_id(TABLE_NAME), COLUMN_NAME, 'IsIdentity') as [identity]
         FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE TABLE_NAME = '%s'
-        ORDER BY ordinal_position",
-            $tableName
-        );
-        $rows = $this->fetchAll($sql);
+        WHERE TABLE_NAME = ?
+        ORDER BY ordinal_position";
+        $rows = $this->query($sql, [$tableName])->fetchAll('assoc');
         foreach ($rows as $columnInfo) {
             try {
                 $type = $this->getPhinxType($columnInfo['type']);
@@ -415,15 +416,11 @@ class SqlserverAdapter extends PdoAdapter
      */
     public function hasColumn(string $tableName, string $columnName): bool
     {
-        $sql = sprintf(
-            "SELECT count(*) as [count]
+        $sql = "SELECT count(*) as [count]
              FROM INFORMATION_SCHEMA.COLUMNS
-             WHERE TABLE_NAME = '%s' AND COLUMN_NAME = '%s'",
-            $tableName,
-            $columnName
-        );
+             WHERE TABLE_NAME = ? AND COLUMN_NAME = ?";
         /** @var array<string, mixed> $result */
-        $result = $this->fetchRow($sql);
+        $result = $this->query($sql, [$tableName, $columnName])->fetch('assoc');
 
         return $result['count'] > 0;
     }
@@ -593,29 +590,14 @@ SQL;
      */
     protected function getDefaultConstraint(string $tableName, string $columnName): string|false
     {
-        $sql = "SELECT
-    default_constraints.name
-FROM
-    sys.all_columns
+        $sql = "SELECT default_constraints.name
+        FROM sys.all_columns
+        INNER JOIN sys.tables ON all_columns.object_id = tables.object_id
+        INNER JOIN sys.schemas ON tables.schema_id = schemas.schema_id
+        INNER JOIN sys.default_constraints ON all_columns.default_object_id = default_constraints.object_id
+        WHERE schemas.name = 'dbo' AND tables.name = ? AND all_columns.name = ?";
 
-        INNER JOIN
-    sys.tables
-        ON all_columns.object_id = tables.object_id
-
-        INNER JOIN
-    sys.schemas
-        ON tables.schema_id = schemas.schema_id
-
-        INNER JOIN
-    sys.default_constraints
-        ON all_columns.default_object_id = default_constraints.object_id
-
-WHERE
-        schemas.name = 'dbo'
-    AND tables.name = '{$tableName}'
-    AND all_columns.name = '{$columnName}'";
-
-        $rows = $this->fetchAll($sql);
+        $rows = $this->query($sql, [$tableName, $columnName])->fetchAll('assoc');
 
         return empty($rows) ? false : $rows[0]['name'];
     }
@@ -627,13 +609,14 @@ WHERE
      */
     protected function getIndexColums(string $tableId, string $indexId): array
     {
-        $sql = "SELECT AC.[name] AS [column_name]
+        $sql = 'SELECT AC.[name] AS [column_name]
 FROM sys.[index_columns] IC
   INNER JOIN sys.[all_columns] AC ON IC.[column_id] = AC.[column_id]
-WHERE AC.[object_id] = {$tableId} AND IC.[index_id] = {$indexId}  AND IC.[object_id] = {$tableId}
-ORDER BY IC.[key_ordinal];";
+WHERE AC.[object_id] = ? AND IC.[index_id] = ?  AND IC.[object_id] = ?
+ORDER BY IC.[key_ordinal]';
 
-        $rows = $this->fetchAll($sql);
+        $params = [$tableId, $indexId, $tableId];
+        $rows = $this->query($sql, $params)->fetchAll('assoc');
         $columns = [];
         foreach ($rows as $row) {
             $columns[] = strtolower($row['column_name']);
@@ -654,10 +637,10 @@ ORDER BY IC.[key_ordinal];";
         $sql = "SELECT I.[name] AS [index_name], I.[index_id] as [index_id], T.[object_id] as [table_id]
 FROM sys.[tables] AS T
   INNER JOIN sys.[indexes] I ON T.[object_id] = I.[object_id]
-WHERE T.[is_ms_shipped] = 0 AND I.[type_desc] <> 'HEAP'  AND T.[name] = '{$tableName}'
-ORDER BY T.[name], I.[index_id];";
+WHERE T.[is_ms_shipped] = 0 AND I.[type_desc] <> 'HEAP'  AND T.[name] = ?
+ORDER BY T.[name], I.[index_id]";
 
-        $rows = $this->fetchAll($sql);
+        $rows = $this->query($sql, [$tableName])->fetchAll('assoc');
         foreach ($rows as $row) {
             $columns = $this->getIndexColums($row['table_id'], $row['index_id']);
             $indexes[$row['index_name']] = ['columns' => $columns];
@@ -803,7 +786,7 @@ ORDER BY T.[name], I.[index_id];";
      */
     public function getPrimaryKey(string $tableName): array
     {
-        $rows = $this->fetchAll(sprintf(
+        $rows = $this->query(
             "SELECT
                     tc.CONSTRAINT_NAME,
                     kcu.COLUMN_NAME
@@ -813,8 +796,8 @@ ORDER BY T.[name], I.[index_id];";
                 WHERE CONSTRAINT_TYPE = 'PRIMARY KEY'
                     AND tc.TABLE_NAME = '%s'
                 ORDER BY kcu.ORDINAL_POSITION",
-            $tableName
-        ));
+            [$tableName]
+        )->fetchAll('assoc');
 
         $primaryKey = [
             'columns' => [],
@@ -863,20 +846,20 @@ ORDER BY T.[name], I.[index_id];";
     protected function getForeignKeys(string $tableName): array
     {
         $foreignKeys = [];
-        $rows = $this->fetchAll(sprintf(
+        $rows = $this->query(
             "SELECT
-                    tc.CONSTRAINT_NAME,
-                    tc.TABLE_NAME, kcu.COLUMN_NAME,
-                    ccu.TABLE_NAME AS REFERENCED_TABLE_NAME,
-                    ccu.COLUMN_NAME AS REFERENCED_COLUMN_NAME
-                FROM
-                    INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc
-                    JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
-                    JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE AS ccu ON ccu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
-                WHERE CONSTRAINT_TYPE = 'FOREIGN KEY' AND tc.TABLE_NAME = '%s'
-                ORDER BY kcu.ORDINAL_POSITION",
-            $tableName
-        ));
+                tc.CONSTRAINT_NAME,
+                tc.TABLE_NAME, kcu.COLUMN_NAME,
+                ccu.TABLE_NAME AS REFERENCED_TABLE_NAME,
+                ccu.COLUMN_NAME AS REFERENCED_COLUMN_NAME
+            FROM
+                INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc
+                JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+                JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE AS ccu ON ccu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+            WHERE CONSTRAINT_TYPE = 'FOREIGN KEY' AND tc.TABLE_NAME = ?
+            ORDER BY kcu.ORDINAL_POSITION",
+            [$tableName]
+        )->fetchAll('assoc');
         foreach ($rows as $row) {
             $foreignKeys[$row['CONSTRAINT_NAME']]['table'] = $row['TABLE_NAME'];
             $foreignKeys[$row['CONSTRAINT_NAME']]['columns'][] = $row['COLUMN_NAME'];
@@ -1086,12 +1069,10 @@ ORDER BY T.[name], I.[index_id];";
     public function hasDatabase(string $name): bool
     {
         /** @var array<string, mixed> $result */
-        $result = $this->fetchRow(
-            sprintf(
-                "SELECT count(*) as [count] FROM master.dbo.sysdatabases WHERE [name] = '%s'",
-                $name
-            )
-        );
+        $result = $this->query(
+            "SELECT count(*) as [count] FROM master.dbo.sysdatabases WHERE [name] = ?",
+            [$name]
+        )->fetch('assoc');
 
         return $result['count'] > 0;
     }

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -139,7 +139,7 @@ class SqlserverAdapter extends PdoAdapter
         $parts = $this->getSchemaName($tableName);
         /** @var array<string, mixed> $result */
         $result = $this->query(
-            "SELECT count(*) as [count] FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?",
+            'SELECT count(*) as [count] FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?',
             [$parts['schema'], $parts['table']]
         )->fetch('assoc');
 
@@ -351,7 +351,7 @@ class SqlserverAdapter extends PdoAdapter
    AND columns.column_id = extended_properties.minor_id
    AND extended_properties.name = 'MS_Description'
    WHERE schemas.[name] = ? AND tables.[name] = ? AND columns.[name] = ?";
-        $params  = [ $this->schema, $tableName, (string)$columnName];
+        $params = [$this->schema, $tableName, (string)$columnName];
         $row = $this->query($sql, $params)->fetch('assoc');
 
         if ($row) {
@@ -1095,7 +1095,7 @@ ORDER BY T.[name], I.[index_id]";
     {
         /** @var array<string, mixed> $result */
         $result = $this->query(
-            "SELECT count(*) as [count] FROM master.dbo.sysdatabases WHERE [name] = ?",
+            'SELECT count(*) as [count] FROM master.dbo.sysdatabases WHERE [name] = ?',
             [$name]
         )->fetch('assoc');
 
@@ -1257,13 +1257,8 @@ SQL;
      */
     public function hasSchema(string $schemaName): bool
     {
-        $sql = sprintf(
-            'SELECT count(*) AS [count]
-             FROM sys.schemas
-             WHERE name = %s',
-            $this->quoteString($schemaName)
-        );
-        $result = $this->fetchRow($sql);
+        $sql = 'SELECT count(*) AS [count] FROM sys.schemas WHERE name = ?';
+        $result = $this->query($sql, [$schemaName])->fetch('assoc');
         if (!$result) {
             return false;
         }

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -375,8 +375,7 @@ class SqlserverAdapter extends PdoAdapter
             NUMERIC_SCALE AS [scale], ORDINAL_POSITION AS [ordinal_position],
             COLUMNPROPERTY(object_id(TABLE_NAME), COLUMN_NAME, 'IsIdentity') as [identity]
         FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE TABLE_SCHEMA = ?
-        WHERE TABLE_NAME = ?
+        WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
         ORDER BY ordinal_position";
         $rows = $this->query($sql, [$parts['schema'], $parts['table']])
             ->fetchAll('assoc');

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -816,8 +816,8 @@ ORDER BY T.[name], I.[index_id]";
                 JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu
                     ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
                 WHERE CONSTRAINT_TYPE = 'PRIMARY KEY'
-                    AND tc.CONSTRAINT_SCHEMA = '%s'
-                    AND tc.TABLE_NAME = '%s'
+                    AND tc.CONSTRAINT_SCHEMA = ?
+                    AND tc.TABLE_NAME = ?
                 ORDER BY kcu.ORDINAL_POSITION",
             [$parts['schema'], $parts['table']]
         )->fetchAll('assoc');

--- a/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
@@ -170,7 +170,7 @@ class BakeMigrationDiffCommandTest extends TestCase
      */
     public function testBakingDiffWithAutoIdCompatibleSignedPrimaryKeys(): void
     {
-        $this->skipIf(getenv('DB_URL_COMPARE') === false);
+        $this->skipIf(!env('DB_URL_COMPARE'));
 
         Configure::write('Migrations.unsigned_primary_keys', false);
 
@@ -183,7 +183,7 @@ class BakeMigrationDiffCommandTest extends TestCase
      */
     public function testBakingDiffWithAutoIdIncompatibleSignedPrimaryKeys(): void
     {
-        $this->skipIf(getenv('DB_URL_COMPARE') === false);
+        $this->skipIf(!env('DB_URL_COMPARE'));
 
         $this->runDiffBakingTest('WithAutoIdIncompatibleSignedPrimaryKeys');
     }
@@ -194,7 +194,7 @@ class BakeMigrationDiffCommandTest extends TestCase
      */
     public function testBakingDiffWithAutoIdIncompatibleUnsignedPrimaryKeys(): void
     {
-        $this->skipIf(getenv('DB_URL_COMPARE') === false);
+        $this->skipIf(!env('DB_URL_COMPARE'));
 
         Configure::write('Migrations.unsigned_primary_keys', false);
 
@@ -203,6 +203,8 @@ class BakeMigrationDiffCommandTest extends TestCase
 
     protected function runDiffBakingTest(string $scenario): void
     {
+        $this->skipIf(!env('DB_URL_COMPARE'));
+
         $diffConfigFolder = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Diff' . DS . lcfirst($scenario) . DS;
         $diffMigrationsPath = $diffConfigFolder . 'the_diff_' . Inflector::underscore($scenario) . '_' . env('DB') . '.php';
         $diffDumpPath = $diffConfigFolder . 'schema-dump-test_comparisons_' . env('DB') . '.lock';

--- a/tests/TestCase/Migration/EnvironmentTest.php
+++ b/tests/TestCase/Migration/EnvironmentTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Test\Phinx\Migration;
+namespace Migrations\Test\TestCase\Migration;
 
 use Cake\Console\ConsoleIo;
 use Cake\Datasource\ConnectionManager;

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -1070,6 +1070,8 @@ class MigrationsTest extends TestCase
             // type is supported by migrations.
             $this->markTestSkipped('Incompatible with sqlserver right now.');
         }
+        $snapshotConfig = ConnectionManager::getConfig('test_snapshot');
+        $this->skipIf(empty($snapshotConfig['database']), 'Requires test_snapshot connection');
 
         if ($flags) {
             Configure::write('Migrations', $flags + Configure::read('Migrations', []));


### PR DESCRIPTION
Reduce the amount of `sprintf` we use to build queries. While it can't be entirely eliminated as prepared statements can't work with many DDL operations, our select and update calls can use prepared statements.