### PR TITLE
check if bake is loaded in BakeSimpleMigrationCommand

### DIFF
--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -20,6 +20,7 @@ use Bake\Utility\TemplateRenderer;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
+use Cake\Core\Plugin;
 use Cake\Utility\Inflector;
 use Migrations\Util\Util;
 
@@ -105,6 +106,10 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
+        if (!Plugin::isLoaded('Bake')) {
+            $io->err('Bake plugin is not loaded. Please load it first to generate a migration.');
+            $this->abort();
+        }
         $this->extractCommonProperties($args);
         $name = $args->getArgumentAt(0);
         if (empty($name)) {

--- a/tests/TestCase/Command/BakeMigrationCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationCommandTest.php
@@ -386,4 +386,16 @@ class BakeMigrationCommandTest extends TestCase
         $this->assertExitCode(BaseCommand::CODE_ERROR);
         $this->assertErrorContains('When applying fields the migration name should start with one of the following prefixes: `Create`, `Drop`, `Add`, `Remove`, `Alter`.');
     }
+
+    public function testBakeMigrationWithoutBake()
+    {
+        // Make sure to unload the Bake plugin
+        $this->createApp()->getEventManager()->on('Console.buildCommands', function ($event, $commands) {
+            Plugin::getCollection()->remove('Bake');
+        });
+
+        $this->exec('bake migration CreateUsers name:string --connection test');
+        $this->assertExitCode(BaseCommand::CODE_ERROR);
+        $this->assertErrorContains('Bake plugin is not loaded. Please load it first to generate a migration.');
+    }
 }


### PR DESCRIPTION
A community member reported in slack/discord, that there is a strange error when trying to bake a migration with
```
bin/cake migrations create CreateSomeTable  
```

<details>

<summary>Stacktrace</summary>

```
2025-01-19 22:06:01 error: [Cake\View\Exception\MissingTemplateException] Template file `No bake template found for "Migrations.config/skeleton" skipping file generation.` could not be found. in /Users/kevin/Documents/sunlime/alfred/vendor/cakephp/bake/src/Utility/TemplateRenderer.php on line 104
Exception Attributes: array (
  'file' => 'No bake template found for "Migrations.config/skeleton" skipping file generation.',
  'paths' => 
  array (
  ),
)
Stack Trace:
- ROOT/vendor/cakephp/migrations/src/Command/BakeSimpleMigrationCommand.php:129
- ROOT/vendor/cakephp/migrations/src/Command/BakeMigrationCommand.php:55
- ROOT/vendor/cakephp/migrations/src/Command/BakeSimpleMigrationCommand.php:92
- CORE/src/Console/BaseCommand.php:202
- CORE/src/Console/CommandRunner.php:330
- CORE/src/Console/CommandRunner.php:168
- ROOT/bin/cake.php:11
- [main]:

[Cake\View\Exception\MissingTemplateException] Template file `No bake template found for "Migrations.config/skeleton" skipping file generation.` could not be found. in /Users/kevin/Documents/sunlime/alfred/vendor/cakephp/bake/src/Utility/TemplateRenderer.php on line 104

Exception Attributes

array (
  'file' => 'No bake template found for "Migrations.config/skeleton" skipping file generation.',
  'paths' => 
  array (
  ),
)

Stack Trace:

Bake\Utility\TemplateRenderer->generate() - ROOT/vendor/cakephp/migrations/src/Command/BakeSimpleMigrationCommand.php, line 129
Migrations\Command\BakeSimpleMigrationCommand->bake() - ROOT/vendor/cakephp/migrations/src/Command/BakeMigrationCommand.php, line 55
Migrations\Command\BakeMigrationCommand->bake() - ROOT/vendor/cakephp/migrations/src/Command/BakeSimpleMigrationCommand.php, line 92
Migrations\Command\BakeSimpleMigrationCommand->execute() - CORE/src/Console/BaseCommand.php, line 202
Cake\Console\BaseCommand->run() - CORE/src/Console/CommandRunner.php, line 330
Cake\Console\CommandRunner->runCommand() - CORE/src/Console/CommandRunner.php, line 168
Cake\Console\CommandRunner->run() - ROOT/bin/cake.php, line 11
[main] - [main], line 0

```

</details>

the main problem was the fact, that the `Bake` Plugin was not loaded in his main app.

We don't check that in our base class, therefore this PR adds this check.