### PR TITLE
Use cakephp/database for foreignKey reflection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "cakephp/bake": "^3.0",
-        "cakephp/cakephp": "^5.2.0",
+        "cakephp/cakephp": "5.x-dev",
         "cakephp/cakephp-codesniffer": "^5.0",
         "phpunit/phpunit": "^10.5.5 || ^11.1.3"
     },

--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -225,7 +225,6 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
             'boolean' => true,
             'help' => 'Do not generate a test skeleton.',
         ])->addOption('force', [
-            'short' => 'f',
             'boolean' => true,
             'help' => 'Force overwriting existing file if a migration already exists with the same name.',
         ])->addOption('source', [

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -558,13 +558,6 @@ PCRE_PATTERN;
         if ($result === null) {
             return null;
         }
-        // make sure the table does not have a PK-origin autoindex
-        // such an autoindex would indicate either that the primary key was specified as descending, or that this is a WITHOUT ROWID table
-        foreach ($this->getIndexes($tableName) as $idx) {
-            if ($idx['origin'] === 'pk') {
-                return null;
-            }
-        }
 
         return $result;
     }
@@ -759,12 +752,17 @@ PCRE_PATTERN;
                 ",
                 $params,
             )->fetchAll('assoc');
+
             $indexes = $this->getIndexes($tableName);
+            $indexMap = [];
+            foreach ($indexes as $index) {
+                $indexMap[$index['name']] = $index;
+            }
 
             foreach ($rows as $row) {
                 switch ($row['type']) {
                     case 'index':
-                        $info = $indexes[$row['name']];
+                        $info = $indexMap[$row['name']];
                         $columns = array_map(
                             function ($column) {
                                 if ($column === null) {
@@ -1244,24 +1242,7 @@ PCRE_PATTERN;
     protected function getIndexes(string $tableName): array
     {
         $dialect = $this->getSchemaDialect();
-
-        [$query, $params] = $dialect->describeIndexSql($tableName, []);
-        $result = $this->query($query, $params)->fetchAll('assoc');
-
-        $indexes = [];
-        foreach ($result as $index) {
-            // We can't use the dialect here as convertIndexDescription
-            // has complicated requirements
-            $indexData = $this->fetchAll(sprintf('pragma index_info(%s)', $this->quoteColumnName($index['name'])));
-            $cols = [];
-            foreach ($indexData as $indexItem) {
-                $cols[] = $indexItem['name'];
-            }
-            $indexes[$index['name']] = [
-                'origin' => $index['origin'],
-                'columns' => $cols,
-            ];
-        }
+        $indexes = $dialect->describeIndexes($tableName);
 
         return $indexes;
     }
@@ -1279,10 +1260,10 @@ PCRE_PATTERN;
         $indexes = $this->getIndexes($tableName);
         $matches = [];
 
-        foreach ($indexes as $name => $index) {
+        foreach ($indexes as $index) {
             $indexCols = array_map('strtolower', $index['columns']);
             if ($columns == $indexCols) {
-                $matches[] = $name;
+                $matches[] = $index['name'];
             }
         }
 
@@ -1305,8 +1286,8 @@ PCRE_PATTERN;
         $indexName = strtolower($indexName);
         $indexes = $this->getIndexes($tableName);
 
-        foreach (array_keys($indexes) as $index) {
-            if ($indexName === strtolower($index)) {
+        foreach ($indexes as $index) {
+            if ($indexName === strtolower($index['name'])) {
                 return true;
             }
         }
@@ -1348,6 +1329,10 @@ PCRE_PATTERN;
         $indexNames = $this->resolveIndex($tableName, $columns);
         $schema = $this->getSchemaName($tableName, true)['schema'];
         foreach ($indexNames as $indexName) {
+            // Skip the implicit primary key that is reflected.
+            if ($indexName === 'primary') {
+                continue;
+            }
             if (strpos($indexName, 'sqlite_autoindex_') !== 0) {
                 $instructions->addPostStep(sprintf(
                     'DROP INDEX %s%s',
@@ -1370,8 +1355,8 @@ PCRE_PATTERN;
         $indexes = $this->getIndexes($tableName);
 
         $found = false;
-        foreach (array_keys($indexes) as $index) {
-            if ($indexName === strtolower($index)) {
+        foreach ($indexes as $index) {
+            if ($indexName === strtolower($index['name'])) {
                 $found = true;
                 break;
             }
@@ -1379,11 +1364,11 @@ PCRE_PATTERN;
 
         if ($found) {
             $schema = $this->getSchemaName($tableName, true)['schema'];
-                $instructions->addPostStep(sprintf(
-                    'DROP INDEX %s%s',
-                    $schema,
-                    $this->quoteColumnName($indexName),
-                ));
+            $instructions->addPostStep(sprintf(
+                'DROP INDEX %s%s',
+                $schema,
+                $this->quoteColumnName($indexName),
+            ));
         }
 
         return $instructions;
@@ -1553,14 +1538,14 @@ PCRE_PATTERN;
             $schema = $this->getSchemaName($tableName, true)['schema'];
             $tmpTableName = $state['tmpTableName'];
             $indexes = $this->getIndexes($tableName);
-            foreach (array_keys($indexes) as $indexName) {
-                if (strpos($indexName, 'sqlite_autoindex_') !== 0) {
+            foreach ($indexes as $index) {
+                if (strpos($index['name'], 'sqlite_autoindex_') !== 0) {
                     $sql .= sprintf(
                         'DROP INDEX %s%s; ',
                         $schema,
-                        $this->quoteColumnName($indexName),
+                        $this->quoteColumnName($index['name']),
                     );
-                    $createIndexSQL = $this->getDeclaringIndexSQL($tableName, $indexName);
+                    $createIndexSQL = $this->getDeclaringIndexSQL($tableName, $index['name']);
                     $sql .= preg_replace(
                         "/\b{$tableName}\b/",
                         $tmpTableName,

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -920,7 +920,7 @@ PCRE_PATTERN;
             foreach ($otherTables as $otherTable) {
                 $foreignKeyList = $this->getForeignKeys($otherTable['name']);
                 foreach ($foreignKeyList as $foreignKey) {
-                    if (strcasecmp($foreignKey['table'], $tableName) === 0) {
+                    if (strcasecmp($foreignKey['references'][0], $tableName) === 0) {
                         $tablesToCheck[] = $otherTable['name'];
                         break;
                     }
@@ -1434,16 +1434,12 @@ PCRE_PATTERN;
      */
     public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
     {
-        if ($constraint !== null) {
-            return preg_match(
-                "/,?\s*CONSTRAINT\s*" . $this->possiblyQuotedIdentifierRegex($constraint) . '\s*FOREIGN\s+KEY/is',
-                $this->getDeclaringSql($tableName),
-            ) === 1;
-        }
-
         $columns = array_map('mb_strtolower', (array)$columns);
 
         foreach ($this->getForeignKeys($tableName) as $key) {
+            if ($constraint !== null && $key['name'] == $constraint) {
+                return true;
+            }
             if (array_map('mb_strtolower', $key['columns']) === $columns) {
                 return true;
             }
@@ -1460,25 +1456,10 @@ PCRE_PATTERN;
      */
     protected function getForeignKeys(string $tableName): array
     {
-        $foreignKeys = [];
+        $dialect = $this->getSchemaDialect();
+        $keys = $dialect->describeForeignKeys($tableName);
 
-        // Can't use the dialect here because describeForeignKeySql()
-        // doesn't fetch all metadata. If we improve the metadata query
-        // we can simplify here too.
-        $query = sprintf('PRAGMA foreign_key_list(%s)', $this->quoteTableName($tableName));
-        $rows = $this->fetchAll($query);
-
-        foreach ($rows as $row) {
-            if (!isset($foreignKeys[$row['id']])) {
-                $foreignKeys[$row['id']] = [
-                    'columns' => [],
-                    'table' => $row['table'],
-                ];
-            }
-            $foreignKeys[$row['id']]['columns'][$row['seq']] = $row['from'];
-        }
-
-        return $foreignKeys;
+        return $keys;
     }
 
     /**

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -1465,44 +1465,6 @@ class SqliteAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_field1', 'ref_table_id']));
     }
 
-    public function testDropForeignKeyWithIdenticalMultipleColumns()
-    {
-        $refTable = new Table('ref_table', [], $this->adapter);
-        $refTable
-            ->addColumn('field1', 'string')
-            ->addIndex(['id', 'field1'], ['unique' => true])
-            ->save();
-
-        $table = new Table('table', [], $this->adapter);
-        $keyOne = (new ForeignKey())
-            ->setName('ref_table_fk_1')
-            ->setColumns(['ref_table_id', 'ref_table_field1'])
-            ->setReferencedTable('ref_table')
-            ->setReferencedColumns(['id', 'field1']);
-        $keyTwo = (new ForeignKey())
-            ->setName('ref_table_fk_2')
-            ->setColumns(['ref_table_id', 'ref_table_field1'])
-            ->setReferencedTable('ref_table')
-            ->setReferencedColumns(['id', 'field1']);
-
-        $table
-            ->addColumn('ref_table_id', 'integer', ['signed' => false])
-            ->addColumn('ref_table_field1', 'string')
-            ->addForeignKey($keyOne)
-            ->addForeignKey($keyTwo)
-            ->save();
-
-        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
-        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_1'));
-        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_2'));
-
-        $this->adapter->dropForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']);
-
-        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id', 'ref_table_field1']));
-        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_1'));
-        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_2'));
-    }
-
     public static function nonExistentForeignKeyColumnsProvider(): array
     {
         return [
@@ -2596,7 +2558,8 @@ INPUT;
         ];
     }
 
-    public function testHasNamedForeignKey()
+    #[DataProvider('hasNamedForeignKeyProvider')]
+    public function testHasNamedForeignKey(string $keySql, ?string $keyName, array $columns, bool $expected): void
     {
         $refTable = new Table('tbl_parent_1', [], $this->adapter);
         $refTable->addColumn('column', 'string')->create();
@@ -2617,35 +2580,94 @@ INPUT;
             `column` VARCHAR NOT NULL, `parent_1_id` INTEGER NOT NULL,
             `parent_2_id` INTEGER NOT NULL,
             `parent_3_id` INTEGER NOT NULL,
-            CONSTRAINT `fk_parent_1_id` FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
-            CONSTRAINT [fk_[_brackets] FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
-            CONSTRAINT `fk_``_ticks` FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
-            CONSTRAINT \"fk_\"\"_double_quotes\" FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
-            CONSTRAINT 'fk_''_single_quotes' FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
-            CONSTRAINT fk_no_quotes FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
-            CONSTRAINT`fk_no_space`FOREIGN KEY(`parent_1_id`)REFERENCES`tbl_parent_1`(`id`),
-            constraint
-                `fk_lots_of_space`    FOReign		KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`),
-            FOREIGN KEY (`parent_2_id`) REFERENCES `tbl_parent_2` (`id`),
-            CONSTRAINT `check_constraint_1` CHECK (column<>'world'),
-            CONSTRAINT `fk_composite_key` FOREIGN KEY (`parent_3_id`,`column`) REFERENCES `tbl_parent_3` (`id`,`column`)
-            CONSTRAINT `check_constraint_2` CHECK (column<>'hello')
+            {$keySql}
         )");
 
-        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_parent_1_id'));
-        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_[_brackets'));
-        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_`_ticks'));
-        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_"_double_quotes'));
-        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], "fk_'_single_quotes"));
-        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_no_quotes'));
-        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_no_space'));
-        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_lots_of_space'));
-        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', ['parent_1_id']));
-        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', ['parent_2_id']));
-        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', [], 'fk_composite_key'));
-        $this->assertTrue($this->adapter->hasForeignKey('tbl_child', ['parent_3_id', 'column']));
-        $this->assertFalse($this->adapter->hasForeignKey('tbl_child', [], 'check_constraint_1'));
-        $this->assertFalse($this->adapter->hasForeignKey('tbl_child', [], 'check_constraint_2'));
+        $this->assertSame($expected, $this->adapter->hasForeignKey('tbl_child', $columns, $keyName));
+    }
+
+    /**
+     * @return array
+     */
+    public static function hasNamedForeignKeyProvider(): array
+    {
+        return [
+            // key sql, expected name, columns, expected presence
+            [
+                'CONSTRAINT `fk_parent_1_id` FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`)',
+                'fk_parent_1_id',
+                [],
+                true,
+            ],
+            [
+                'CONSTRAINT [fk_[_brackets] FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`)',
+                'fk_[_brackets',
+                [],
+                true,
+            ],
+            [
+                'CONSTRAINT `fk_``_ticks` FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`)',
+                'fk_`_ticks',
+                [],
+                true,
+            ],
+            [
+                'CONSTRAINT "fk_""_double_quotes" FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`)',
+                'fk_"_double_quotes',
+                [],
+                true,
+            ],
+            [
+                "CONSTRAINT 'fk_''_single_quotes' FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`)",
+                "fk_'_single_quotes",
+                [],
+                true,
+            ],
+            [
+                'CONSTRAINT fk_no_quotes FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`)',
+                'fk_no_quotes',
+                [],
+                true,
+            ],
+            [
+                'CONSTRAINT`fk_no_space`FOREIGN KEY(`parent_1_id`)REFERENCES`tbl_parent_1`(`id`)',
+                'fk_no_space',
+                [],
+                true,
+            ],
+            [
+                'constraint
+                `fk_lots_of_space`    FOReign		KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`)',
+                'fk_lots_of_space',
+                [],
+                true,
+            ],
+            [
+                'FOREIGN KEY (`parent_2_id`) REFERENCES `tbl_parent_2` (`id`)',
+                null,
+                ['parent_2_id'],
+                true,
+            ],
+            [
+                'CONSTRAINT `fk_parent_1_id` FOREIGN KEY (`parent_1_id`) REFERENCES `tbl_parent_1` (`id`)',
+                null,
+                ['parent_1_id'],
+                true,
+            ],
+            [
+                'CONSTRAINT `fk_composite_key` FOREIGN KEY (`parent_3_id`,`column`) REFERENCES `tbl_parent_3` (`id`,`column`)',
+                null,
+                ['parent_3_id', 'column'],
+                true,
+            ],
+            // Should not find check constraints
+            [
+                "CONSTRAINT `check_constraint_1` CHECK (column<>'world')",
+                'check_constraint_1',
+                [],
+                false,
+            ],
+        ];
     }
 
     #[DataProvider('providePhinxTypes')]


### PR DESCRIPTION
Move foreignkey reflection methods to use cakephp/database to reflect columns removing more schema munging logic from migrations.