### PR TITLE
Add BaseMigration::index()

### DIFF
--- a/src/BaseMigration.php
+++ b/src/BaseMigration.php
@@ -18,6 +18,7 @@ use Migrations\Config\ConfigInterface;
 use Migrations\Db\Adapter\AdapterInterface;
 use Migrations\Db\Table;
 use Migrations\Db\Table\ForeignKey;
+use Migrations\Db\Table\Index;
 use RuntimeException;
 
 /**
@@ -434,6 +435,17 @@ class BaseMigration implements MigrationInterface
     public function foreignKey(string|array $columns): ForeignKey
     {
         return (new ForeignKey())->setColumns($columns);
+    }
+
+    /**
+     * Create a new Index object.
+     *
+     * @params string|string[] $columns Columns
+     * @return \Migrations\Db\Table\Index
+     */
+    public function index(string|array $columns): Index
+    {
+        return (new Index())->setColumns($columns);
     }
 
     /**

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -1288,6 +1288,7 @@ class PostgresAdapter extends PdoAdapter
         $include = $index->getInclude();
         $includedColumns = $include ? sprintf('INCLUDE ("%s")', implode('","', $include)) : '';
 
+        // TODO always concurrently
         $createIndexSentence = 'CREATE %s INDEX %s ON %s ';
         if ($index->getType() === self::GIN_INDEX_TYPE) {
             $createIndexSentence .= ' USING ' . $index->getType() . '(%s) %s;';

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -33,6 +33,8 @@ use Migrations\Db\Table\Index;
 use Migrations\Db\Table\Table as TableValue;
 use RuntimeException;
 
+use function Cake\Core\deprecationWarning;
+
 /**
  * This object is based loosely on: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Table.html.
  */
@@ -513,6 +515,8 @@ class Table
      * @param string|string[] $referencedColumns Referenced Columns
      * @param array<string, mixed> $options Options
      * @return $this
+     * @deprecated 4.6.0 Use addForeignKey() instead. Use `BaseMigration::foreignKey()` to get
+     *   a fluent interface for building foreign keys.
      */
     public function addForeignKeyWithName(
         string|ForeignKey $name,
@@ -521,6 +525,11 @@ class Table
         string|array $referencedColumns = ['id'],
         array $options = []
     ) {
+        deprecationWarning(
+            '4.6.0',
+            'Use addForeignKey() instead. Use `BaseMigration::foreignKey()` to get a fluent' .
+                ' interface for building foreign keys.'
+        );
         if (is_string($name)) {
             if ($columns === null || $referencedTable === null) {
                 throw new InvalidArgumentException(

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -32,7 +32,6 @@ use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use Migrations\Db\Table\Table as TableValue;
 use RuntimeException;
-
 use function Cake\Core\deprecationWarning;
 
 /**

--- a/src/Db/Table/ForeignKey.php
+++ b/src/Db/Table/ForeignKey.php
@@ -17,7 +17,7 @@ use function Cake\Core\deprecationWarning;
  *
  * Used to define foreign keys that are added to tables as part of migrations.
  *
- * @see \Migrations\Db\Table::foreignKey()
+ * @see \Migrations\BaseMigration::foreignKey()
  * @see \Migrations\Db\Table::addForeignKey()
  */
 class ForeignKey

--- a/src/Db/Table/Index.php
+++ b/src/Db/Table/Index.php
@@ -10,6 +10,19 @@ namespace Migrations\Db\Table;
 
 use RuntimeException;
 
+/**
+ * Index value object
+ *
+ * Used to define indexes that are added to tables as part of migrations.
+ *
+ * @see \Migrations\BaseMigration::index()
+ * @see \Migrations\Db\Table::addIndex()
+ *
+ * TODO expand functionality of Index:
+ * - Add ifnotexists
+ * - Add nullsfirst/nullslast
+ * - Add where for partial indexes
+ */
 class Index
 {
     /**
@@ -129,6 +142,9 @@ class Index
     /**
      * Sets the index limit.
      *
+     * In MySQL indexes can have limit clauses to control the number of
+     * characters indexed in text and char columns.
+     *
      * @param int|array $limit limit value or array of limit value
      * @return $this
      */
@@ -173,7 +189,12 @@ class Index
     }
 
     /**
-     * Sets the index included columns.
+     * Sets the index included columns for a 'covering index'.
+     *
+     * In postgres and sqlserver, indexes can define additional non-key
+     * columns to build 'covering indexes'. This feature allows you to
+     * further optimize well-crafted queries that leverage specific
+     * indexes by reading all data from the index.
      *
      * @param string[] $includedColumns Columns
      * @return $this

--- a/templates/bake/config/diff.twig
+++ b/templates/bake/config/diff.twig
@@ -99,7 +99,7 @@ not empty %}
 {{                Migration.element('Migrations.add-columns', {'columns': tableDiff['columns']['add']}) | raw -}}
 {%            endif -%}
 {%            if tableDiff['indexes']['add'] is not empty %}
-{{                Migration.element('Migrations.add-indexes', {'indexes': tableDiff['indexes']['add']}) | raw -}}
+{{                Migration.element('Migrations.add-indexes', {'backend': backend, 'indexes': tableDiff['indexes']['add']}) | raw -}}
 {%            endif -%}
 {%            if Migration.wasTableStatementGeneratedFor(tableName) %}
             ->update();

--- a/templates/bake/element/add-indexes.twig
+++ b/templates/bake/element/add-indexes.twig
@@ -1,10 +1,28 @@
 {% for indexName, index in indexes %}
-            ->addIndex(
-                [{{ Migration.stringifyList(index['columns'], {'indent': 5}) | raw }}],
-{%     set params = {'name': indexName} %}
-{%     if index['type'] == 'unique' %}
-{%         set params = params|merge({'unique': true}) %}
+{%     set columnsList = '\'' ~ index['columns'][0] ~ '\'' %}
+{%     if index['columns']|length > 1 %}
+{%         set columnsList = '[' ~ Migration.stringifyList(index['columns'], {'indent': 6}) ~ ']' %}
 {%     endif %}
+            ->addIndex(
+{%     if backend == 'builtin' %}
+                $this->index({{ columnsList | raw }})
+                    ->setName('{{ indexName }}')
+{%         if index['type'] == 'unique' %}
+                    ->setType('unique')
+{%         elseif index['type'] == 'fulltext' %}
+                    ->setType('fulltext')
+{%         endif %}
+{%         if index['options'] %}
+                    ->setOptions([{{ Migration.stringifyList(index['options'], {'indent': 6}) | raw }}])
+{%         endif %}
+            )
+{%     else %}
+                [{{ Migration.stringifyList(index['columns'], {'indent': 5}) | raw }}],
+{%         set params = {'name': indexName} %}
+{%         if index['type'] == 'unique' %}
+{%             set params = params|merge({'unique': true}) %}
+{%         endif %}
                 [{{ Migration.stringifyList(params, {'indent': 5}) | raw }}]
             )
+{%     endif %}
 {% endfor %}

--- a/templates/bake/element/create-tables.twig
+++ b/templates/bake/element/create-tables.twig
@@ -39,26 +39,17 @@
 {%     if createData.tables[table].constraints is not empty %}
 {%         for name, constraint in createData.tables[table].constraints %}
 {%             if constraint['type'] == 'unique' %}
-            ->addIndex(
-                [{{ Migration.stringifyList(constraint['columns'], {'indent': 5}) | raw }}],
-{%                 set params = {'name': name, 'unique': true} %}
-                [{{ Migration.stringifyList(params, {'indent': 5}) | raw }}]
-            )
+{{                 element('Migrations.add-indexes', {
+                     indexes: {(name): constraint},
+                     backend: backend,
+                  }) -}}
 {%             endif %}
 {%         endfor %}
 {%     endif %}
-{%     for indexName, index in createData.tables[table].indexes %}
-{%         set indexColumns = index['columns'] | sort %}
-            ->addIndex(
-                [{{ Migration.stringifyList(index['columns'], {'indent': 5}) | raw }}],
-{%         set params = {'name': indexName} %}
-{%         if index['type'] == 'fulltext' %}
-{%             set params = params|merge({'type': 'fulltext'}) %}
-{%         endif %}
-                [{{ Migration.stringifyList(params, {'indent': 5}) | raw }}]
-            )
-{%     endfor %}
-            ->create();
+{{-     element('Migrations.add-indexes', {
+           indexes: createData.tables[table].indexes,
+           backend: backend,
+}) }}            ->create();
 {% endfor -%}
 {% if createData.constraints %}
 {%   for table, tableConstraints in createData.constraints %}

--- a/tests/comparisons/Diff/default/the_diff_default_mysql.php
+++ b/tests/comparisons/Diff/default/the_diff_default_mysql.php
@@ -78,20 +78,12 @@ class TheDiffDefaultMysql extends BaseMigration
                 'signed' => true,
             ])
             ->addIndex(
-                [
-                    'user_id',
-                ],
-                [
-                    'name' => 'categories_ibfk_1',
-                ]
+                $this->index('user_id')
+                    ->setName('categories_ibfk_1')
             )
             ->addIndex(
-                [
-                    'name',
-                ],
-                [
-                    'name' => 'name',
-                ]
+                $this->index('name')
+                    ->setName('name')
             )
             ->create();
 
@@ -123,28 +115,16 @@ class TheDiffDefaultMysql extends BaseMigration
                 'signed' => true,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'UNIQUE_SLUG',
-                ]
+                $this->index('slug')
+                    ->setName('UNIQUE_SLUG')
             )
             ->addIndex(
-                [
-                    'category_id',
-                ],
-                [
-                    'name' => 'category_id',
-                ]
+                $this->index('category_id')
+                    ->setName('category_id')
             )
             ->addIndex(
-                [
-                    'name',
-                ],
-                [
-                    'name' => 'rating_index',
-                ]
+                $this->index('name')
+                    ->setName('rating_index')
             )
             ->update();
 
@@ -233,29 +213,17 @@ class TheDiffDefaultMysql extends BaseMigration
             ->removeColumn('category_id')
             ->removeColumn('average_note')
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'UNIQUE_SLUG',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('UNIQUE_SLUG')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'rating',
-                ],
-                [
-                    'name' => 'rating_index',
-                ]
+                $this->index('rating')
+                    ->setName('rating_index')
             )
             ->addIndex(
-                [
-                    'name',
-                ],
-                [
-                    'name' => 'BY_NAME',
-                ]
+                $this->index('name')
+                    ->setName('BY_NAME')
             )
             ->update();
 

--- a/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
@@ -52,12 +52,8 @@ class TheDiffSimpleMysql extends BaseMigration
                 'signed' => false,
             ])
             ->addIndex(
-                [
-                    'user_id',
-                ],
-                [
-                    'name' => 'user_id',
-                ]
+                $this->index('user_id')
+                    ->setName('user_id')
             )
             ->update();
 

--- a/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
@@ -70,12 +70,8 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
                 'scale' => 6,
             ])
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'articles_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('articles_title_idx')
             )
             ->create();
 
@@ -117,13 +113,9 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
                 'scale' => 6,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'categories_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
             )
             ->create();
 
@@ -185,13 +177,11 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
                 'null' => false,
             ])
             ->addIndex(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                [
-                    'name' => 'orders_product_category_idx',
-                ]
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
             )
             ->create();
 
@@ -253,31 +243,21 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
                 'scale' => 6,
             ])
             ->addIndex(
-                [
-                    'id',
-                    'category_id',
-                ],
-                [
-                    'name' => 'products_category_unique',
-                    'unique' => true,
-                ]
+                $this->index([
+                        'id',
+                        'category_id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'products_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'products_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('products_title_idx')
             )
             ->create();
 
@@ -331,13 +311,9 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
                 'scale' => 6,
             ])
             ->addIndex(
-                [
-                    'article_id',
-                ],
-                [
-                    'name' => 'special_tags_article_unique',
-                    'unique' => true,
-                ]
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
             )
             ->create();
 

--- a/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
@@ -61,12 +61,8 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
                 'scale' => 6,
             ])
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'articles_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('articles_title_idx')
             )
             ->create();
 
@@ -101,13 +97,9 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
                 'scale' => 6,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'categories_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
             )
             ->create();
 
@@ -154,13 +146,11 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
                 'null' => false,
             ])
             ->addIndex(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                [
-                    'name' => 'orders_product_category_idx',
-                ]
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
             )
             ->create();
 
@@ -208,31 +198,21 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
                 'scale' => 6,
             ])
             ->addIndex(
-                [
-                    'id',
-                    'category_id',
-                ],
-                [
-                    'name' => 'products_category_unique',
-                    'unique' => true,
-                ]
+                $this->index([
+                        'id',
+                        'category_id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'products_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'products_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('products_title_idx')
             )
             ->create();
 
@@ -278,13 +258,9 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
                 'scale' => 6,
             ])
             ->addIndex(
-                [
-                    'article_id',
-                ],
-                [
-                    'name' => 'special_tags_article_unique',
-                    'unique' => true,
-                ]
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
             )
             ->create();
 

--- a/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
@@ -61,12 +61,8 @@ class TestSnapshotPluginBlogPgsql extends BaseMigration
                 'scale' => 6,
             ])
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'articles_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('articles_title_idx')
             )
             ->create();
 
@@ -101,13 +97,9 @@ class TestSnapshotPluginBlogPgsql extends BaseMigration
                 'scale' => 6,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'categories_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
             )
             ->create();
 

--- a/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
@@ -169,10 +169,10 @@ class TestSnapshotAutoIdDisabledSqlite extends BaseMigration
             ])
             ->addIndex(
                 $this->index([
-                    'product_category',
-                    'product_id',
-                ])
-                ->setName('orders_product_category_idx')
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
             )
             ->create();
 
@@ -297,7 +297,7 @@ class TestSnapshotAutoIdDisabledSqlite extends BaseMigration
             ])
             ->addIndex(
                 $this->index('article_id')
-                    ->setName('special_tags_article_idx')
+                    ->setName('special_tags_article_unique')
                     ->setType('unique')
             )
             ->create();

--- a/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
@@ -65,12 +65,8 @@ class TestSnapshotAutoIdDisabledSqlite extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'articles_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('articles_title_idx')
             )
             ->create();
 
@@ -108,13 +104,9 @@ class TestSnapshotAutoIdDisabledSqlite extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'categories_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
             )
             ->create();
 
@@ -176,13 +168,11 @@ class TestSnapshotAutoIdDisabledSqlite extends BaseMigration
                 'null' => false,
             ])
             ->addIndex(
-                [
+                $this->index([
                     'product_category',
                     'product_id',
-                ],
-                [
-                    'name' => 'orders_product_category_idx',
-                ]
+                ])
+                ->setName('orders_product_category_idx')
             )
             ->create();
 
@@ -240,31 +230,21 @@ class TestSnapshotAutoIdDisabledSqlite extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'name' => 'products_category_unique',
-                    'unique' => true,
-                ]
+                $this->index([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'products_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'products_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('products_title_idx')
             )
             ->create();
 
@@ -316,13 +296,9 @@ class TestSnapshotAutoIdDisabledSqlite extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'article_id',
-                ],
-                [
-                    'name' => 'special_tags_article_unique',
-                    'unique' => true,
-                ]
+                $this->index('article_id')
+                    ->setName('special_tags_article_idx')
+                    ->setType('unique')
             )
             ->create();
 

--- a/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
@@ -56,12 +56,8 @@ class TestSnapshotNotEmptySqlite extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'articles_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('articles_title_idx')
             )
             ->create();
 
@@ -92,13 +88,9 @@ class TestSnapshotNotEmptySqlite extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'categories_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
             )
             ->create();
 
@@ -145,13 +137,11 @@ class TestSnapshotNotEmptySqlite extends BaseMigration
                 'null' => false,
             ])
             ->addIndex(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                [
-                    'name' => 'orders_product_category_idx',
-                ]
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
             )
             ->create();
 
@@ -195,31 +185,21 @@ class TestSnapshotNotEmptySqlite extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'name' => 'products_category_unique',
-                    'unique' => true,
-                ]
+                $this->index([
+                        'id',
+                        'category_id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'products_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'products_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('products_title_idx')
             )
             ->create();
 
@@ -263,13 +243,9 @@ class TestSnapshotNotEmptySqlite extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'article_id',
-                ],
-                [
-                    'name' => 'special_tags_article_unique',
-                    'unique' => true,
-                ]
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
             )
             ->create();
 

--- a/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
@@ -186,8 +186,8 @@ class TestSnapshotNotEmptySqlite extends BaseMigration
             ])
             ->addIndex(
                 $this->index([
-                        'id',
                         'category_id',
+                        'id',
                     ])
                     ->setName('products_category_unique')
                     ->setType('unique')

--- a/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
@@ -56,12 +56,8 @@ class TestSnapshotPluginBlogSqlite extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'articles_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('articles_title_idx')
             )
             ->create();
 
@@ -92,13 +88,9 @@ class TestSnapshotPluginBlogSqlite extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'categories_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
             )
             ->create();
 

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_auto_id_disabled_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_auto_id_disabled_sqlserver.php
@@ -185,10 +185,10 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
             ])
             ->addIndex(
                 $this->index([
-                    'product_category',
-                    'product_id',
-                ])
-                ->setName('orders_product_category_idx')
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
             )
             ->create();
 
@@ -322,13 +322,9 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
                 'scale' => 7,
             ])
             ->addIndex(
-                [
-                    'article_id',
-                ],
-                [
-                    'name' => 'special_tags_article_unique',
-                    'unique' => true,
-                ]
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
             )
             ->create();
 

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_auto_id_disabled_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_auto_id_disabled_sqlserver.php
@@ -71,12 +71,8 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
                 'scale' => 7,
             ])
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'articles_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('articles_title_idx')
             )
             ->create();
 
@@ -120,13 +116,9 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
                 'scale' => 7,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'categories_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
             )
             ->create();
 
@@ -192,13 +184,11 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
                 'null' => false,
             ])
             ->addIndex(
-                [
+                $this->index([
                     'product_category',
                     'product_id',
-                ],
-                [
-                    'name' => 'orders_product_category_idx',
-                ]
+                ])
+                ->setName('orders_product_category_idx')
             )
             ->create();
 
@@ -263,31 +253,21 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
                 'scale' => 7,
             ])
             ->addIndex(
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'name' => 'products_category_unique',
-                    'unique' => true,
-                ]
+                $this->index([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'products_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'products_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('products_title_idx')
             )
             ->create();
 

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_not_empty_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_not_empty_sqlserver.php
@@ -62,12 +62,8 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
                 'scale' => 7,
             ])
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'articles_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('articles_title_idx')
             )
             ->create();
 
@@ -104,13 +100,9 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
                 'scale' => 7,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'categories_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
             )
             ->create();
 
@@ -161,13 +153,11 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
                 'null' => false,
             ])
             ->addIndex(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                [
-                    'name' => 'orders_product_category_idx',
-                ]
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
             )
             ->create();
 
@@ -218,31 +208,21 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
                 'scale' => 7,
             ])
             ->addIndex(
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'name' => 'products_category_unique',
-                    'unique' => true,
-                ]
+                $this->index([
+                        'id',
+                        'category_id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'products_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'products_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('products_title_idx')
             )
             ->create();
 
@@ -289,13 +269,9 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
                 'scale' => 7,
             ])
             ->addIndex(
-                [
-                    'article_id',
-                ],
-                [
-                    'name' => 'special_tags_article_unique',
-                    'unique' => true,
-                ]
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
             )
             ->create();
 

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_not_empty_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_not_empty_sqlserver.php
@@ -209,8 +209,8 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
             ])
             ->addIndex(
                 $this->index([
-                        'id',
                         'category_id',
+                        'id',
                     ])
                     ->setName('products_category_unique')
                     ->setType('unique')

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_plugin_blog_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_plugin_blog_sqlserver.php
@@ -62,12 +62,8 @@ class TestSnapshotPluginBlogSqlserver extends BaseMigration
                 'scale' => 7,
             ])
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'articles_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('articles_title_idx')
             )
             ->create();
 
@@ -104,13 +100,9 @@ class TestSnapshotPluginBlogSqlserver extends BaseMigration
                 'scale' => 7,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'categories_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
             )
             ->create();
 

--- a/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
+++ b/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
@@ -71,7 +71,7 @@ class TestSnapshotAutoIdDisabled extends BaseMigration
             ])
             ->addIndex(
                 $this->index('category_id')
-                    ->setName('articles_category_idx')
+                    ->setName('articles_category_fk')
             )
             ->addIndex(
                 $this->index('title')
@@ -184,10 +184,10 @@ class TestSnapshotAutoIdDisabled extends BaseMigration
             ])
             ->addIndex(
                 $this->index([
-                    'product_category',
-                    'product_id',
-                ])
-                ->setName('orders_product_category_idx')
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
             )
             ->create();
 
@@ -321,7 +321,7 @@ class TestSnapshotAutoIdDisabled extends BaseMigration
             ])
             ->addIndex(
                 $this->index('article_id')
-                    ->setName('special_tags_article_idx')
+                    ->setName('special_tags_article_unique')
                     ->setType('unique')
             )
             ->create();

--- a/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
+++ b/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
@@ -70,20 +70,12 @@ class TestSnapshotAutoIdDisabled extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'category_id',
-                ],
-                [
-                    'name' => 'articles_category_fk',
-                ]
+                $this->index('category_id')
+                    ->setName('articles_category_idx')
             )
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'articles_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('articles_title_idx')
             )
             ->create();
 
@@ -123,13 +115,9 @@ class TestSnapshotAutoIdDisabled extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'categories_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
             )
             ->create();
 
@@ -195,13 +183,11 @@ class TestSnapshotAutoIdDisabled extends BaseMigration
                 'signed' => false,
             ])
             ->addIndex(
-                [
+                $this->index([
                     'product_category',
                     'product_id',
-                ],
-                [
-                    'name' => 'orders_product_category_idx',
-                ]
+                ])
+                ->setName('orders_product_category_idx')
             )
             ->create();
 
@@ -263,32 +249,22 @@ class TestSnapshotAutoIdDisabled extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'products_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'name' => 'products_category_unique',
-                    'unique' => true,
-                ]
+                $this->index([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'products_title_idx',
-                    'type' => 'fulltext',
-                ]
+                $this->index('title')
+                    ->setName('products_title_idx')
+                    ->setType('fulltext')
             )
             ->create();
 
@@ -344,13 +320,9 @@ class TestSnapshotAutoIdDisabled extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'article_id',
-                ],
-                [
-                    'name' => 'special_tags_article_unique',
-                    'unique' => true,
-                ]
+                $this->index('article_id')
+                    ->setName('special_tags_article_idx')
+                    ->setType('unique')
             )
             ->create();
 

--- a/tests/comparisons/Migration/test_snapshot_not_empty.php
+++ b/tests/comparisons/Migration/test_snapshot_not_empty.php
@@ -60,20 +60,12 @@ class TestSnapshotNotEmpty extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'category_id',
-                ],
-                [
-                    'name' => 'articles_category_fk',
-                ]
+                $this->index('category_id')
+                    ->setName('articles_category_fk')
             )
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'articles_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('articles_title_idx')
             )
             ->create();
 
@@ -105,13 +97,9 @@ class TestSnapshotNotEmpty extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'categories_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
             )
             ->create();
 
@@ -160,13 +148,11 @@ class TestSnapshotNotEmpty extends BaseMigration
                 'signed' => false,
             ])
             ->addIndex(
-                [
-                    'product_category',
-                    'product_id',
-                ],
-                [
-                    'name' => 'orders_product_category_idx',
-                ]
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
             )
             ->create();
 
@@ -212,32 +198,22 @@ class TestSnapshotNotEmpty extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'products_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'category_id',
-                    'id',
-                ],
-                [
-                    'name' => 'products_category_unique',
-                    'unique' => true,
-                ]
+                $this->index([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
             )
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'products_title_idx',
-                    'type' => 'fulltext',
-                ]
+                $this->index('title')
+                    ->setName('products_title_idx')
+                    ->setType('fulltext')
             )
             ->create();
 
@@ -284,13 +260,9 @@ class TestSnapshotNotEmpty extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'article_id',
-                ],
-                [
-                    'name' => 'special_tags_article_unique',
-                    'unique' => true,
-                ]
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
             )
             ->create();
 

--- a/tests/comparisons/Migration/test_snapshot_plugin_blog.php
+++ b/tests/comparisons/Migration/test_snapshot_plugin_blog.php
@@ -60,20 +60,12 @@ class TestSnapshotPluginBlog extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'category_id',
-                ],
-                [
-                    'name' => 'articles_category_fk',
-                ]
+                $this->index('category_id')
+                    ->setName('articles_category_fk')
             )
             ->addIndex(
-                [
-                    'title',
-                ],
-                [
-                    'name' => 'articles_title_idx',
-                ]
+                $this->index('title')
+                    ->setName('articles_title_idx')
             )
             ->create();
 
@@ -105,13 +97,9 @@ class TestSnapshotPluginBlog extends BaseMigration
                 'null' => true,
             ])
             ->addIndex(
-                [
-                    'slug',
-                ],
-                [
-                    'name' => 'categories_slug_unique',
-                    'unique' => true,
-                ]
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
             )
             ->create();
 

--- a/tests/test_app/config/BaseMigrations/20230628181900_base_migration_tables.php
+++ b/tests/test_app/config/BaseMigrations/20230628181900_base_migration_tables.php
@@ -11,7 +11,12 @@ class BaseMigrationTables extends BaseMigration
             ->addColumn('name', 'string')
             ->addTimestamps()
             ->addPrimaryKey('id')
+            ->addIndex(
+                $this->index('name')
+                    ->setName('base_stores_name_idx')
+            )
             ->create();
+
         $io = $this->getIo();
 
         $res = $this->query('SELECT 121 as val');


### PR DESCRIPTION
The existing addIndex() method already was compatible with value objects, so only the templates and BaseMigration method were required.
