### PR TITLE
Clean up output from pending migrations middleware.

### DIFF
--- a/src/Middleware/PendingMigrationsMiddleware.php
+++ b/src/Middleware/PendingMigrationsMiddleware.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Migrations\Middleware;
 
 use Cake\Console\ConsoleIo;
+use Cake\Console\TestSuite\StubConsoleInput;
+use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Core\InstanceConfigTrait;
@@ -107,8 +109,7 @@ class PendingMigrationsMiddleware implements MiddlewareInterface
         $database = $connection->config()['database'];
         $this->_config['environment']['database'] = $database;
 
-        $config = new Config($this->_config);
-        $manager = new Manager($config, new ConsoleIo());
+        $manager = $this->getManager($this->_config);
 
         $migrations = $manager->getMigrations();
         foreach ($migrations as $migration) {
@@ -144,9 +145,7 @@ class PendingMigrationsMiddleware implements MiddlewareInterface
         $table = Util::tableName($plugin);
 
         $config['environment']['migration_table'] = $table;
-
-        $managerConfig = new Config($config);
-        $manager = new Manager($managerConfig, new ConsoleIo());
+        $manager = $this->getManager($config);
 
         $migrations = $manager->getMigrations();
         foreach ($migrations as $migration) {
@@ -165,5 +164,23 @@ class PendingMigrationsMiddleware implements MiddlewareInterface
     protected function isSkipped(ServerRequestInterface $request): bool
     {
         return (bool)Hash::get($request->getQueryParams(), static::SKIP_QUERY_KEY);
+    }
+
+    /**
+     * Create a manager instance with stubbed console io
+     *
+     * @param array $config Configuration data
+     * @return \Migrations\Migration\Manager
+     */
+    protected function getManager(array $config): Manager
+    {
+        $managerConfig = new Config($config);
+        $io = new ConsoleIo(
+            new StubConsoleOutput(),
+            new StubConsoleOutput(),
+            new StubConsoleInput([]),
+        );
+
+        return new Manager($managerConfig, $io);
     }
 }

--- a/tests/TestCase/Middleware/PendingMigrationsMiddlewareTest.php
+++ b/tests/TestCase/Middleware/PendingMigrationsMiddlewareTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Migrations\Test\TestCase\Middleware;
 
 use Cake\Console\ConsoleIo;
+use Cake\Console\TestSuite\StubConsoleInput;
+use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Core\Exception\CakeException;
 use Cake\Datasource\ConnectionManager;
 use Cake\Http\Response;
@@ -26,6 +28,10 @@ use TestApp\Http\TestRequestHandler;
 
 class PendingMigrationsMiddlewareTest extends TestCase
 {
+    private string $db;
+
+    private ConsoleIo $io;
+
     /**
      * Setup method
      *
@@ -34,6 +40,15 @@ class PendingMigrationsMiddlewareTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+        $connection = ConnectionManager::get('test');
+
+        $config = $connection->config();
+        $this->db = $config['database'];
+        $this->io = new ConsoleIo(
+            new StubConsoleOutput(),
+            new StubConsoleOutput(),
+            new StubConsoleInput([])
+        );
     }
 
     public function tearDown(): void
@@ -75,13 +90,13 @@ class PendingMigrationsMiddlewareTest extends TestCase
                'migrations' => ROOT . DS . 'config' . DS . 'Migrations' . DS,
             ],
             'environment' => [
-               'database' => 'cakephp_test',
+               'database' => $this->db,
                'connection' => 'default',
                'migration_table' => 'phinxlog',
             ],
         ];
         $config = new Config($config);
-        $manager = new Manager($config, new ConsoleIo());
+        $manager = new Manager($config, $this->io);
         $manager->migrate(null, true);
 
         $request = new ServerRequest();
@@ -132,12 +147,12 @@ class PendingMigrationsMiddlewareTest extends TestCase
             ],
             'environment' => [
                 'connection' => 'default',
-                'database' => 'cakephp_test',
+                'database' => $this->db,
                 'migration_table' => 'migrator_phinxlog',
             ],
         ];
         $config = new Config($config);
-        $manager = new Manager($config, new ConsoleIo());
+        $manager = new Manager($config, $this->io);
         $manager->migrate(null, true);
 
         $request = new ServerRequest();


### PR DESCRIPTION
Clean up the output leaks in tests and make tests compatible with database names that aren't `cakephp_test`.