### PR TITLE
Fix up DateTime support for seed bulkinsert().

### DIFF
--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -17,6 +17,8 @@ use Cake\Database\Query\InsertQuery;
 use Cake\Database\Query\SelectQuery;
 use Cake\Database\Query\UpdateQuery;
 use Cake\Database\Schema\SchemaDialect;
+use Cake\I18n\Date;
+use Cake\I18n\DateTime;
 use Exception;
 use InvalidArgumentException;
 use Migrations\Config\Config;
@@ -723,7 +725,11 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
                         $placeholder = (string)$v;
                     }
                     if ($placeholder == '?') {
-                        if (is_bool($v)) {
+                        if ($v instanceof DateTime) {
+                            $vals[] = $v->toDateTimeString();
+                        } elseif ($v instanceof Date) {
+                            $vals[] = $v->toDateString();
+                        } elseif (is_bool($v)) {
                             $vals[] = $this->castToBool($v);
                         } else {
                             $vals[] = $v;

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace Migrations\Db\Adapter;
 
 use Cake\Database\Connection;
+use Cake\I18n\Date;
+use Cake\I18n\DateTime;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
 use Migrations\Db\Literal;
@@ -1526,7 +1528,11 @@ class PostgresAdapter extends AbstractAdapter
                     }
                     $values[] = $placeholder;
                     if ($placeholder == '?') {
-                        if (is_bool($v)) {
+                        if ($v instanceof DateTime) {
+                            $vals[] = $v->toDateTimeString();
+                        } elseif ($v instanceof Date) {
+                            $vals[] = $v->toDateString();
+                        } elseif (is_bool($v)) {
                             $vals[] = $this->castToBool($v);
                         } else {
                             $vals[] = $v;

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace Migrations\Db\Adapter;
 
 use BadMethodCallException;
+use Cake\I18n\Date;
+use Cake\I18n\DateTime;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
 use Migrations\Db\Literal;
@@ -1361,7 +1363,11 @@ SQL;
                         $placeholder = (string)$v;
                     }
                     if ($placeholder == '?') {
-                        if (is_bool($v)) {
+                        if ($v instanceof DateTime) {
+                            $vals[] = $v->toDateTimeString();
+                        } elseif ($v instanceof Date) {
+                            $vals[] = $v->toDateString();
+                        } elseif (is_bool($v)) {
                             $vals[] = $this->castToBool($v);
                         } else {
                             $vals[] = $v;

--- a/tests/TestCase/Command/Phinx/SeedTest.php
+++ b/tests/TestCase/Command/Phinx/SeedTest.php
@@ -21,7 +21,6 @@ use Migrations\MigrationsDispatcher;
 use Migrations\Test\CommandTester;
 use Migrations\Test\TestCase\DriverConnectionTrait;
 use PDO;
-use Phinx\Config\FeatureFlags;
 use Phinx\Db\Adapter\WrapperInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\StreamOutput;
@@ -91,8 +90,6 @@ class SeedTest extends TestCase
         $this->connection->execute('DROP TABLE IF EXISTS numbers');
         $this->connection->execute('DROP TABLE IF EXISTS letters');
         $this->connection->execute('DROP TABLE IF EXISTS stores');
-
-        FeatureFlags::$addTimestampsUseDateTime = false;
     }
 
     /**

--- a/tests/TestCase/Command/Phinx/SeedTest.php
+++ b/tests/TestCase/Command/Phinx/SeedTest.php
@@ -21,6 +21,7 @@ use Migrations\MigrationsDispatcher;
 use Migrations\Test\CommandTester;
 use Migrations\Test\TestCase\DriverConnectionTrait;
 use PDO;
+use Phinx\Config\FeatureFlags;
 use Phinx\Db\Adapter\WrapperInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\StreamOutput;
@@ -90,6 +91,8 @@ class SeedTest extends TestCase
         $this->connection->execute('DROP TABLE IF EXISTS numbers');
         $this->connection->execute('DROP TABLE IF EXISTS letters');
         $this->connection->execute('DROP TABLE IF EXISTS stores');
+
+        FeatureFlags::$addTimestampsUseDateTime = false;
     }
 
     /**

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -12,6 +12,7 @@ use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Phinx\Config\FeatureFlags;
+use ReflectionClass;
 use ReflectionProperty;
 
 class SeedCommandTest extends TestCase
@@ -39,6 +40,13 @@ class SeedCommandTest extends TestCase
         $connection->execute('DROP TABLE IF EXISTS numbers');
         $connection->execute('DROP TABLE IF EXISTS letters');
         $connection->execute('DROP TABLE IF EXISTS stores');
+
+        if (class_exists(FeatureFlags::class)) {
+            $reflection = new ReflectionClass(FeatureFlags::class);
+            if ($reflection->hasProperty('addTimestampsUseDateTime')) {
+                FeatureFlags::$addTimestampsUseDateTime = false;
+            }
+        }
     }
 
     protected function resetOutput(): void
@@ -194,9 +202,14 @@ class SeedCommandTest extends TestCase
         $this->exec('migrations seed -c test --source NotThere --seed LettersSeed');
     }
 
-    public function testSeederWithDateTimeFields(): void
+    public function testSeederWithTimestampFields(): void
     {
-        FeatureFlags::$addTimestampsUseDateTime = true;
+        if (class_exists(FeatureFlags::class)) {
+            $reflection = new ReflectionClass(FeatureFlags::class);
+            if ($reflection->hasProperty('addTimestampsUseDateTime')) {
+                FeatureFlags::$addTimestampsUseDateTime = false;
+            }
+        }
 
         $this->createTables();
         $this->exec('migrations seed -c test --seed StoresSeed');
@@ -221,9 +234,14 @@ class SeedCommandTest extends TestCase
         $this->assertNotEmpty($store['modified']);
     }
 
-    public function testSeederWithTimestampFields(): void
+    public function testSeederWithDateTimeFields(): void
     {
-        FeatureFlags::$addTimestampsUseDateTime = false;
+        $this->skipIf(!class_exists(FeatureFlags::class));
+
+        $reflection = new ReflectionClass(FeatureFlags::class);
+        $this->skipIf(!$reflection->hasProperty('addTimestampsUseDateTime'));
+
+        FeatureFlags::$addTimestampsUseDateTime = true;
 
         $this->createTables();
         $this->exec('migrations seed -c test --seed StoresSeed');

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -11,6 +11,7 @@ use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use Phinx\Config\FeatureFlags;
 use ReflectionProperty;
 
 class SeedCommandTest extends TestCase
@@ -141,7 +142,7 @@ class SeedCommandTest extends TestCase
         $this->assertEquals(2, $query->fetchColumn(0));
     }
 
-    public function testSeederImplictAll(): void
+    public function testSeederImplicitAll(): void
     {
         $this->createTables();
         $this->exec('migrations seed -c test');
@@ -191,5 +192,59 @@ class SeedCommandTest extends TestCase
         $this->expectExceptionMessage('The seed class "LettersSeed" does not exist');
 
         $this->exec('migrations seed -c test --source NotThere --seed LettersSeed');
+    }
+
+    public function testSeederWithDateTimeFields(): void
+    {
+        FeatureFlags::$addTimestampsUseDateTime = true;
+
+        $this->createTables();
+        $this->exec('migrations seed -c test --seed StoresSeed');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('StoresSeed:</info> <comment>seeding');
+        $this->assertOutputContains('All Done');
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $result = $connection->selectQuery()
+            ->select(['*'])
+            ->from('stores')
+            ->orderBy('id DESC')
+            ->limit(1)
+            ->execute()->fetchAll('assoc');
+
+        $this->assertNotEmpty($result[0]);
+        $store = $result[0];
+        $this->assertEquals('foo_with_date', $store['name']);
+        $this->assertNotEmpty($store['created']);
+        $this->assertNotEmpty($store['modified']);
+    }
+
+    public function testSeederWithTimestampFields(): void
+    {
+        FeatureFlags::$addTimestampsUseDateTime = false;
+
+        $this->createTables();
+        $this->exec('migrations seed -c test --seed StoresSeed');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('StoresSeed:</info> <comment>seeding');
+        $this->assertOutputContains('All Done');
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $result = $connection->selectQuery()
+            ->select(['*'])
+            ->from('stores')
+            ->orderBy('id DESC')
+            ->limit(1)
+            ->execute()->fetchAll('assoc');
+
+        $this->assertNotEmpty($result[0]);
+        $store = $result[0];
+        $this->assertEquals('foo_with_date', $store['name']);
+        $this->assertNotEmpty($store['created']);
+        $this->assertNotEmpty($store['modified']);
     }
 }

--- a/tests/test_app/config/Seeds/NumbersSeed.php
+++ b/tests/test_app/config/Seeds/NumbersSeed.php
@@ -9,11 +9,6 @@ class NumbersSeed extends AbstractSeed
 {
     /**
      * Run Method.
-     *
-     * Write your database seeder using this method.
-     *
-     * More information on writing seeders is available here:
-     * https://book.cakephp.org/phinx/0/en/seeding.html
      */
     public function run(): void
     {

--- a/tests/test_app/config/Seeds/StoresSeed.php
+++ b/tests/test_app/config/Seeds/StoresSeed.php
@@ -1,0 +1,33 @@
+<?php
+
+use Cake\I18n\Date;
+use Cake\I18n\DateTime;
+use Migrations\AbstractSeed;
+
+/**
+ * NumbersSeed seed.
+ */
+class StoresSeed extends AbstractSeed
+{
+    /**
+     * Run Method.
+     */
+    public function run(): void
+    {
+        $data = [
+            [
+                'name' => 'foo',
+                'created' => new Date(),
+                'modified' => new Date(),
+            ],
+            [
+                'name' => 'foo_with_date',
+                'created' => new DateTime(),
+                'modified' => new DateTime(),
+            ],
+        ];
+
+        $table = $this->table('stores');
+        $table->insert($data)->save();
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/cakephp/migrations/issues/836

Apparently adding this to bulkinsert()
```php
                    if ($placeholder == '?') {
                        if ($v instanceof DateTime) {
                            $vals[] = $v->toDateTimeString();
                        } elseif ($v instanceof Date) {
                            $vals[] = $v->toDateString();
                        } elseif (is_bool($v)) {
                            $vals[] = $this->castToBool($v);
                        } else {
                            $vals[] = $v;
                        }
                    }
```          
seems to fix it for my local MySql env.


How could a test case look like for this?
And in what class, for what method?