### PR TITLE
Allow dynamic connection

### DIFF
--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**
@@ -647,6 +646,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
 
         if ($this->isDryRunEnabled()) {
             $sql .= ' VALUES (' . implode(', ', array_map($this->quoteValue(...), $row)) . ');';
+
             return $sql;
         } else {
             $values = [];
@@ -658,6 +658,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
                 $values[] = $placeholder;
             }
             $sql .= ' VALUES (' . implode(',', $values) . ')';
+
             return $sql;
         }
     }
@@ -733,6 +734,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
             $this->getConnection()->execute($sql, $vals);
         }
     }
+
     /**
      * Generates the SQL for a bulk insert.
      *
@@ -756,6 +758,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
                 return '(' . implode(', ', array_map($this->quoteValue(...), $row)) . ')';
             }, $rows);
             $sql .= implode(', ', $values) . ';';
+
             return $sql;
         } else {
             $queries = [];
@@ -772,6 +775,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
                 $queries[] = $query;
             }
             $sql .= implode(',', $queries);
+
             return $sql;
         }
     }

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**
@@ -17,8 +16,8 @@ use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use Migrations\Db\Table\Table;
-use Migrations\MigrationInterface;
 use Migrations\Db\Table\Table as TableMetadata;
+use Migrations\MigrationInterface;
 use Phinx\Util\Literal as PhinxLiteral;
 
 /**
@@ -1315,6 +1314,7 @@ SQL;
 
         return parent::migrated($migration, $direction, $startTime, $endTime);
     }
+
     /**
      * @inheritDoc
      */
@@ -1323,7 +1323,6 @@ SQL;
         $sql = $this->generateInsertSql($table, $row);
 
         $sql = $this->updateSQLForIdentityInsert($table->getName(), $sql);
-
 
         if ($this->isDryRunEnabled()) {
             $this->io->out($sql);
@@ -1341,6 +1340,7 @@ SQL;
             $this->getConnection()->execute($sql, $vals);
         }
     }
+
     /**
      * @inheritDoc
      */
@@ -1372,6 +1372,7 @@ SQL;
             $this->getConnection()->execute($sql, $vals);
         }
     }
+
     /**
      * @param string $tableName Table name
      * @param string $sql SQL statement
@@ -1383,14 +1384,15 @@ SQL;
         if (isset($options['identity_insert']) && $options['identity_insert'] == true) {
             $identityInsertStart = sprintf(
                 'SET IDENTITY_INSERT %s ON',
-                $this->quoteTableName($tableName)
+                $this->quoteTableName($tableName),
             );
             $identityInsertEnd = sprintf(
                 'SET IDENTITY_INSERT %s OFF',
-                $this->quoteTableName($tableName)
+                $this->quoteTableName($tableName),
             );
             $sql = $identityInsertStart . ';' . PHP_EOL . $sql . ';' . PHP_EOL . $identityInsertEnd;
         }
+
         return $sql;
     }
 }

--- a/src/Migration/ManagerFactory.php
+++ b/src/Migration/ManagerFactory.php
@@ -88,12 +88,21 @@ class ManagerFactory
         $templatePath = dirname(__DIR__) . DS . 'templates' . DS;
         $connectionName = (string)$this->getOption('connection');
 
-        $connectionConfig = ConnectionManager::getConfig($connectionName);
+        if (str_contains($connectionName, '://')) {
+            $connectionConfig = ConnectionManager::parseDsn($connectionName);
+            $connectionName = 'tmp';
+        } else {
+            $connectionConfig = ConnectionManager::getConfig($connectionName);
+        }
         if (!$connectionConfig) {
             throw new RuntimeException("Could not find connection `{$connectionName}`");
         }
         if (!isset($connectionConfig['database'])) {
             throw new RuntimeException("The `{$connectionName}` connection has no `database` key defined.");
+        }
+
+        if (!ConnectionManager::getConfig($connectionName)) {
+            ConnectionManager::setConfig($connectionName, $connectionConfig);
         }
 
         /** @var array<string, string> $connectionConfig */

--- a/src/Migration/ManagerFactory.php
+++ b/src/Migration/ManagerFactory.php
@@ -91,6 +91,9 @@ class ManagerFactory
         if (str_contains($connectionName, '://')) {
             $connectionConfig = ConnectionManager::parseDsn($connectionName);
             $connectionName = 'tmp';
+            if (!ConnectionManager::getConfig($connectionName)) {
+                ConnectionManager::setConfig($connectionName, $connectionConfig);
+            }
         } else {
             $connectionConfig = ConnectionManager::getConfig($connectionName);
         }
@@ -99,10 +102,6 @@ class ManagerFactory
         }
         if (!isset($connectionConfig['database'])) {
             throw new RuntimeException("The `{$connectionName}` connection has no `database` key defined.");
-        }
-
-        if (!ConnectionManager::getConfig($connectionName)) {
-            ConnectionManager::setConfig($connectionName, $connectionConfig);
         }
 
         /** @var array<string, string> $connectionConfig */

--- a/src/Migration/ManagerFactory.php
+++ b/src/Migration/ManagerFactory.php
@@ -89,6 +89,7 @@ class ManagerFactory
         $connectionName = (string)$this->getOption('connection');
 
         if (str_contains($connectionName, '://')) {
+            /** @var array<string, mixed> $connectionConfig */
             $connectionConfig = ConnectionManager::parseDsn($connectionName);
             $connectionName = 'tmp';
             if (!ConnectionManager::getConfig($connectionName)) {

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Migrations\Test\Db\Adapter;
@@ -832,7 +831,7 @@ WHERE t.name='ntable'");
             ->addColumn('lname', 'string')
             ->addIndex(
                 ['fname', 'lname'],
-                ['name' => 'twocolumnuniqueindex', 'unique' => true]
+                ['name' => 'twocolumnuniqueindex', 'unique' => true],
             )
             ->save();
 
@@ -1269,7 +1268,7 @@ WHERE t.name='ntable'");
                 [
                     'column1' => 'value3',
                     'column2' => 3,
-                ]
+                ],
             );
 
         $this->adapter->bulkinsert($table->getTable(), $table->getData());
@@ -1335,7 +1334,7 @@ WHERE t.name='ntable'");
                 [
                     'column1' => 'value3',
                     'column2' => 3,
-                ]
+                ],
             )
             ->save();
 

--- a/tests/TestCase/Migration/ManagerFactoryTest.php
+++ b/tests/TestCase/Migration/ManagerFactoryTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Migrations\Test\TestCase\Migration;
+
+use Cake\Console\ConsoleIo;
+use Cake\Console\TestSuite\StubConsoleInput;
+use Cake\Console\TestSuite\StubConsoleOutput;
+use Cake\Datasource\ConnectionManager;
+use Migrations\Migration\ManagerFactory;
+use PHPUnit\Framework\TestCase;
+
+class ManagerFactoryTest extends TestCase
+{
+    public function testConnection(): void
+    {
+        $this->out = new StubConsoleOutput();
+        $this->out->setOutputAs(StubConsoleOutput::PLAIN);
+        $this->in = new StubConsoleInput([]);
+
+        $io = new ConsoleIo($this->out, $this->out, $this->in);
+
+        $factory = new ManagerFactory(['connection' => 'test']);
+        $result = $factory->createManager($io);
+
+        $this->assertSame('test', $result->getConfig()->getConnection());
+    }
+
+    public function testDsnConnection(): void
+    {
+        $this->out = new StubConsoleOutput();
+        $this->out->setOutputAs(StubConsoleOutput::PLAIN);
+        $this->in = new StubConsoleInput([]);
+
+        $io = new ConsoleIo($this->out, $this->out, $this->in);
+
+        $factory = new ManagerFactory(['connection' => 'mysql://root@127.0.0.1/db_tmp']);
+        $result = $factory->createManager($io);
+
+        $this->assertSame('tmp', $result->getConfig()->getConnection());
+        $expected = [
+            'scheme' => 'mysql',
+            'username' => 'root',
+            'host' => '127.0.0.1',
+            'className' => 'Cake\Database\Connection',
+            'database' => 'db_tmp',
+            'driver' => 'Cake\Database\Driver\Mysql',
+            'name' => 'tmp',
+        ];
+        $this->assertEquals($expected, ConnectionManager::getConfig('tmp'));
+    }
+}


### PR DESCRIPTION
If a valid DSN is passed, it should take that one.
This allows to create a tmp connection without the need to hardcode that in configs.

> bin/cake migrations migrate -c mysql://root@127.0.0.1/db_tmp --no-lock