### PR TITLE
4.x: fix rollback not working with a simple change migration

### DIFF
--- a/src/Migration/Environment.php
+++ b/src/Migration/Environment.php
@@ -109,7 +109,7 @@ class Environment
                             ->getWrapper('record', $adapter);
 
                         // Wrap the adapter with a phinx shim to maintain contain
-                        $migration->setAdapter($adapter);
+                        $migration->setAdapter($recordAdapter);
 
                         $migration->{MigrationInterface::CHANGE}();
                         $recordAdapter->executeInvertedCommands();

--- a/tests/TestCase/Command/RollbackCommandTest.php
+++ b/tests/TestCase/Command/RollbackCommandTest.php
@@ -82,6 +82,26 @@ class RollbackCommandTest extends TestCase
         $this->assertFileDoesNotExist($dumpFile);
     }
 
+    public function testExecuteActuallyWorks(): void
+    {
+        $this->exec('migrations migrate -c test -s MigrationsRollback --no-lock');
+        $this->assertExitSuccess();
+        $this->resetOutput();
+
+        $this->exec('migrations rollback -c test -s MigrationsRollback --no-lock');
+        $this->assertExitSuccess();
+
+        $this->assertOutputContains('<info>20250307183600 ChangeTestTable:</info> <comment>reverting </comment>');
+        $this->assertOutputContains('<info>20250307183600 ChangeTestTable:</info> <comment>reverted');
+        $this->resetOutput();
+
+        $this->exec('migrations status -c test -s MigrationsRollback --format json');
+        $this->assertExitSuccess();
+        $output = $this->_out->messages();
+        $parsed = json_decode($output[0], true);
+        $this->assertEquals('down', $parsed[0]['status'], 'Migration status should be down');
+    }
+
     /**
      * Test that running with dry-run works
      */

--- a/tests/test_app/config/MigrationsRollback/20250307183600_change_test_table.php
+++ b/tests/test_app/config/MigrationsRollback/20250307183600_change_test_table.php
@@ -1,0 +1,14 @@
+<?php
+
+use Migrations\BaseMigration;
+
+// This NEEDs to be the new BaseMigration class to check if rollbacks work correctly with the new builtin backend
+class ChangeTestTable extends BaseMigration
+{
+    public function change(): void
+    {
+        $this->table('test')
+            ->addColumn('name', 'string')
+            ->save();
+    }
+}


### PR DESCRIPTION
Do you want an adapter? I can get you an adpater for your adapater to adapter your adapter to another adaptor.

It seems we have adaptered too hard here....

---

As the title says trying to rollback a simple
```
        $this->table('test')
            ->addColumn('othername', 'string')
            ->save();
```

cause the following error 

```
 == 20250307170352 Test2: reverting 
SQLSTATE[HY000]: General error: 1 duplicate column name: othername
Query: CREATE TABLE "tmp_test" ("id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, "name" VARCHAR NOT NULL, "othername" VARCHAR NOT NULL, "othername" VARCHAR NOT NULL);
```

since it didn't actually prevent the migrations from executing again (to rollback the actions accordingly)

This ONLY was the case, when using the built-in backend and tried to rollback a new migration with the new base class `\Migrations\BaseMigration`.

