### PR TITLE
Add support for partial indexes and concurrent indexes in postgres

### DIFF
--- a/docs/en/writing-migrations.rst
+++ b/docs/en/writing-migrations.rst
@@ -1249,44 +1249,62 @@ table object.
             }
         }
 
-By default Migrations instructs the database adapter to create a normal index. We
+By default Migrations instructs the database adapter to create a simple index. We
 can pass an additional parameter ``unique`` to the ``addIndex()`` method to
 specify a unique index. We can also explicitly specify a name for the index
 using the ``name`` parameter, the index columns sort order can also be specified using
-the ``order`` parameter. The order parameter takes an array of column names and sort order key/value pairs.
+the ``order`` parameter. The order parameter takes an array of column names and sort order key/value pairs::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up()
         {
-            /**
-             * Migrate Up.
-             */
-            public function up()
-            {
-                $table = $this->table('users');
-                $table->addColumn('email', 'string')
-                      ->addColumn('username','string')
-                      ->addIndex(['email', 'username'], [
-                            'unique' => true,
-                            'name' => 'idx_users_email',
-                            'order' => ['email' => 'DESC', 'username' => 'ASC']]
-                            )
-                      ->save();
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down()
-            {
-
-            }
+            $table = $this->table('users');
+            $table->addColumn('email', 'string')
+                  ->addColumn('username','string')
+                  ->addIndex(['email', 'username'], [
+                        'unique' => true,
+                        'name' => 'idx_users_email',
+                        'order' => ['email' => 'DESC', 'username' => 'ASC']]
+                  )
+                  ->save();
         }
+    }
+
+As of 4.6.0, you can use ``BaseMigration::index()`` to get a fluent builder to
+define indexes::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up()
+        {
+            $table = $this->table('users');
+            $table->addColumn('email', 'string')
+                  ->addColumn('username','string')
+                  ->addIndex(
+                      $this->index(['email', 'username'])
+                          ->setType('unique')
+                          ->setName('idx_users_email')
+                          ->setOrder(['email' => 'DESC', 'username' => 'ASC'])
+                  )
+                  ->save();
+        }
+    }
+
 
 The MySQL adapter also supports ``fulltext`` indexes. If you are using a version before 5.6 you must
 ensure the table uses the ``MyISAM`` engine.
@@ -1308,103 +1326,145 @@ ensure the table uses the ``MyISAM`` engine.
             }
         }
 
-In addition, MySQL adapter also supports setting the index length defined by limit option.
+MySQL adapter supports setting the index length defined by limit option.
 When you are using a multi-column index, you are able to define each column index length.
-The single column index can define its index length with or without defining column name in limit option.
+The single column index can define its index length with or without defining column name in limit option::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        public function change()
         {
-            public function change()
-            {
-                $table = $this->table('users');
-                $table->addColumn('email', 'string')
-                      ->addColumn('username','string')
-                      ->addColumn('user_guid', 'string', ['limit' => 36])
-                      ->addIndex(['email','username'], ['limit' => ['email' => 5, 'username' => 2]])
-                      ->addIndex('user_guid', ['limit' => 6])
-                      ->create();
-            }
+            $table = $this->table('users');
+            $table->addColumn('email', 'string')
+                  ->addColumn('username','string')
+                  ->addColumn('user_guid', 'string', ['limit' => 36])
+                  ->addIndex(['email','username'], ['limit' => ['email' => 5, 'username' => 2]])
+                  ->addIndex('user_guid', ['limit' => 6])
+                  ->create();
         }
+    }
 
-The SQL Server and PostgreSQL adapters also supports ``include`` (non-key) columns on indexes.
+The SQL Server and PostgreSQL adapters support ``include`` (non-key) columns on indexes::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        public function change()
         {
-            public function change()
-            {
-                $table = $this->table('users');
-                $table->addColumn('email', 'string')
-                      ->addColumn('firstname','string')
-                      ->addColumn('lastname','string')
-                      ->addIndex(['email'], ['include' => ['firstname', 'lastname']])
-                      ->create();
-            }
+            $table = $this->table('users');
+            $table->addColumn('email', 'string')
+                  ->addColumn('firstname','string')
+                  ->addColumn('lastname','string')
+                  ->addIndex(['email'], ['include' => ['firstname', 'lastname']])
+                  ->create();
         }
+    }
 
-In addition PostgreSQL adapters also supports Generalized Inverted Index ``gin`` indexes.
+PostgreSQL, SQLServer, and SQLite support partial indexes by defining where
+clauses for the index::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        public function change()
         {
-            public function change()
-            {
-                $table = $this->table('users');
-                $table->addColumn('address', 'string')
-                      ->addIndex('address', ['type' => 'gin'])
-                      ->create();
-            }
+            $table = $this->table('users');
+            $table->addColumn('email', 'string')
+                  ->addColumn('is_verified','boolean')
+                  ->addIndex(
+                      $this->index('email')
+                          ->setName('user_email_verified_idx')
+                          ->setType('unique')
+                          ->setWhere('is_verified = true')
+                  )
+                  ->create();
         }
+    }
+
+PostgreSQL can create indexes concurrently which avoids taking disruptive locks
+during index creation::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class MyNewMigration extends BaseMigration
+    {
+        public function change()
+        {
+            $table = $this->table('users');
+            $table->addColumn('email', 'string')
+                  ->addIndex(
+                      $this->index('email')
+                          ->setName('user_email_unique_idx')
+                          ->setType('unique')
+                          ->setConcurrently(true)
+                  )
+                  ->create();
+        }
+    }
+
+PostgreSQL adapters also supports Generalized Inverted Index ``gin`` indexes::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class MyNewMigration extends BaseMigration
+    {
+        public function change()
+        {
+            $table = $this->table('users');
+            $table->addColumn('address', 'string')
+                  ->addIndex('address', ['type' => 'gin'])
+                  ->create();
+        }
+    }
 
 Removing indexes is as easy as calling the ``removeIndex()`` method. You must
-call this method for each index.
+call this method for each index::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up()
         {
-            /**
-             * Migrate Up.
-             */
-            public function up()
-            {
-                $table = $this->table('users');
-                $table->removeIndex(['email'])
-                    ->save();
+            $table = $this->table('users');
+            $table->removeIndex(['email'])
+                ->save();
 
-                // alternatively, you can delete an index by its name, ie:
-                $table->removeIndexByName('idx_users_email')
-                    ->save();
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down()
-            {
-
-            }
+            // alternatively, you can delete an index by its name, ie:
+            $table->removeIndexByName('idx_users_email')
+                ->save();
         }
+
+        /**
+         * Migrate Down.
+         */
+        public function down()
+        {
+
+        }
+    }
+
+.. versionadded:: 4.6.0
+    ``Index::setWhere()``, and ``Index::setConcurrently()`` were added.
 
 
 Working With Foreign Keys

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
+  <file src="src/AbstractMigration.php">
+    <DeprecatedClass>
+      <code><![CDATA[Table]]></code>
+      <code><![CDATA[\Migrations\Table]]></code>
+      <code><![CDATA[new Table($tableName, $options, $this->getAdapter())]]></code>
+    </DeprecatedClass>
+  </file>
   <file src="src/AbstractSeed.php">
     <DeprecatedClass>
       <code><![CDATA[new Seed()]]></code>

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -98,7 +98,6 @@ class MysqlAdapter extends PdoAdapter
      */
     public function connect(): void
     {
-
         $this->getConnection()->getDriver()->connect();
         $this->setConnection($this->getConnection());
     }

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -1291,7 +1291,7 @@ class PostgresAdapter extends PdoAdapter
         $includedColumns = $include ? sprintf('INCLUDE ("%s")', implode('","', $include)) : '';
 
         // TODO always concurrently
-        $createIndexSentence = 'CREATE %s INDEX %s ON %s ';
+        $createIndexSentence = 'CREATE %sINDEX %s ON %s ';
         if ($index->getType() === self::GIN_INDEX_TYPE) {
             $createIndexSentence .= ' USING ' . $index->getType() . '(%s) %s;';
         } else {
@@ -1300,7 +1300,7 @@ class PostgresAdapter extends PdoAdapter
 
         return sprintf(
             $createIndexSentence,
-            ($index->getType() === Index::UNIQUE ? 'UNIQUE' : ''),
+            ($index->getType() === Index::UNIQUE ? 'UNIQUE ' : ''),
             $this->quoteColumnName((string)$indexName),
             $this->quoteTableName($tableName),
             implode(',', $columnNames),

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -1288,13 +1288,17 @@ class PostgresAdapter extends PdoAdapter
         }, $columnNames);
 
         $include = $index->getInclude();
-        $includedColumns = $include ? sprintf('INCLUDE ("%s")', implode('","', $include)) : '';
+        $includedColumns = $include ? sprintf(' INCLUDE ("%s")', implode('","', $include)) : '';
 
         $createIndexSentence = 'CREATE %sINDEX%s %s ON %s ';
         if ($index->getType() === self::GIN_INDEX_TYPE) {
             $createIndexSentence .= ' USING ' . $index->getType() . '(%s) %s;';
         } else {
-            $createIndexSentence .= '(%s) %s;';
+            $createIndexSentence .= '(%s)%s%s;';
+        }
+        $where = (string)$index->getWhere();
+        if ($where) {
+            $where = ' WHERE ' . $where;
         }
 
         return sprintf(
@@ -1304,7 +1308,8 @@ class PostgresAdapter extends PdoAdapter
             $this->quoteColumnName((string)$indexName),
             $this->quoteTableName($tableName),
             implode(',', $columnNames),
-            $includedColumns
+            $includedColumns,
+            $where,
         );
     }
 

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -1290,8 +1290,7 @@ class PostgresAdapter extends PdoAdapter
         $include = $index->getInclude();
         $includedColumns = $include ? sprintf('INCLUDE ("%s")', implode('","', $include)) : '';
 
-        // TODO always concurrently
-        $createIndexSentence = 'CREATE %sINDEX %s ON %s ';
+        $createIndexSentence = 'CREATE %sINDEX%s %s ON %s ';
         if ($index->getType() === self::GIN_INDEX_TYPE) {
             $createIndexSentence .= ' USING ' . $index->getType() . '(%s) %s;';
         } else {
@@ -1300,7 +1299,8 @@ class PostgresAdapter extends PdoAdapter
 
         return sprintf(
             $createIndexSentence,
-            ($index->getType() === Index::UNIQUE ? 'UNIQUE ' : ''),
+            $index->getType() === Index::UNIQUE ? 'UNIQUE ' : '',
+            $index->getConcurrently() ? ' CONCURRENTLY' : '',
             $this->quoteColumnName((string)$indexName),
             $this->quoteTableName($tableName),
             implode(',', $columnNames),

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1378,11 +1378,16 @@ PCRE_PATTERN;
             $indexColumnArray[] = sprintf('`%s` ASC', $column);
         }
         $indexColumns = implode(',', $indexColumnArray);
+        $where = (string)$index->getWhere();
+        if ($where) {
+            $where = ' WHERE ' . $where;
+        }
         $sql = sprintf(
-            'CREATE %s ON %s (%s)',
+            'CREATE %s ON %s (%s)%s',
             $this->getIndexSqlDefinition($table, $index),
             $this->quoteTableName($table->getName()),
-            $indexColumns
+            $indexColumns,
+            $where
         );
 
         return new AlterInstructions([], [$sql]);

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -1201,14 +1201,14 @@ SQL;
         }, $columnNames);
 
         $include = $index->getInclude();
-        $includedColumns = $include ? sprintf('INCLUDE ([%s])', implode('],[', $include)) : '';
+        $includedColumns = $include ? sprintf(' INCLUDE ([%s])', implode('],[', $include)) : '';
         $where = (string)$index->getWhere();
         if ($where) {
             $where = ' WHERE ' . $where;
         }
 
         return sprintf(
-            'CREATE %s INDEX %s ON %s (%s) %s%s;',
+            'CREATE %s INDEX %s ON %s (%s)%s%s;',
             ($index->getType() === Index::UNIQUE ? 'UNIQUE' : ''),
             $indexName,
             $this->quoteTableName($tableName),

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -1202,14 +1202,19 @@ SQL;
 
         $include = $index->getInclude();
         $includedColumns = $include ? sprintf('INCLUDE ([%s])', implode('],[', $include)) : '';
+        $where = (string)$index->getWhere();
+        if ($where) {
+            $where = ' WHERE ' . $where;
+        }
 
         return sprintf(
-            'CREATE %s INDEX %s ON %s (%s) %s;',
+            'CREATE %s INDEX %s ON %s (%s) %s%s;',
             ($index->getType() === Index::UNIQUE ? 'UNIQUE' : ''),
             $indexName,
             $this->quoteTableName($tableName),
             implode(',', $columnNames),
-            $includedColumns
+            $includedColumns,
+            $where
         );
     }
 

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -35,6 +35,13 @@ use RuntimeException;
 use function Cake\Core\deprecationWarning;
 
 /**
+ * Migration Table
+ *
+ * Table instances allow you to define schema changes
+ * to be made on a table. You can manipulate columns,
+ * indexes and foreign keys. You can also manipulate table
+ * data with row operations.
+ *
  * This object is based loosely on: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Table.html.
  */
 class Table

--- a/src/Db/Table/Index.php
+++ b/src/Db/Table/Index.php
@@ -20,7 +20,6 @@ use RuntimeException;
  *
  * TODO expand functionality of Index:
  * - Add ifnotexists
- * - Add nullsfirst/nullslast
  * - Add where for partial indexes
  */
 class Index
@@ -69,6 +68,11 @@ class Index
      * @var string[]|null
      */
     protected ?array $includedColumns = null;
+
+    /**
+     * @var bool
+     */
+    protected bool $concurrent = false;
 
     /**
      * Sets the index columns.
@@ -214,6 +218,31 @@ class Index
     public function getInclude(): ?array
     {
         return $this->includedColumns;
+    }
+
+    /**
+     * Set the concurrent mode for an index
+     *
+     * In postgres, concurrent indexes don't take locks, but cannot be run within transactions.
+     *
+     * @param bool $value The concurrent mode for an index.
+     * @return $this
+     */
+    public function setConcurrently(bool $value)
+    {
+        $this->concurrent = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the concurrent value for an index.
+     *
+     * @return bool
+     */
+    public function getConcurrently(): bool
+    {
+        return $this->concurrent;
     }
 
     /**

--- a/src/Db/Table/Index.php
+++ b/src/Db/Table/Index.php
@@ -17,10 +17,6 @@ use RuntimeException;
  *
  * @see \Migrations\BaseMigration::index()
  * @see \Migrations\Db\Table::addIndex()
- *
- * TODO expand functionality of Index:
- * - Add ifnotexists
- * - Add where for partial indexes
  */
 class Index
 {
@@ -73,6 +69,11 @@ class Index
      * @var bool
      */
     protected bool $concurrent = false;
+
+    /**
+     * @var string|null The where clause for partial indexes.
+     */
+    protected ?string $where = null;
 
     /**
      * Sets the index columns.
@@ -246,6 +247,29 @@ class Index
     }
 
     /**
+     * Set the where clause for partial indexes.
+     *
+     * @param ?string $where The where clause for partial indexes.
+     * @return $this
+     */
+    public function setWhere(?string $where)
+    {
+        $this->where = $where;
+
+        return $this;
+    }
+
+    /**
+     * Get the where clause for partial indexes.
+     *
+     * @return ?string
+     */
+    public function getWhere(): ?string
+    {
+        return $this->where;
+    }
+
+    /**
      * Utility method that maps an array of index options to this objects methods.
      *
      * @param array<string, mixed> $options Options
@@ -255,7 +279,7 @@ class Index
     public function setOptions(array $options)
     {
         // Valid Options
-        $validOptions = ['type', 'unique', 'name', 'limit', 'order', 'include'];
+        $validOptions = ['concurrently', 'type', 'unique', 'name', 'limit', 'order', 'include', 'where'];
         foreach ($options as $option => $value) {
             if (!in_array($option, $validOptions, true)) {
                 throw new RuntimeException(sprintf('"%s" is not a valid index option.', $option));

--- a/src/Table.php
+++ b/src/Table.php
@@ -21,9 +21,13 @@ use Phinx\Db\Table\Column;
 use Phinx\Util\Literal;
 
 /**
- * TODO figure out how to update this for built-in backend.
+ * Migration Table
+ *
+ * This class enhances the phinx provided Table class
+ * with additional CakePHP related logic.
  *
  * @method \Migrations\CakeAdapter getAdapter()
+ * @deprecated 4.6.0 Use \Migrations\Db\Table instead with the builtin backend.
  */
 class Table extends BaseTable
 {

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -16,6 +16,7 @@ use Migrations\Db\Adapter\UnsupportedColumnTypeException;
 use Migrations\Db\Literal;
 use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
+use Migrations\Db\Table\Index;
 use PDO;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
@@ -403,6 +404,26 @@ class PostgresAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasIndex('table1', ['email']));
         $this->assertFalse($this->adapter->hasIndex('table1', ['email', 'user_email']));
         $this->assertTrue($this->adapter->hasIndexByName('table1', 'myemailindex'));
+    }
+
+    public function testCreateTableWithIndexNullOrdering(): void
+    {
+        $options = $this->adapter->getOptions();
+        $options['dryrun'] = true;
+        $this->adapter->setOptions($options);
+
+        $index = new Index();
+        $index->setColumns('email')
+            ->setOrder(['email' => 'ASC NULLS FIRST']);
+
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('email', 'string')
+              ->addIndex($index)
+              ->save();
+        $queries = $this->out->messages();
+        $indexQuery = $queries[3];
+        $this->assertStringContainsString('CREATE INDEX "table1_email"', $indexQuery);
+        $this->assertStringContainsString('("email" ASC NULLS FIRST)', $indexQuery);
     }
 
     public function testAddPrimaryKey()

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -426,6 +426,26 @@ class PostgresAdapterTest extends TestCase
         $this->assertStringContainsString('("email" ASC NULLS FIRST)', $indexQuery);
     }
 
+    public function testCreateTableWithIndexConcurrently(): void
+    {
+        $options = $this->adapter->getOptions();
+        $options['dryrun'] = true;
+        $this->adapter->setOptions($options);
+
+        $index = new Index();
+        $index->setColumns('email')
+            ->setType(Index::UNIQUE)
+            ->setConcurrently(true);
+
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('email', 'string')
+              ->addIndex($index)
+              ->save();
+        $queries = $this->out->messages();
+        $indexQuery = $queries[3];
+        $this->assertStringContainsString('CREATE UNIQUE INDEX CONCURRENTLY "table1_email"', $indexQuery);
+    }
+
     public function testAddPrimaryKey()
     {
         $table = new Table('table1', ['id' => false], $this->adapter);

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -446,6 +446,28 @@ class PostgresAdapterTest extends TestCase
         $this->assertStringContainsString('CREATE UNIQUE INDEX CONCURRENTLY "table1_email"', $indexQuery);
     }
 
+    public function testCreateTableIndexWithWhere(): void
+    {
+        $options = $this->adapter->getOptions();
+        $options['dryrun'] = true;
+        $this->adapter->setOptions($options);
+
+        $index = new Index();
+        $index->setColumns('email')
+            ->setType(Index::UNIQUE)
+            ->setWhere('is_verified = true');
+
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('email', 'string')
+              ->addColumn('is_verified', 'boolean')
+              ->addIndex($index)
+              ->save();
+        $queries = $this->out->messages();
+        $indexQuery = $queries[3];
+        $this->assertStringContainsString('CREATE UNIQUE INDEX "table1_email"', $indexQuery);
+        $this->assertStringContainsString('("email") WHERE is_verified = true', $indexQuery);
+    }
+
     public function testAddPrimaryKey()
     {
         $table = new Table('table1', ['id' => false], $this->adapter);

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -18,6 +18,7 @@ use Migrations\Db\Literal;
 use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
+use Migrations\Db\Table\Index;
 use PDOException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -356,6 +357,28 @@ class SqliteAdapterTest extends TestCase
             'CONSTRAINT `fk_master_id` FOREIGN KEY (`master_id`) REFERENCES `tbl_master` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION',
             $row['sql']
         );
+    }
+
+    public function testCreateTableIndexWithWhere(): void
+    {
+        $options = $this->adapter->getOptions();
+        $options['dryrun'] = true;
+        $this->adapter->setOptions($options);
+
+        $index = new Index();
+        $index->setColumns('email')
+            ->setType(Index::UNIQUE)
+            ->setWhere('is_verified = true');
+
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('email', 'string')
+              ->addColumn('is_verified', 'boolean')
+              ->addIndex($index)
+              ->save();
+        $queries = $this->out->messages();
+        $indexQuery = $queries[2];
+        $this->assertStringContainsString('CREATE UNIQUE INDEX `table1_email_index`', $indexQuery);
+        $this->assertStringContainsString('(`email` ASC) WHERE is_verified = true', $indexQuery);
     }
 
     public function testAddPrimaryKey()

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -324,8 +324,8 @@ WHERE t.name='ntable'");
               ->addIndex($index)
               ->save();
         $queries = $this->out->messages();
-        $indexQuery = $queries[2];
-        $this->assertStringContainsString('CREATE UNIQUE INDEX [active_email_index]', $indexQuery);
+        $indexQuery = $queries[1];
+        $this->assertStringContainsString('CREATE UNIQUE INDEX active_email_index', $indexQuery);
         $this->assertStringContainsString('([email]) WHERE is_verified = true', $indexQuery);
     }
 

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -15,6 +15,7 @@ use Migrations\Db\Literal;
 use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
+use Migrations\Db\Table\Index;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
@@ -303,6 +304,29 @@ WHERE t.name='ntable'");
         $this->assertTrue($this->adapter->hasIndex('table1', ['email']));
         $this->assertFalse($this->adapter->hasIndex('table1', ['email', 'user_email']));
         $this->assertTrue($this->adapter->hasIndexByName('table1', 'myemailindex'));
+    }
+
+    public function testCreateTableIndexWithWhere(): void
+    {
+        $options = $this->adapter->getOptions();
+        $options['dryrun'] = true;
+        $this->adapter->setOptions($options);
+
+        $index = new Index();
+        $index->setColumns('email')
+            ->setName('active_email_index')
+            ->setType(Index::UNIQUE)
+            ->setWhere('is_verified = true');
+
+        $table = new Table('table1', [], $this->adapter);
+        $table->addColumn('email', 'string')
+              ->addColumn('is_verified', 'boolean')
+              ->addIndex($index)
+              ->save();
+        $queries = $this->out->messages();
+        $indexQuery = $queries[2];
+        $this->assertStringContainsString('CREATE UNIQUE INDEX [active_email_index]', $indexQuery);
+        $this->assertStringContainsString('([email]) WHERE is_verified = true', $indexQuery);
     }
 
     public function testAddPrimaryKey()


### PR DESCRIPTION
Add support for `CREATE INDEX CONCURRENTLY` in postgres. This is an important feature for deploying indexes without downtime. I've also added support for partial indexes via `CREATE INDEX ... WHERE` which is supported in postgres, sqlserver and sqlite. I've only implemented SQL fragment support for `WHERE` clauses on indexes as supporting `QueryExpression` objects was complicated because cakephp/database doesn't expose good APIs for compiling expressions into SQL fragments with parameters inserted.