### PR TITLE
Update more deprecated method usage

### DIFF
--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -16,6 +16,7 @@ use Migrations\Db\Adapter\UnsupportedColumnTypeException;
 use Migrations\Db\Literal;
 use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
+use Migrations\Db\Table\ForeignKey;
 use PDO;
 use PDOException;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -1679,21 +1680,22 @@ class MysqlAdapterTest extends TestCase
             ->save();
 
         $table = new Table('table', [], $this->adapter);
+        $keyOne = (new ForeignKey())
+            ->setName('ref_table_fk_1')
+            ->setColumns(['ref_table_id', 'ref_table_field1'])
+            ->setReferencedTable('ref_table')
+            ->setReferencedColumns(['id', 'field1']);
+        $keyTwo = (new ForeignKey())
+            ->setName('ref_table_fk_2')
+            ->setColumns(['ref_table_id', 'ref_table_field1'])
+            ->setReferencedTable('ref_table')
+            ->setReferencedColumns(['id', 'field1']);
+
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addColumn('ref_table_field1', 'string', ['limit' => 8])
-            ->addForeignKeyWithName(
-                'ref_table_fk_1',
-                ['ref_table_id', 'ref_table_field1'],
-                'ref_table',
-                ['id', 'field1'],
-            )
-            ->addForeignKeyWithName(
-                'ref_table_fk_2',
-                ['ref_table_id', 'ref_table_field1'],
-                'ref_table',
-                ['id', 'field1']
-            )
+            ->addForeignKey($keyOne)
+            ->addForeignKey($keyTwo)
             ->save();
 
         $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
@@ -1770,9 +1772,14 @@ class MysqlAdapterTest extends TestCase
         $refTable->save();
 
         $table = new Table('table', [], $this->adapter);
+        $key = (new ForeignKey())
+            ->setName('my_constraint')
+            ->setColumns(['ref_table_id'])
+            ->setReferencedTable('ref_table')
+            ->setReferencedColumns(['id']);
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
-            ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])
+            ->addForeignKey($key)
             ->save();
 
         $this->adapter->dropForeignKey($table->getName(), [], 'my_constraint');
@@ -1865,9 +1872,14 @@ class MysqlAdapterTest extends TestCase
         $refTable->addColumn('field1', 'string')->save();
 
         $table = new Table('table', [], $this->adapter);
+        $key = (new ForeignKey())
+            ->setName('my_constraint')
+            ->setColumns(['ref_table_id'])
+            ->setReferencedTable('ref_table')
+            ->setReferencedColumns(['id']);
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
-            ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])
+            ->addForeignKey($key)
             ->save();
 
         $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id'], 'my_constraint'));
@@ -1883,9 +1895,14 @@ class MysqlAdapterTest extends TestCase
         $refTable->addColumn('field1', 'string')->save();
 
         $table = new Table('table', [], $this->adapter);
+        $key = (new ForeignKey())
+            ->setName('my_constraint')
+            ->setColumns(['ref_table_id'])
+            ->setReferencedTable('ref_table')
+            ->setReferencedColumns(['id']);
         $table
             ->addColumn('ref_table_id', 'integer')
-            ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])
+            ->addForeignKey($key)
             ->save();
 
         $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id'], 'my_constraint'));

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -1462,21 +1462,22 @@ class SqliteAdapterTest extends TestCase
             ->save();
 
         $table = new Table('table', [], $this->adapter);
+        $keyOne = (new ForeignKey())
+            ->setName('ref_table_fk_1')
+            ->setColumns(['ref_table_id', 'ref_table_field1'])
+            ->setReferencedTable('ref_table')
+            ->setReferencedColumns(['id', 'field1']);
+        $keyTwo = (new ForeignKey())
+            ->setName('ref_table_fk_2')
+            ->setColumns(['ref_table_id', 'ref_table_field1'])
+            ->setReferencedTable('ref_table')
+            ->setReferencedColumns(['id', 'field1']);
+
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addColumn('ref_table_field1', 'string')
-            ->addForeignKeyWithName(
-                'ref_table_fk_1',
-                ['ref_table_id', 'ref_table_field1'],
-                'ref_table',
-                ['id', 'field1'],
-            )
-            ->addForeignKeyWithName(
-                'ref_table_fk_2',
-                ['ref_table_id', 'ref_table_field1'],
-                'ref_table',
-                ['id', 'field1']
-            )
+            ->addForeignKey($keyOne)
+            ->addForeignKey($keyTwo)
             ->save();
 
         $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
@@ -1556,9 +1557,14 @@ class SqliteAdapterTest extends TestCase
         $refTable->save();
 
         $table = new Table('table', [], $this->adapter);
+        $key = (new ForeignKey())
+            ->setName('my_constraint')
+            ->setColumns(['ref_table_id'])
+            ->setReferencedTable('ref_table')
+            ->setReferencedColumns(['id']);
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
-            ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])
+            ->addForeignKey($key)
             ->save();
 
         $this->adapter->dropForeignKey($table->getName(), [], 'my_constraint');

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -851,7 +851,7 @@ WHERE t.name='ntable'");
         $fk->setReferencedTable($refTable->getTable())
            ->setColumns(['ref_table_id'])
            ->setReferencedColumns(['id'])
-           ->setConstraint('fk1');
+           ->setName('fk1');
 
         $this->adapter->addForeignKey($table->getTable(), $fk);
         $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id'], 'fk1'));
@@ -932,21 +932,21 @@ WHERE t.name='ntable'");
             ->save();
 
         $table = new Table('table', [], $this->adapter);
+        $keyOne = (new ForeignKey())
+            ->setName('ref_table_fk_1')
+            ->setColumns(['ref_table_id', 'ref_table_field1'])
+            ->setReferencedTable('ref_table')
+            ->setReferencedColumns(['id', 'field1']);
+        $keyTwo = (new ForeignKey())
+            ->setName('ref_table_fk_2')
+            ->setColumns(['ref_table_id', 'ref_table_field1'])
+            ->setReferencedTable('ref_table')
+            ->setReferencedColumns(['id', 'field1']);
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
             ->addColumn('ref_table_field1', 'string')
-            ->addForeignKeyWithName(
-                'ref_table_fk_1',
-                ['ref_table_id', 'ref_table_field1'],
-                'ref_table',
-                ['id', 'field1'],
-            )
-            ->addForeignKeyWithName(
-                'ref_table_fk_2',
-                ['ref_table_id', 'ref_table_field1'],
-                'ref_table',
-                ['id', 'field1']
-            )
+            ->addForeignKey($keyOne)
+            ->addForeignKey($keyTwo)
             ->save();
 
         $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
@@ -1030,9 +1030,14 @@ WHERE t.name='ntable'");
         $refTable->save();
 
         $table = new Table('table', [], $this->adapter);
+        $key = (new ForeignKey())
+            ->setName('my_constraint')
+            ->setColumns(['ref_table_id'])
+            ->setReferencedTable('ref_table')
+            ->setReferencedColumns(['id']);
         $table
             ->addColumn('ref_table_id', 'integer', ['signed' => false])
-            ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])
+            ->addForeignKey($key)
             ->save();
 
         $this->adapter->dropForeignKey($table->getName(), [], 'my_constraint');
@@ -1080,9 +1085,14 @@ WHERE t.name='ntable'");
         $refTable->save();
 
         $table = new Table('table', [], $this->adapter);
+        $key = (new ForeignKey())
+            ->setName('my_constraint')
+            ->setColumns(['ref_table_id'])
+            ->setReferencedTable('ref_table')
+            ->setReferencedColumns(['id']);
         $table
             ->addColumn('ref_table_id', 'integer')
-            ->addForeignKeyWithName('my_constraint', ['ref_table_id'], 'ref_table', ['id'])
+            ->addForeignKey($key)
             ->save();
 
         $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id'], 'my_constraint'));


### PR DESCRIPTION
There were more deprecated method calls in tests that we can update now. I've retained a couple tests for addForeignKeyWithName() in TableTest.