### PR TITLE
Add missing array cast in SqliteAdapter

### DIFF
--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -376,6 +376,10 @@ class SqliteAdapter extends PdoAdapter
 
         $sql = 'CREATE TABLE ';
         $sql .= $this->quoteTableName($table->getName()) . ' (';
+        if (isset($options['primary_key'])) {
+            $options['primary_key'] = (array)$options['primary_key'];
+        }
+
         foreach ($columns as $column) {
             $sql .= $this->quoteColumnName((string)$column->getName()) . ' ' . $this->getColumnSqlDefinition($column) . ', ';
 

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -360,17 +360,14 @@ class SqliteAdapterTest extends TestCase
 
     public function testAddPrimaryKey()
     {
-        $table = new Table('table1', ['id' => false], $this->adapter);
+        $table = new Table('table1', [], $this->adapter);
         $table
             ->addColumn('column1', 'integer')
             ->addColumn('column2', 'integer')
+            ->addPrimaryKey('id')
             ->save();
 
-        $table
-            ->changePrimaryKey('column1')
-            ->save();
-
-        $this->assertTrue($this->adapter->hasPrimaryKey('table1', ['column1']));
+        $this->assertTrue($this->adapter->hasPrimaryKey('table1', ['id']));
     }
 
     public function testChangePrimaryKey()


### PR DESCRIPTION
Add an array cast to SqliteAdapter to fix compatibility issue with phinx/table.

Fixes #804