### PR TITLE
Consolidate shared code into PdoAdapter

### DIFF
--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -11,7 +11,6 @@ namespace Migrations\Db\Adapter;
 use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Exception\QueryException;
-use Cake\Database\Schema\SchemaDialect;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
 use Migrations\Db\Literal;
@@ -172,18 +171,6 @@ class MysqlAdapter extends PdoAdapter
         $driver = $this->getConnection()->getDriver();
 
         return $driver->quoteIdentifier($columnName);
-    }
-
-    /**
-     * Get the schema dialect for this adapter.
-     *
-     * @return \Cake\Database\Schema\SchemaDialect
-     */
-    protected function getSchemaDialect(): SchemaDialect
-    {
-        $driver = $this->getConnection()->getDriver();
-
-        return $driver->schemaDialect();
     }
 
     /**

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -91,19 +91,6 @@ class MysqlAdapter extends PdoAdapter
     public const FIRST = 'FIRST';
 
     /**
-     * {@inheritDoc}
-     *
-     * @throws \RuntimeException
-     * @throws \InvalidArgumentException
-     * @return void
-     */
-    public function connect(): void
-    {
-        $this->getConnection()->getDriver()->connect();
-        $this->setConnection($this->getConnection());
-    }
-
-    /**
      * @inheritDoc
      */
     public function setConnection(Connection $connection): AdapterInterface
@@ -116,61 +103,11 @@ class MysqlAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function disconnect(): void
-    {
-        $this->getConnection()->getDriver()->disconnect();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function hasTransactions(): bool
-    {
-        return true;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function beginTransaction(): void
-    {
-        $this->getConnection()->begin();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function commitTransaction(): void
-    {
-        $this->getConnection()->commit();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function rollbackTransaction(): void
-    {
-        $this->getConnection()->rollback();
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function quoteTableName(string $tableName): string
     {
         $driver = $this->getConnection()->getDriver();
 
         return $driver->quoteIdentifier($tableName);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function quoteColumnName(string $columnName): string
-    {
-        $driver = $this->getConnection()->getDriver();
-
-        return $driver->quoteIdentifier($columnName);
     }
 
     /**

--- a/src/Db/Adapter/PdoAdapter.php
+++ b/src/Db/Adapter/PdoAdapter.php
@@ -16,6 +16,7 @@ use Cake\Database\Query\DeleteQuery;
 use Cake\Database\Query\InsertQuery;
 use Cake\Database\Query\SelectQuery;
 use Cake\Database\Query\UpdateQuery;
+use Cake\Database\Schema\SchemaDialect;
 use InvalidArgumentException;
 use Migrations\Config\Config;
 use Migrations\Db\Action\AddColumn;
@@ -54,6 +55,18 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
      * @var \Cake\Database\Connection|null
      */
     protected ?Connection $connection = null;
+
+    /**
+     * Get the schema dialect for this adapter.
+     *
+     * @return \Cake\Database\Schema\SchemaDialect
+     */
+    protected function getSchemaDialect(): SchemaDialect
+    {
+        $driver = $this->getConnection()->getDriver();
+
+        return $driver->schemaDialect();
+    }
 
     /**
      * Writes a message to stdout if verbose output is on

--- a/src/Db/Adapter/PdoAdapter.php
+++ b/src/Db/Adapter/PdoAdapter.php
@@ -124,7 +124,7 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     /**
      * @inheritDoc
      */
-    public function quoteColumnName($columnName): string
+    public function quoteColumnName(string $columnName): string
     {
         $driver = $this->getConnection()->getDriver();
 

--- a/src/Db/Adapter/PdoAdapter.php
+++ b/src/Db/Adapter/PdoAdapter.php
@@ -69,6 +69,69 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    public function connect(): void
+    {
+        $this->getConnection()->getDriver()->connect();
+        $this->setConnection($this->getConnection());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function disconnect(): void
+    {
+        $this->getConnection()->getDriver()->disconnect();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function beginTransaction(): void
+    {
+        $this->getConnection()->begin();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function commitTransaction(): void
+    {
+        $this->getConnection()->commit();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function rollbackTransaction(): void
+    {
+        $this->getConnection()->rollback();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasTransactions(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function quoteColumnName($columnName): string
+    {
+        $driver = $this->getConnection()->getDriver();
+
+        return $driver->quoteIdentifier($columnName);
+    }
+
+    /**
      * Writes a message to stdout if verbose output is on
      *
      * @param string $message The message to show
@@ -198,16 +261,6 @@ abstract class PdoAdapter extends AbstractAdapter implements DirectActionInterfa
     {
         return $this->getConnection();
     }
-
-    /**
-     * @inheritDoc
-     */
-    abstract public function connect(): void;
-
-    /**
-     * @inheritDoc
-     */
-    abstract public function disconnect(): void;
 
     /**
      * @inheritDoc

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Migrations\Db\Adapter;
 
 use Cake\Database\Connection;
-use Cake\Database\Schema\SchemaDialect;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
 use Migrations\Db\Literal;
@@ -122,18 +121,6 @@ class PostgresAdapter extends PdoAdapter
     public function rollbackTransaction(): void
     {
         $this->getConnection()->rollback();
-    }
-
-    /**
-     * Get the schema dialect for this adapter.
-     *
-     * @return \Cake\Database\Schema\SchemaDialect
-     */
-    protected function getSchemaDialect(): SchemaDialect
-    {
-        $driver = $this->getConnection()->getDriver();
-
-        return $driver->schemaDialect();
     }
 
     /**

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -71,59 +71,6 @@ class PostgresAdapter extends PdoAdapter
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @throws \RuntimeException
-     * @throws \InvalidArgumentException
-     * @return void
-     */
-    public function connect(): void
-    {
-        $this->getConnection()->getDriver()->connect();
-        $this->setConnection($this->getConnection());
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function disconnect(): void
-    {
-        $this->getConnection()->getDriver()->disconnect();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function hasTransactions(): bool
-    {
-        return true;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function beginTransaction(): void
-    {
-        $this->getConnection()->begin();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function commitTransaction(): void
-    {
-        $this->getConnection()->commit();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function rollbackTransaction(): void
-    {
-        $this->getConnection()->rollback();
-    }
-
-    /**
      * Quotes a schema name for use in a query.
      *
      * @param string $schemaName Schema Name
@@ -142,16 +89,6 @@ class PostgresAdapter extends PdoAdapter
         $parts = $this->getSchemaName($tableName);
 
         return $this->quoteSchemaName($parts['schema']) . '.' . $this->quoteColumnName($parts['table']);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function quoteColumnName(string $columnName): string
-    {
-        $driver = $this->getConnection()->getDriver();
-
-        return $driver->quoteIdentifier($columnName);
     }
 
     /**

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -754,7 +754,7 @@ PCRE_PATTERN;
                 "SELECT *
                 FROM sqlite_master
                 WHERE
-                    (\"type\" = 'index' OR `type` = 'trigger')
+                    (\"type\" = 'index' OR \"type\" = 'trigger')
                     AND tbl_name = ?
                     AND sql IS NOT NULL
                 ",

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -134,19 +134,6 @@ class SqliteAdapter extends PdoAdapter
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @throws \RuntimeException
-     * @throws \InvalidArgumentException
-     * @return void
-     */
-    public function connect(): void
-    {
-        $this->getConnection()->getDriver()->connect();
-        $this->setConnection($this->getConnection());
-    }
-
-    /**
      * @inheritDoc
      */
     public function setOptions(array $options): AdapterInterface
@@ -168,61 +155,11 @@ class SqliteAdapter extends PdoAdapter
     /**
      * @inheritDoc
      */
-    public function disconnect(): void
-    {
-        $this->getConnection()->getDriver()->disconnect();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function hasTransactions(): bool
-    {
-        return true;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function beginTransaction(): void
-    {
-        $this->getConnection()->begin();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function commitTransaction(): void
-    {
-        $this->getConnection()->commit();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function rollbackTransaction(): void
-    {
-        $this->getConnection()->rollBack();
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function quoteTableName($tableName): string
     {
         $driver = $this->getConnection()->getDriver();
 
         return $driver->quoteIdentifier($tableName);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function quoteColumnName($columnName): string
-    {
-        $driver = $this->getConnection()->getDriver();
-
-        return $driver->quoteIdentifier($columnName);
     }
 
     /**

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Migrations\Db\Adapter;
 
 use BadMethodCallException;
-use Cake\Database\Schema\SchemaDialect;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
 use Migrations\Db\Expression;
@@ -224,18 +223,6 @@ class SqliteAdapter extends PdoAdapter
         $driver = $this->getConnection()->getDriver();
 
         return $driver->quoteIdentifier($columnName);
-    }
-
-    /**
-     * Get the schema dialect for this adapter.
-     *
-     * @return \Cake\Database\Schema\SchemaDialect
-     */
-    protected function getSchemaDialect(): SchemaDialect
-    {
-        $driver = $this->getConnection()->getDriver();
-
-        return $driver->schemaDialect();
     }
 
     /**

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -136,7 +136,7 @@ class SqlserverAdapter extends PdoAdapter
             if (is_string($primaryKey)) { // handle primary_key => 'id'
                 $pkSql .= $this->quoteColumnName($primaryKey);
             } elseif (is_array($primaryKey)) { // handle primary_key => array('tag_id', 'resource_id')
-                $pkSql .= implode(',', array_map([$this, 'quoteColumnName'], $primaryKey));
+                $pkSql .= implode(',', array_map($this->quoteColumnName(...), $primaryKey));
             }
             $pkSql .= ')';
             $sqlBuffer[] = $pkSql;
@@ -190,7 +190,7 @@ class SqlserverAdapter extends PdoAdapter
             if (is_string($newColumns)) { // handle primary_key => 'id'
                 $sql .= $this->quoteColumnName($newColumns);
             } elseif (is_array($newColumns)) { // handle primary_key => array('tag_id', 'resource_id')
-                $sql .= implode(',', array_map([$this, 'quoteColumnName'], $newColumns));
+                $sql .= implode(',', array_map($this->quoteColumnName(...), $newColumns));
             }
             $sql .= ')';
             $instructions->addPostStep($sql);

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Migrations\Db\Adapter;
 
 use BadMethodCallException;
-use Cake\Database\Schema\SchemaDialect;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
 use Migrations\Db\Literal;
@@ -98,18 +97,6 @@ class SqlserverAdapter extends PdoAdapter
     public function rollbackTransaction(): void
     {
         $this->getConnection()->rollback();
-    }
-
-    /**
-     * Get the schema dialect for this adapter.
-     *
-     * @return \Cake\Database\Schema\SchemaDialect
-     */
-    protected function getSchemaDialect(): SchemaDialect
-    {
-        $driver = $this->getConnection()->getDriver();
-
-        return $driver->schemaDialect();
     }
 
     /**

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -48,58 +48,6 @@ class SqlserverAdapter extends PdoAdapter
     ];
 
     /**
-     * {@inheritDoc}
-     *
-     * @throws \InvalidArgumentException
-     * @return void
-     */
-    public function connect(): void
-    {
-        $this->getConnection()->getDriver()->connect();
-        $this->setConnection($this->getConnection());
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function disconnect(): void
-    {
-        $this->getConnection()->getDriver()->disconnect();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function hasTransactions(): bool
-    {
-        return true;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function beginTransaction(): void
-    {
-        $this->getConnection()->begin();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function commitTransaction(): void
-    {
-        $this->getConnection()->commit();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function rollbackTransaction(): void
-    {
-        $this->getConnection()->rollback();
-    }
-
-    /**
      * Quotes a schema name for use in a query.
      *
      * @param string $schemaName Schema Name
@@ -118,16 +66,6 @@ class SqlserverAdapter extends PdoAdapter
         $parts = $this->getSchemaName($tableName);
 
         return $this->quoteSchemaName($parts['schema']) . '.' . $this->quoteColumnName($parts['table']);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function quoteColumnName(string $columnName): string
-    {
-        $driver = $this->getConnection()->getDriver();
-
-        return $driver->quoteIdentifier($columnName);
     }
 
     /**


### PR DESCRIPTION
Move a handful of common methods up to `PdoAdapter`. Next, I plan on merging `PdoAdapter` -> `AbstractAdapter` as there aren't any adapter implementations that aren't also `PdoAdapter` and there isn't any support for custom migrations adapters at this time.