### PR TITLE
fix migration diff dump source by parsing source parameter

### DIFF
--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -516,6 +516,11 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
         if (!empty($args->getOption('connection'))) {
             $connectionName = $inputArgs['--connection'] = $args->getOption('connection');
         }
+
+        if (!empty($args->getOption('source'))) {
+            $inputArgs['--source'] = $args->getOption('source');
+        }
+
         if (!empty($args->getOption('plugin'))) {
             $inputArgs['--plugin'] = $args->getOption('plugin');
         }

--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -517,7 +517,7 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             $connectionName = $inputArgs['--connection'] = $args->getOption('connection');
         }
 
-        if (!empty($args->getOption('source'))) {
+        if ($args->getOption('source')) {
             $inputArgs['--source'] = $args->getOption('source');
         }
 


### PR DESCRIPTION
fixes #809

source parameter was not parsed when building the path for the dump file.