### PR TITLE
Add Table::foreignKey()

### DIFF
--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -28,6 +28,7 @@ use Migrations\Db\Adapter\AdapterInterface;
 use Migrations\Db\Plan\Intent;
 use Migrations\Db\Plan\Plan;
 use Migrations\Db\Table\Column;
+use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use Migrations\Db\Table\Table as TableValue;
 use RuntimeException;
@@ -479,18 +480,36 @@ class Table
      * In $options you can specify on_delete|on_delete = cascade|no_action ..,
      * on_update, constraint = constraint name.
      *
-     * @param string|string[] $columns Columns
+     * @param string|string[]|\Migrations\Db\Table\ForeignKey $columns Columns
      * @param string|\Migrations\Db\Table\Table $referencedTable Referenced Table
      * @param string|string[] $referencedColumns Referenced Columns
      * @param array<string, mixed> $options Options
      * @return $this
      */
-    public function addForeignKey(string|array $columns, string|TableValue $referencedTable, string|array $referencedColumns = ['id'], array $options = [])
+    public function addForeignKey(string|array|ForeignKey $columns, string|TableValue|null $referencedTable = null, string|array $referencedColumns = ['id'], array $options = [])
     {
-        $action = AddForeignKey::build($this->table, $columns, $referencedTable, $referencedColumns, $options);
+        if ($columns instanceof ForeignKey) {
+            $action = new AddForeignKey($this->table, $columns);
+        } else {
+            if (!$referencedTable) {
+                throw new InvalidArgumentException('Referenced table is required');
+            }
+            $action = AddForeignKey::build($this->table, $columns, $referencedTable, $referencedColumns, $options);
+        }
         $this->actions->addAction($action);
 
         return $this;
+    }
+
+    /**
+     * Create a new ForeignKey object.
+     *
+     * @params string|string[] $columns Columns
+     * @return \Migrations\Db\Table\ForeignKey
+     */
+    public function foreignKey(string|array $columns): ForeignKey
+    {
+        return (new ForeignKey())->setColumns($columns);
     }
 
     /**
@@ -499,23 +518,37 @@ class Table
      * In $options you can specify on_delete|on_delete = cascade|no_action ..,
      * on_update, constraint = constraint name.
      *
-     * @param string $name The constraint name
+     * @param string|\Migrations\Db\Table\ForeignKey $name The constraint name or a foreign key object.
      * @param string|string[] $columns Columns
      * @param string|\Migrations\Db\Table\Table $referencedTable Referenced Table
      * @param string|string[] $referencedColumns Referenced Columns
      * @param array<string, mixed> $options Options
      * @return $this
      */
-    public function addForeignKeyWithName(string $name, string|array $columns, string|TableValue $referencedTable, string|array $referencedColumns = ['id'], array $options = [])
-    {
-        $action = AddForeignKey::build(
-            $this->table,
-            $columns,
-            $referencedTable,
-            $referencedColumns,
-            $options,
-            $name
-        );
+    public function addForeignKeyWithName(
+        string|ForeignKey $name,
+        string|array|null $columns = null,
+        string|TableValue|null $referencedTable = null,
+        string|array $referencedColumns = ['id'],
+        array $options = []
+    ) {
+        if (is_string($name)) {
+            if ($columns === null || $referencedTable === null) {
+                throw new InvalidArgumentException(
+                    'Columns and referencedTable are required when adding a foreign key with a name'
+                );
+            }
+            $action = AddForeignKey::build(
+                $this->table,
+                $columns,
+                $referencedTable,
+                $referencedColumns,
+                $options,
+                $name
+            );
+        } else {
+            $action = new AddForeignKey($this->table, $name);
+        }
         $this->actions->addAction($action);
 
         return $this;

--- a/src/Db/Table/Column.php
+++ b/src/Db/Table/Column.php
@@ -62,7 +62,7 @@ class Column
     /**
      * @var string
      */
-    protected string $name;
+    protected string $name = '';
 
     /**
      * @var string|\Migrations\Db\Literal

--- a/src/Db/Table/ForeignKey.php
+++ b/src/Db/Table/ForeignKey.php
@@ -10,7 +10,15 @@ namespace Migrations\Db\Table;
 
 use InvalidArgumentException;
 use RuntimeException;
+use function Cake\Core\deprecationWarning;
 
+/**
+ * Foreign key value object
+ *
+ * Used to define foreign keys that are added to tables as part of migrations.
+ *
+ * @see \Migrations\Db\Table::addForeignKey()
+ */
 class ForeignKey
 {
     public const CASCADE = 'CASCADE';
@@ -24,7 +32,7 @@ class ForeignKey
     /**
      * @var array<string>
      */
-    protected static array $validOptions = ['delete', 'update', 'constraint', 'deferrable'];
+    protected static array $validOptions = ['delete', 'update', 'constraint', 'name', 'deferrable'];
 
     /**
      * @var string[]
@@ -54,7 +62,7 @@ class ForeignKey
     /**
      * @var string|null
      */
-    protected ?string $constraint = null;
+    protected ?string $name = null;
 
     /**
      * @var string|null
@@ -87,11 +95,14 @@ class ForeignKey
     /**
      * Sets the foreign key referenced table.
      *
-     * @param \Migrations\Db\Table\Table $table The table this KEY is pointing to
+     * @param \Migrations\Db\Table\Table|string $table The table this KEY is pointing to
      * @return $this
      */
-    public function setReferencedTable(Table $table)
+    public function setReferencedTable(Table|string $table)
     {
+        if (is_string($table)) {
+            $table = new Table($table);
+        }
         $this->referencedTable = $table;
 
         return $this;
@@ -177,6 +188,29 @@ class ForeignKey
     }
 
     /**
+     * Set the constraint name for the foreign key.
+     *
+     * @param string $name Constraint name
+     * @return $this
+     */
+    public function setName(string $name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Get the constraint name if set.
+     *
+     * @return string|null
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
      * Sets constraint for the foreign key.
      *
      * @param string $constraint Constraint
@@ -184,7 +218,8 @@ class ForeignKey
      */
     public function setConstraint(string $constraint)
     {
-        $this->constraint = $constraint;
+        deprecationWarning('4.6.0', 'setConstraint() is deprecated. Use setName() instead.');
+        $this->name = $constraint;
 
         return $this;
     }
@@ -196,7 +231,9 @@ class ForeignKey
      */
     public function getConstraint(): ?string
     {
-        return $this->constraint;
+        deprecationWarning('4.6.0', 'getConstraint() is deprecated. Use getName() instead.');
+
+        return $this->name;
     }
 
     /**

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -1518,6 +1518,27 @@ class PostgresAdapterTest extends TestCase
         $this->adapter->dropSchema('schema2');
     }
 
+    public function testAddForeignKeyDeferrable()
+    {
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable->addColumn('field1', 'string')->save();
+
+        $table = new Table('table', [], $this->adapter);
+        $table
+            ->addColumn('ref_table_id', 'integer')
+            ->addForeignKey(
+                ['ref_table_id'],
+                'ref_table',
+                ['id'],
+                [
+                    'deferrable' => 'DEFERRED',
+                ]
+            )
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
+    }
+
     public function testDropForeignKey()
     {
         $refTable = new Table('ref_table', [], $this->adapter);

--- a/tests/TestCase/Db/Table/ForeignKeyTest.php
+++ b/tests/TestCase/Db/Table/ForeignKeyTest.php
@@ -21,6 +21,13 @@ class ForeignKeyTest extends TestCase
         $this->fk = new ForeignKey();
     }
 
+    public function testName(): void
+    {
+        $this->assertNull($this->fk->getName());
+        $this->assertSame($this->fk, $this->fk->setName('fk_name'));
+        $this->assertEquals('fk_name', $this->fk->getName());
+    }
+
     public function testOnDeleteSetNullCanBeSetThroughOptions()
     {
         $this->assertEquals(

--- a/tests/TestCase/Db/Table/TableTest.php
+++ b/tests/TestCase/Db/Table/TableTest.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 namespace Migrations\Test\TestCase\Db\Table;
 
 use InvalidArgumentException;
-use Phinx\Db\Action\DropIndex;
-use Phinx\Db\Adapter\AdapterInterface;
-use Phinx\Db\Adapter\MysqlAdapter;
-use Phinx\Db\Adapter\PostgresAdapter;
-use Phinx\Db\Adapter\SQLiteAdapter;
-use Phinx\Db\Adapter\SqlServerAdapter;
-use Phinx\Db\Table;
-use Phinx\Db\Table\Column;
-use Phinx\Db\Table\Index;
+use Migrations\Db\Action\AddColumn;
+use Migrations\Db\Action\AddForeignKey;
+use Migrations\Db\Action\AddIndex;
+use Migrations\Db\Action\DropIndex;
+use Migrations\Db\Adapter\AdapterInterface;
+use Migrations\Db\Adapter\MysqlAdapter;
+use Migrations\Db\Adapter\PostgresAdapter;
+use Migrations\Db\Adapter\SQLiteAdapter;
+use Migrations\Db\Adapter\SqlServerAdapter;
+use Migrations\Db\Table;
+use Migrations\Db\Table\Column;
+use Migrations\Db\Table\Index;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
@@ -33,11 +36,11 @@ class TableTest extends TestCase
             $result = array_merge(
                 $result,
                 [
-                    [$adapter[0], null, null, 'created_at', 'updated_at', false],
+                    [$adapter[0], null, null, 'created', 'updated', false],
                     [$adapter[0], 'created_at', 'updated_at', 'created_at', 'updated_at', true],
                     [$adapter[0], 'created', 'updated', 'created', 'updated', false],
-                    [$adapter[0], null, 'amendment_date', 'created_at', 'amendment_date', true],
-                    [$adapter[0], 'insertion_date', null, 'insertion_date', 'updated_at', true],
+                    [$adapter[0], null, 'amendment_date', 'created', 'amendment_date', true],
+                    [$adapter[0], 'insertion_date', null, 'insertion_date', 'updated', true],
                 ]
             );
         }
@@ -72,7 +75,7 @@ class TableTest extends TestCase
         $table = new Table('ntable', [], $adapter);
         $table->addColumn($column);
         $actions = $this->getPendingActions($table);
-        $this->assertInstanceOf('Phinx\Db\Action\AddColumn', $actions[0]);
+        $this->assertInstanceOf(AddColumn::class, $actions[0]);
         $this->assertSame($column, $actions[0]->getColumn());
     }
 
@@ -108,17 +111,108 @@ class TableTest extends TestCase
         $table = new Table('ntable', [], $adapter);
         $table->addIndex($index);
         $actions = $this->getPendingActions($table);
-        $this->assertInstanceOf('Phinx\Db\Action\AddIndex', $actions[0]);
+        $this->assertInstanceOf(AddIndex::class, $actions[0]);
         $this->assertSame($index, $actions[0]->getIndex());
+    }
+
+    public function testAddForeignKeyPositionalParameters(): void
+    {
+        $adapter = new MysqlAdapter([]);
+        $table = new Table('ntable', [], $adapter);
+        $table->addForeignKey('user_id', 'users', 'id', [
+            'delete' => 'CASCADE',
+            'update' => 'CASCADE',
+            'name' => 'fk_user_id',
+        ]);
+
+        $actions = $this->getPendingActions($table);
+        $this->assertInstanceOf(AddForeignKey::class, $actions[0]);
+        $key = $actions[0]->getForeignKey();
+        $this->assertSame($key->getReferencedTable()->getName(), 'users');
+        $this->assertSame($key->getReferencedColumns(), ['id']);
+        $this->assertSame($key->getColumns(), ['user_id']);
+        $this->assertSame($key->getName(), 'fk_user_id');
+    }
+
+    public function testAddForeignKeyWithObject(): void
+    {
+        $adapter = new MysqlAdapter([]);
+        $table = new Table('ntable', [], $adapter);
+        $table->addForeignKey(
+            $table->foreignKey('user_id')
+                ->setReferencedTable('users')
+                ->setReferencedColumns(['id'])
+                ->setOnDelete('CASCADE')
+                ->setOnUpdate('CASCADE')
+                ->setName('fk_user_id')
+        );
+
+        $actions = $this->getPendingActions($table);
+        $this->assertInstanceOf(AddForeignKey::class, $actions[0]);
+        $key = $actions[0]->getForeignKey();
+        $this->assertSame($key->getReferencedTable()->getName(), 'users');
+        $this->assertSame($key->getReferencedColumns(), ['id']);
+        $this->assertSame($key->getColumns(), ['user_id']);
+        $this->assertSame($key->getName(), 'fk_user_id');
+    }
+
+    public function testAddForeignKeyWithNamePositionalParameters(): void
+    {
+        $adapter = new MysqlAdapter([]);
+        $table = new Table('ntable', [], $adapter);
+        $table->addForeignKeyWithName('fk_user_id', 'user_id', 'users', 'id', [
+            'delete' => 'CASCADE',
+            'update' => 'CASCADE',
+        ]);
+
+        $actions = $this->getPendingActions($table);
+        $this->assertInstanceOf(AddForeignKey::class, $actions[0]);
+        $key = $actions[0]->getForeignKey();
+        $this->assertSame($key->getReferencedTable()->getName(), 'users');
+        $this->assertSame($key->getReferencedColumns(), ['id']);
+        $this->assertSame($key->getColumns(), ['user_id']);
+        $this->assertSame($key->getName(), 'fk_user_id');
+    }
+
+    public function testAddForeignKeyWithNameObject(): void
+    {
+        $adapter = new MysqlAdapter([]);
+        $table = new Table('ntable', [], $adapter);
+        $table->addForeignKeyWithName(
+            $table->foreignKey('user_id')
+                ->setReferencedTable('users')
+                ->setReferencedColumns(['id'])
+                ->setOnDelete('CASCADE')
+                ->setOnUpdate('CASCADE')
+                ->setName('fk_user_id')
+        );
+
+        $actions = $this->getPendingActions($table);
+        $this->assertInstanceOf(AddForeignKey::class, $actions[0]);
+        $key = $actions[0]->getForeignKey();
+        $this->assertSame($key->getReferencedTable()->getName(), 'users');
+        $this->assertSame($key->getReferencedColumns(), ['id']);
+        $this->assertSame($key->getColumns(), ['user_id']);
+        $this->assertSame($key->getName(), 'fk_user_id');
     }
 
     /**
      * @param AdapterInterface $adapter
-     * @param string|null      $createdAtColumnName * @param string|null      $updatedAtColumnName * @param string           $expectedCreatedAtColumnName * @param string           $expectedUpdatedAtColumnName * @param bool $withTimezone
+     * @param string|null      $createdAtColumnName
+     * @param string|null      $updatedAtColumnName
+     * @param string           $expectedCreatedAtColumnName
+     * @param string           $expectedUpdatedAtColumnName
+     * @param bool $withTimezone
      */
     #[DataProvider('provideTimestampColumnNames')]
-    public function testAddTimestamps(AdapterInterface $adapter, $createdAtColumnName, $updatedAtColumnName, $expectedCreatedAtColumnName, $expectedUpdatedAtColumnName, $withTimezone)
-    {
+    public function testAddTimestamps(
+        AdapterInterface $adapter,
+        $createdAtColumnName,
+        $updatedAtColumnName,
+        $expectedCreatedAtColumnName,
+        $expectedUpdatedAtColumnName,
+        $withTimezone
+    ): void {
         $table = new Table('ntable', [], $adapter);
         $table->addTimestamps($createdAtColumnName, $updatedAtColumnName, $withTimezone);
         $actions = $this->getPendingActions($table);
@@ -161,7 +255,7 @@ class TableTest extends TestCase
 
         $this->assertCount(1, $columns);
 
-        $this->assertSame('created_at', $columns[0]->getName());
+        $this->assertSame('created', $columns[0]->getName());
         $this->assertSame('timestamp', $columns[0]->getType());
         $this->assertSame('CURRENT_TIMESTAMP', $columns[0]->getDefault());
         $this->assertFalse($columns[0]->getTimezone());
@@ -186,7 +280,7 @@ class TableTest extends TestCase
 
         $this->assertCount(1, $columns);
 
-        $this->assertSame('updated_at', $columns[0]->getName());
+        $this->assertSame('updated', $columns[0]->getName());
         $this->assertSame('timestamp', $columns[0]->getType());
         $this->assertFalse($columns[0]->getTimezone());
         $this->assertSame('CURRENT_TIMESTAMP', $columns[0]->getUpdate());
@@ -215,8 +309,14 @@ class TableTest extends TestCase
      * @param bool $withTimezone
      */
     #[DataProvider('provideTimestampColumnNames')]
-    public function testAddTimestampsWithTimezone(AdapterInterface $adapter, $createdAtColumnName, $updatedAtColumnName, $expectedCreatedAtColumnName, $expectedUpdatedAtColumnName, $withTimezone)
-    {
+    public function testAddTimestampsWithTimezone(
+        AdapterInterface $adapter,
+        $createdAtColumnName,
+        $updatedAtColumnName,
+        $expectedCreatedAtColumnName,
+        $expectedUpdatedAtColumnName,
+        $withTimezone
+    ): void {
         $table = new Table('ntable', [], $adapter);
         $table->addTimestampsWithTimezone($createdAtColumnName, $updatedAtColumnName);
         $actions = $this->getPendingActions($table);
@@ -243,7 +343,7 @@ class TableTest extends TestCase
 
     public function testInsert()
     {
-        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+        $adapterStub = $this->getMockBuilder(MysqlAdapter::class)
             ->setConstructorArgs([[]])
             ->getMock();
         $table = new Table('ntable', [], $adapterStub);
@@ -260,7 +360,7 @@ class TableTest extends TestCase
 
     public function testInsertMultipleRowsWithoutZeroKey()
     {
-        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+        $adapterStub = $this->getMockBuilder(MysqlAdapter::class)
             ->setConstructorArgs([[]])
             ->getMock();
         $table = new Table('ntable', [], $adapterStub);
@@ -281,7 +381,7 @@ class TableTest extends TestCase
 
     public function testInsertSaveEmptyData()
     {
-        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+        $adapterStub = $this->getMockBuilder(MysqlAdapter::class)
             ->setConstructorArgs([[]])
             ->getMock();
         $table = new Table('ntable', [], $adapterStub);
@@ -293,7 +393,7 @@ class TableTest extends TestCase
 
     public function testInsertSaveData()
     {
-        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+        $adapterStub = $this->getMockBuilder(MysqlAdapter::class)
             ->setConstructorArgs([[]])
             ->getMock();
         $table = new Table('ntable', [], $adapterStub);
@@ -326,7 +426,7 @@ class TableTest extends TestCase
 
     public function testSaveAfterSaveData()
     {
-        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+        $adapterStub = $this->getMockBuilder(MysqlAdapter::class)
             ->setConstructorArgs([[]])
             ->getMock();
         $table = new Table('ntable', [], $adapterStub);
@@ -359,7 +459,7 @@ class TableTest extends TestCase
 
     public function testResetAfterAddingData()
     {
-        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+        $adapterStub = $this->getMockBuilder(MysqlAdapter::class)
             ->setConstructorArgs([[]])
             ->getMock();
         $table = new Table('ntable', [], $adapterStub);
@@ -371,7 +471,7 @@ class TableTest extends TestCase
 
     public function testPendingAfterAddingData()
     {
-        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+        $adapterStub = $this->getMockBuilder(MysqlAdapter::class)
             ->setConstructorArgs([[]])
             ->getMock();
         $table = new Table('ntable', [], $adapterStub);
@@ -383,7 +483,7 @@ class TableTest extends TestCase
 
     public function testPendingAfterAddingColumn()
     {
-        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+        $adapterStub = $this->getMockBuilder(MysqlAdapter::class)
             ->setConstructorArgs([[]])
             ->getMock();
         $adapterStub->expects($this->any())
@@ -396,7 +496,7 @@ class TableTest extends TestCase
 
     public function testGetColumn()
     {
-        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+        $adapterStub = $this->getMockBuilder(MysqlAdapter::class)
             ->setConstructorArgs([[]])
             ->getMock();
 
@@ -421,11 +521,8 @@ class TableTest extends TestCase
     #[DataProvider('removeIndexDataprovider')]
     public function testRemoveIndex($indexIdentifier, Index $index)
     {
-        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
-            ->setConstructorArgs([[]])
-            ->getMock();
-
-        $table = new Table('table', [], $adapterStub);
+        $adapter = new MysqlAdapter([]);
+        $table = new Table('table', [], $adapter);
         $table->removeIndex($indexIdentifier);
 
         $indexes = array_map(function (DropIndex $action) {

--- a/tests/TestCase/Db/Table/TableTest.php
+++ b/tests/TestCase/Db/Table/TableTest.php
@@ -11,8 +11,8 @@ use Migrations\Db\Action\DropIndex;
 use Migrations\Db\Adapter\AdapterInterface;
 use Migrations\Db\Adapter\MysqlAdapter;
 use Migrations\Db\Adapter\PostgresAdapter;
-use Migrations\Db\Adapter\SQLiteAdapter;
-use Migrations\Db\Adapter\SqlServerAdapter;
+use Migrations\Db\Adapter\SqliteAdapter;
+use Migrations\Db\Adapter\SqlserverAdapter;
 use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\Index;
@@ -23,12 +23,12 @@ use RuntimeException;
 
 class TableTest extends TestCase
 {
-    public static function provideAdapters()
+    public static function provideAdapters(): array
     {
-        return [[new SqlServerAdapter([])], [new MysqlAdapter([])], [new PostgresAdapter([])], [new SQLiteAdapter(['name' => ':memory:'])]];
+        return [[new SqlserverAdapter([])], [new MysqlAdapter([])], [new PostgresAdapter([])], [new SqliteAdapter(['name' => ':memory:'])]];
     }
 
-    public static function provideTimestampColumnNames()
+    public static function provideTimestampColumnNames(): array
     {
         $result = [];
         $adapters = static::provideAdapters();


### PR DESCRIPTION
Add a factory method that allows the `ForeignKey` fluent method API to be used to define foreign keys instead of having to remember all the positional parameters.

I'm considering deprecating `addForeignKeyWithName` as setting a name on a foreign key is simpler with the new builder method.

Refs #770
