### PR TITLE
Update migration generation and docs to use foreignKey()

### DIFF
--- a/docs/en/writing-migrations.rst
+++ b/docs/en/writing-migrations.rst
@@ -1438,73 +1438,66 @@ Let's add a foreign key to an example table:
         }
 
 "On delete" and "On update" actions are defined with a 'delete' and 'update' options array. Possibles values are 'SET_NULL', 'NO_ACTION', 'CASCADE' and 'RESTRICT'.  If 'SET_NULL' is used then the column must be created as nullable with the option ``['null' => true]``.
-Constraint name can be changed with the 'constraint' option.
 
-It is also possible to pass ``addForeignKey()`` an array of columns.
-This allows us to establish a foreign key relationship to a table which uses a combined key.
+Foreign keys can be defined with arrays of columns to build constraints between
+tables with composite keys::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        public function up()
         {
-            /**
-             * Migrate Up.
-             */
-            public function up()
-            {
-                $table = $this->table('follower_events');
-                $table->addColumn('user_id', 'integer')
-                      ->addColumn('follower_id', 'integer')
-                      ->addColumn('event_id', 'integer')
-                      ->addForeignKey(['user_id', 'follower_id'],
-                                      'followers',
-                                      ['user_id', 'follower_id'],
-                                      ['delete'=> 'NO_ACTION', 'update'=> 'NO_ACTION', 'constraint' => 'user_follower_id'])
-                      ->save();
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down()
-            {
-
-            }
+            $table = $this->table('follower_events');
+            $table->addColumn('user_id', 'integer')
+                ->addColumn('follower_id', 'integer')
+                ->addColumn('event_id', 'integer')
+                ->addForeignKey(
+                    ['user_id', 'follower_id'],
+                    'followers',
+                    ['user_id', 'follower_id'],
+                    [
+                        'delete'=> 'NO_ACTION',
+                        'update'=> 'NO_ACTION',
+                        'constraint' => 'user_follower_id'
+                    ]
+                )
+                ->save();
         }
+    }
 
-We can add named foreign keys using the ``constraint`` parameter.
+Using the ``foreignKey()`` method provides a fluent builder to define a foreign
+key::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
+    use Migrations\Db\Table\ForeignKey;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up()
         {
-            /**
-             * Migrate Up.
-             */
-            public function up()
-            {
-                $table = $this->table('your_table');
-                $table->addForeignKey('foreign_id', 'reference_table', ['id'],
-                                    ['constraint' => 'your_foreign_key_name']);
-                      ->save();
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down()
-            {
-
-            }
+            $table = $this->table('articles');
+            $table->addForeignKey(
+                $this->foreignKey()
+                    ->setColumns('user_id')
+                    ->setReferencedTable('users')
+                    ->setReferencedColumns('user_id')
+                    ->setDelete(ForeignKey::CASCADE)
+                    ->setName('article_user_fk')
+            )
+            ->save();
         }
+    }
+
+.. versionadded:: 4.6.0
+   The ``foreignKey`` method was added.
 
 We can also easily check if a foreign key exists:
 

--- a/src/BaseMigration.php
+++ b/src/BaseMigration.php
@@ -17,6 +17,7 @@ use Cake\Database\Query\UpdateQuery;
 use Migrations\Config\ConfigInterface;
 use Migrations\Db\Adapter\AdapterInterface;
 use Migrations\Db\Table;
+use Migrations\Db\Table\ForeignKey;
 use RuntimeException;
 
 /**
@@ -422,6 +423,17 @@ class BaseMigration implements MigrationInterface
         $this->tables[] = $table;
 
         return $table;
+    }
+
+    /**
+     * Create a new ForeignKey object.
+     *
+     * @params string|string[] $columns Columns
+     * @return \Migrations\Db\Table\ForeignKey
+     */
+    public function foreignKey(string|array $columns): ForeignKey
+    {
+        return (new ForeignKey())->setColumns($columns);
     }
 
     /**

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -502,17 +502,6 @@ class Table
     }
 
     /**
-     * Create a new ForeignKey object.
-     *
-     * @params string|string[] $columns Columns
-     * @return \Migrations\Db\Table\ForeignKey
-     */
-    public function foreignKey(string|array $columns): ForeignKey
-    {
-        return (new ForeignKey())->setColumns($columns);
-    }
-
-    /**
      * Add a foreign key to a database table with a given name.
      *
      * In $options you can specify on_delete|on_delete = cascade|no_action ..,

--- a/src/Db/Table/ForeignKey.php
+++ b/src/Db/Table/ForeignKey.php
@@ -17,6 +17,7 @@ use function Cake\Core\deprecationWarning;
  *
  * Used to define foreign keys that are added to tables as part of migrations.
  *
+ * @see \Migrations\Db\Table::foreignKey()
  * @see \Migrations\Db\Table::addForeignKey()
  */
 class ForeignKey
@@ -121,11 +122,12 @@ class ForeignKey
     /**
      * Sets the foreign key referenced columns.
      *
-     * @param string[] $referencedColumns Referenced columns
+     * @param string|string[] $referencedColumns Referenced columns
      * @return $this
      */
-    public function setReferencedColumns(array $referencedColumns)
+    public function setReferencedColumns(array|string $referencedColumns)
     {
+        $referencedColumns = is_string($referencedColumns) ? [$referencedColumns] : $referencedColumns;
         $this->referencedColumns = $referencedColumns;
 
         return $this;

--- a/templates/bake/config/diff.twig
+++ b/templates/bake/config/diff.twig
@@ -14,7 +14,6 @@
 */
 #}
 {% set tables = data['fullTables'] %}
-{# unset($data['fullTables']) #}
 {% set constraints = [] %}
 {% set autoId = not Migration.hasAutoIdIncompatiblePrimaryKey(tables['add'] + tables['remove']) %}
 <?php
@@ -112,7 +111,7 @@ not empty %}
 
 {{ Migration.element(
                 'Migrations.add-foreign-keys',
-                {'constraints': tableDiff['constraints']['add'], 'table': tableName}
+                {'constraints': tableDiff['constraints']['add'], 'table': tableName, 'backend': backend}
             ) | raw -}}
 {%        endif -%}
 {%    endfor -%}

--- a/templates/bake/config/snapshot.twig
+++ b/templates/bake/config/snapshot.twig
@@ -48,7 +48,8 @@ class {{ name }} extends AbstractMigration
 {{~ element('Migrations.create-tables', {
     tables: tables,
     autoId: autoId,
-    useSchema: false
+    useSchema: false,
+    backend: backend
 })
 }}    }
 

--- a/templates/bake/element/add-foreign-keys.twig
+++ b/templates/bake/element/add-foreign-keys.twig
@@ -5,12 +5,15 @@
 {%     if constraint['type'] != 'unique' %}
 {%         set hasProcessedConstraint = true %}
 {%         set columnsList = '\'' ~ constraint['columns'][0] ~ '\'' %}
+{%         set storedColumnList = columnsList %}
+{%         set indent = backend == 'builtin' ? 6 : 5 %}
 {%         if constraint['columns']|length > 1 %}
-{%             set columnsList = '[' ~ Migration.stringifyList(constraint['columns'], {'indent': 5}) ~ ']' %}
+{%             set storedColumnList = '[' ~ Migration.stringifyList(constraint['columns'], {'indent': 5}) ~ ']' %}
+{%             set columnsList = '[' ~ Migration.stringifyList(constraint['columns'], {'indent': indent}) ~ ']' %}
 {%         endif %}
-{%         set record = Migration.storeReturnedData(table, columnsList) %}
+{%         set record = Migration.storeReturnedData(table, storedColumnList) %}
 {%         if constraint['references'][1] is iterable %}
-{%             set columnsReference = '[' ~ Migration.stringifyList(constraint['references'][1], {'indent': 5}) ~ ']' %}
+{%             set columnsReference = '[' ~ Migration.stringifyList(constraint['references'][1], {'indent': indent}) ~ ']' %}
 {%         else %}
 {%             set columnsReference = '\'' ~ constraint['references'][1] ~ '\'' %}
 {%         endif %}

--- a/templates/bake/element/add-foreign-keys.twig
+++ b/templates/bake/element/add-foreign-keys.twig
@@ -22,6 +22,16 @@
         {{ statement | raw }}
 {%             set statement = null %}
 {%         endif %}
+{%         if backend == 'builtin' %}
+            ->addForeignKey(
+                $this->foriegnKey({{ columnsList | raw }})
+                    ->setReferencedTable('{{ constraint['references'][0] }}')
+                    ->setReferencedColumns({{ columnsReference | raw }})
+                    ->setOnDelete('{{ Migration.formatConstraintAction(constraint['delete']) | raw }}')
+                    ->setOnUpdate('{{ Migration.formatConstraintAction(constraint['update']) | raw }}')
+                    ->setName('{{ constraintName }}')
+            )
+{%          else %}
             ->addForeignKey(
                 {{ columnsList  | raw }},
                 '{{ constraint['references'][0] }}',
@@ -32,6 +42,7 @@
                     'constraint' => '{{ constraintName }}'
                 ]
             )
+{%          endif %}
 {%     endif %}
 {% endfor %}
 {% if Migration.wasTableStatementGeneratedFor(table) and hasProcessedConstraint %}

--- a/templates/bake/element/add-foreign-keys.twig
+++ b/templates/bake/element/add-foreign-keys.twig
@@ -24,7 +24,7 @@
 {%         endif %}
 {%         if backend == 'builtin' %}
             ->addForeignKey(
-                $this->foriegnKey({{ columnsList | raw }})
+                $this->foreignKey({{ columnsList | raw }})
                     ->setReferencedTable('{{ constraint['references'][0] }}')
                     ->setReferencedColumns({{ columnsReference | raw }})
                     ->setOnDelete('{{ Migration.formatConstraintAction(constraint['delete']) | raw }}')

--- a/templates/bake/element/create-tables.twig
+++ b/templates/bake/element/create-tables.twig
@@ -65,6 +65,7 @@
 {{-     element('Migrations.add-foreign-keys', {
          constraints: tableConstraints,
          table: table,
+         backend: backend,
        })
 -}}
 {%   endfor -%}

--- a/tests/TestCase/Db/Table/ForeignKeyTest.php
+++ b/tests/TestCase/Db/Table/ForeignKeyTest.php
@@ -28,6 +28,16 @@ class ForeignKeyTest extends TestCase
         $this->assertEquals('fk_name', $this->fk->getName());
     }
 
+    public function testReferencedColumns(): void
+    {
+        $this->assertEquals([], $this->fk->getReferencedColumns());
+        $this->assertSame($this->fk, $this->fk->setReferencedColumns('user_id'));
+        $this->assertEquals(['user_id'], $this->fk->getReferencedColumns());
+
+        $this->assertSame($this->fk, $this->fk->setReferencedColumns(['user_id', 'tenant_id']));
+        $this->assertEquals(['user_id', 'tenant_id'], $this->fk->getReferencedColumns());
+    }
+
     public function testOnDeleteSetNullCanBeSetThroughOptions()
     {
         $this->assertEquals(

--- a/tests/TestCase/Db/Table/TableTest.php
+++ b/tests/TestCase/Db/Table/TableTest.php
@@ -15,6 +15,7 @@ use Migrations\Db\Adapter\SqliteAdapter;
 use Migrations\Db\Adapter\SqlserverAdapter;
 use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
+use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -138,8 +139,9 @@ class TableTest extends TestCase
     {
         $adapter = new MysqlAdapter([]);
         $table = new Table('ntable', [], $adapter);
+        $key = new ForeignKey();
         $table->addForeignKey(
-            $table->foreignKey('user_id')
+            $key->setColumns('user_id')
                 ->setReferencedTable('users')
                 ->setReferencedColumns(['id'])
                 ->setOnDelete('CASCADE')
@@ -178,8 +180,9 @@ class TableTest extends TestCase
     {
         $adapter = new MysqlAdapter([]);
         $table = new Table('ntable', [], $adapter);
+        $key = new ForeignKey();
         $table->addForeignKeyWithName(
-            $table->foreignKey('user_id')
+            $key->setColumns('user_id')
                 ->setReferencedTable('users')
                 ->setReferencedColumns(['id'])
                 ->setOnDelete('CASCADE')

--- a/tests/comparisons/Diff/default/the_diff_default_mysql.php
+++ b/tests/comparisons/Diff/default/the_diff_default_mysql.php
@@ -97,7 +97,7 @@ class TheDiffDefaultMysql extends BaseMigration
 
         $this->table('categories')
             ->addForeignKey(
-                $this->foriegnKey('user_id')
+                $this->foreignKey('user_id')
                     ->setReferencedTable('users')
                     ->setReferencedColumns('id')
                     ->setOnDelete('RESTRICT')
@@ -150,7 +150,7 @@ class TheDiffDefaultMysql extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                $this->foriegnKey('category_id')
+                $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
                     ->setOnDelete('NO_ACTION')
@@ -270,7 +270,7 @@ class TheDiffDefaultMysql extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                $this->foriegnKey('user_id')
+                $this->foreignKey('user_id')
                     ->setReferencedTable('users')
                     ->setReferencedColumns('id')
                     ->setOnDelete('CASCADE')

--- a/tests/comparisons/Diff/default/the_diff_default_mysql.php
+++ b/tests/comparisons/Diff/default/the_diff_default_mysql.php
@@ -97,14 +97,12 @@ class TheDiffDefaultMysql extends BaseMigration
 
         $this->table('categories')
             ->addForeignKey(
-                'user_id',
-                'users',
-                'id',
-                [
-                    'update' => 'RESTRICT',
-                    'delete' => 'RESTRICT',
-                    'constraint' => 'categories_ibfk_1'
-                ]
+                $this->foriegnKey('user_id')
+                    ->setReferencedTable('users')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('RESTRICT')
+                    ->setOnUpdate('RESTRICT')
+                    ->setName('categories_ibfk_1')
             )
             ->update();
 
@@ -152,14 +150,12 @@ class TheDiffDefaultMysql extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                    'constraint' => 'articles_ibfk_1'
-                ]
+                $this->foriegnKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('articles_ibfk_1')
             )
             ->update();
 
@@ -274,14 +270,12 @@ class TheDiffDefaultMysql extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'user_id',
-                'users',
-                'id',
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'articles_ibfk_1'
-                ]
+                $this->foriegnKey('user_id')
+                    ->setReferencedTable('users')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('articles_ibfk_1')
             )
             ->update();
 

--- a/tests/comparisons/Diff/default/the_diff_default_pgsql.php
+++ b/tests/comparisons/Diff/default/the_diff_default_pgsql.php
@@ -60,13 +60,11 @@ class TheDiffDefaultPgsql extends AbstractMigration
 
         $this->table('categories')
             ->addForeignKey(
-                'user_id',
-                'users',
-                'id',
-                [
-                    'update' => 'RESTRICT',
-                    'delete' => 'RESTRICT',
-                ]
+                $this->foreignKey('user_id')
+                    ->setReferencedTable('users')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('RESTRICT')
+                    ->setOnUpdate('RESTRICT')
             )
             ->update();
 
@@ -112,13 +110,11 @@ class TheDiffDefaultPgsql extends AbstractMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
             )
             ->update();
 
@@ -206,13 +202,11 @@ class TheDiffDefaultPgsql extends AbstractMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'user_id',
-                'users',
-                'id',
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                ]
+                $this->foreignKey('user_id')
+                    ->setReferencedTable('users')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
             )
             ->update();
 

--- a/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
@@ -63,14 +63,12 @@ class TheDiffSimpleMysql extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'user_id',
-                'users',
-                'id',
-                [
-                    'update' => 'RESTRICT',
-                    'delete' => 'RESTRICT',
-                    'constraint' => 'articles_ibfk_1'
-                ]
+                $this->foriegnKey('user_id')
+                    ->setReferencedTable('users')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('RESTRICT')
+                    ->setOnUpdate('RESTRICT')
+                    ->setName('articles_ibfk_1')
             )
             ->update();
     }

--- a/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
@@ -63,7 +63,7 @@ class TheDiffSimpleMysql extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                $this->foriegnKey('user_id')
+                $this->foreignKey('user_id')
                     ->setReferencedTable('users')
                     ->setReferencedColumns('id')
                     ->setOnDelete('RESTRICT')

--- a/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
@@ -390,46 +390,40 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                    'constraint' => 'articles_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
             )
             ->update();
 
         $this->table('orders')
             ->addForeignKey(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                'products',
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'orders_product_fk'
-                ]
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('orders_product_fk')
             )
             ->update();
 
         $this->table('products')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'products_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('products_category_fk')
             )
             ->update();
     }

--- a/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
@@ -330,46 +330,40 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                    'constraint' => 'articles_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
             )
             ->update();
 
         $this->table('orders')
             ->addForeignKey(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                'products',
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'orders_product_fk'
-                ]
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('orders_product_fk')
             )
             ->update();
 
         $this->table('products')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'products_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('products_category_fk')
             )
             ->update();
     }

--- a/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
@@ -126,14 +126,12 @@ class TestSnapshotPluginBlogPgsql extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                    'constraint' => 'articles_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
             )
             ->update();
     }

--- a/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
@@ -371,46 +371,40 @@ class TestSnapshotAutoIdDisabledSqlite extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                    'constraint' => 'category_id_0_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('category_id_0_fk')
             )
             ->update();
 
         $this->table('orders')
             ->addForeignKey(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                'products',
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'product_category_product_id_0_fk'
-                ]
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('product_category_product_id_0_fk')
             )
             ->update();
 
         $this->table('products')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'category_id_0_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('category_id_0_fk')
             )
             ->update();
     }

--- a/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
@@ -311,46 +311,40 @@ class TestSnapshotNotEmptySqlite extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                    'constraint' => 'category_id_0_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('category_id_0_fk')
             )
             ->update();
 
         $this->table('orders')
             ->addForeignKey(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                'products',
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'product_category_product_id_0_fk'
-                ]
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('product_category_product_id_0_fk')
             )
             ->update();
 
         $this->table('products')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'category_id_0_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('category_id_0_fk')
             )
             ->update();
     }

--- a/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
@@ -117,14 +117,12 @@ class TestSnapshotPluginBlogSqlite extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                    'constraint' => 'category_id_0_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('category_id_0_fk')
             )
             ->update();
     }

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_auto_id_disabled_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_auto_id_disabled_sqlserver.php
@@ -405,46 +405,40 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                    'constraint' => 'articles_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
             )
             ->update();
 
         $this->table('orders')
             ->addForeignKey(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                'products',
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'orders_product_fk'
-                ]
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('orders_product_fk')
             )
             ->update();
 
         $this->table('products')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'products_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('products_category_fk')
             )
             ->update();
     }

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_not_empty_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_not_empty_sqlserver.php
@@ -345,46 +345,40 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                    'constraint' => 'articles_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
             )
             ->update();
 
         $this->table('orders')
             ->addForeignKey(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                'products',
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'orders_product_fk'
-                ]
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('orders_product_fk')
             )
             ->update();
 
         $this->table('products')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'products_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('products_category_fk')
             )
             ->update();
     }

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_plugin_blog_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_plugin_blog_sqlserver.php
@@ -130,14 +130,12 @@ class TestSnapshotPluginBlogSqlserver extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                    'constraint' => 'articles_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
             )
             ->update();
     }

--- a/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
+++ b/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
@@ -400,46 +400,40 @@ class TestSnapshotAutoIdDisabled extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                    'constraint' => 'articles_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
             )
             ->update();
 
         $this->table('orders')
             ->addForeignKey(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                'products',
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'orders_product_fk'
-                ]
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('orders_product_fk')
             )
             ->update();
 
         $this->table('products')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'products_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('products_category_fk')
             )
             ->update();
     }

--- a/tests/comparisons/Migration/test_snapshot_not_empty.php
+++ b/tests/comparisons/Migration/test_snapshot_not_empty.php
@@ -332,46 +332,40 @@ class TestSnapshotNotEmpty extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                    'constraint' => 'articles_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
             )
             ->update();
 
         $this->table('orders')
             ->addForeignKey(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                'products',
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'orders_product_fk'
-                ]
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('orders_product_fk')
             )
             ->update();
 
         $this->table('products')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'CASCADE',
-                    'delete' => 'CASCADE',
-                    'constraint' => 'products_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('products_category_fk')
             )
             ->update();
     }

--- a/tests/comparisons/Migration/test_snapshot_plugin_blog.php
+++ b/tests/comparisons/Migration/test_snapshot_plugin_blog.php
@@ -131,14 +131,12 @@ class TestSnapshotPluginBlog extends BaseMigration
 
         $this->table('articles')
             ->addForeignKey(
-                'category_id',
-                'categories',
-                'id',
-                [
-                    'update' => 'NO_ACTION',
-                    'delete' => 'NO_ACTION',
-                    'constraint' => 'articles_category_fk'
-                ]
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
             )
             ->update();
     }


### PR DESCRIPTION
Use `foreignKey()` in migration generation (when `builtin` backend is active) and update the docs. The `foreignKey()` method was moved to `BaseMigration` to make code generation easier.