### PR TITLE
decrease the amount of info being dumped when doing migrate, rollback or seed

### DIFF
--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -135,13 +135,13 @@ class DumpCommand extends Command
         }
 
         $filePath = $path . DS . 'schema-dump-' . $connectionName . '.lock';
-        $io->out("<info>Writing dump file `{$filePath}`...</info>");
+        $io->verbose("<info>Writing dump file `{$filePath}`...</info>");
         if (file_put_contents($filePath, serialize($dump))) {
-            $io->out("<info>Dump file `{$filePath}` was successfully written</info>");
+            $io->verbose("<info>Dump file `{$filePath}` was successfully written</info>");
 
             return self::CODE_SUCCESS;
         }
-        $io->out("<error>An error occurred while writing dump file `{$filePath}`</error>");
+        $io->error("An error occurred while writing dump file `{$filePath}`");
 
         return self::CODE_ERROR;
     }

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -137,9 +137,9 @@ class MigrateCommand extends Command
         if ($dryRun) {
             $io->out('<warning>dry-run mode enabled</warning>');
         }
-        $io->out('<info>using connection</info> ' . (string)$args->getOption('connection'));
-        $io->out('<info>using paths</info> ' . $config->getMigrationPath());
-        $io->out('<info>ordering by</info> ' . $versionOrder . ' time');
+        $io->verbose('<info>using connection</info> ' . (string)$args->getOption('connection'));
+        $io->verbose('<info>using paths</info> ' . $config->getMigrationPath());
+        $io->verbose('<info>ordering by</info> ' . $versionOrder . ' time');
 
         if ($fake) {
             $io->out('<warning>warning</warning> performing fake migrations');
@@ -166,16 +166,16 @@ class MigrateCommand extends Command
             return self::CODE_ERROR;
         }
 
-        $io->out('');
         $io->out('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+        $io->out('');
 
         $exitCode = self::CODE_SUCCESS;
 
         // Run dump command to generate lock file
         if (!$args->getOption('no-lock') && !$args->getOption('dry-run')) {
-            $io->out('');
-            $io->out('Dumping the current schema of the database to be used while baking a diff');
-            $io->out('');
+            $io->verbose('');
+            $io->verbose('Dumping the current schema of the database to be used while baking a diff');
+            $io->verbose('');
 
             $newArgs = DumpCommand::extractArgs($args);
             $exitCode = $this->executeCommand(DumpCommand::class, $newArgs, $io);

--- a/src/Command/RollbackCommand.php
+++ b/src/Command/RollbackCommand.php
@@ -140,9 +140,9 @@ class RollbackCommand extends Command
         $config = $manager->getConfig();
 
         $versionOrder = $config->getVersionOrder();
-        $io->out('<info>using connection</info> ' . (string)$args->getOption('connection'));
-        $io->out('<info>using paths</info> ' . $config->getMigrationPath());
-        $io->out('<info>ordering by</info> ' . $versionOrder . ' time');
+        $io->verbose('<info>using connection</info> ' . (string)$args->getOption('connection'));
+        $io->verbose('<info>using paths</info> ' . $config->getMigrationPath());
+        $io->verbose('<info>ordering by</info> ' . $versionOrder . ' time');
 
         if ($dryRun) {
             $io->out('<warning>dry-run mode enabled</warning>');
@@ -176,16 +176,16 @@ class RollbackCommand extends Command
             return self::CODE_ERROR;
         }
 
-        $io->out('');
         $io->out('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+        $io->out('');
 
         $exitCode = self::CODE_SUCCESS;
 
         // Run dump command to generate lock file
         if (!$args->getOption('no-lock')) {
-            $io->out('');
-            $io->out('Dumping the current schema of the database to be used while baking a diff');
-            $io->out('');
+            $io->verbose('');
+            $io->verbose('Dumping the current schema of the database to be used while baking a diff');
+            $io->verbose('');
 
             $newArgs = DumpCommand::extractArgs($args);
             $exitCode = $this->executeCommand(DumpCommand::class, $newArgs, $io);

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -119,9 +119,9 @@ class SeedCommand extends Command
         }
 
         $versionOrder = $config->getVersionOrder();
-        $io->out('<info>using connection</info> ' . (string)$args->getOption('connection'));
-        $io->out('<info>using paths</info> ' . $config->getMigrationPath());
-        $io->out('<info>ordering by</info> ' . $versionOrder . ' time');
+        $io->verbose('<info>using connection</info> ' . (string)$args->getOption('connection'));
+        $io->verbose('<info>using paths</info> ' . $config->getMigrationPath());
+        $io->verbose('<info>ordering by</info> ' . $versionOrder . ' time');
 
         $start = microtime(true);
         if (!$seeds) {

--- a/tests/TestCase/Command/DumpCommandTest.php
+++ b/tests/TestCase/Command/DumpCommandTest.php
@@ -71,7 +71,6 @@ class DumpCommandTest extends TestCase
         $this->exec('migrations dump --connection test --source TestsMigrations');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('config' . DS . 'TestsMigrations' . DS . 'schema-dump-test.lock');
 
         $this->assertFileExists($this->dumpFile);
         /** @var array<string, TableSchema> $generatedDump */
@@ -92,7 +91,6 @@ class DumpCommandTest extends TestCase
         $this->exec('migrations dump --connection test --plugin Migrator');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('Migrator' . DS . 'config' . DS . 'Migrations' . DS . 'schema-dump-test.lock');
 
         $dumpFile = Plugin::path('Migrator') . '/config/Migrations/schema-dump-test.lock';
         if (file_exists($dumpFile)) {

--- a/tests/TestCase/Command/MigrateCommandTest.php
+++ b/tests/TestCase/Command/MigrateCommandTest.php
@@ -62,8 +62,6 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test -s Missing --no-lock');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<info>using paths</info> ' . $migrationPath);
-        $this->assertOutputContains('<info>using connection</info> test');
         $this->assertOutputContains('All Done');
 
         $table = $this->fetchTable('Phinxlog');
@@ -94,11 +92,8 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . $migrationPath);
         $this->assertOutputContains('MarkMigratedTest:</info> <comment>migrated');
         $this->assertOutputContains('All Done');
-        $this->assertOutputContains('Dumping the current schema');
 
         $table = $this->fetchTable('Phinxlog');
         $this->assertCount(2, $table->find()->all()->toArray());
@@ -113,12 +108,9 @@ class MigrateCommandTest extends TestCase
      */
     public function testMigrateBaseMigration(): void
     {
-        $migrationPath = ROOT . DS . 'config' . DS . 'BaseMigrations';
         $this->exec('migrations migrate -v --source BaseMigrations -c test --no-lock');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . $migrationPath);
         $this->assertOutputContains('BaseMigrationTables:</info> <comment>migrated');
         $this->assertOutputContains('query=121');
         $this->assertOutputContains('fetchRow=122');
@@ -138,8 +130,6 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test -s ShouldExecute');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . $migrationPath);
         $this->assertOutputContains('ShouldExecuteMigration:</info> <comment>migrated');
         $this->assertOutputContains('ShouldNotExecuteMigration:</info> <comment>skipped </comment>');
         $this->assertOutputContains('All Done');
@@ -162,8 +152,6 @@ class MigrateCommandTest extends TestCase
         $this->assertExitSuccess();
 
         $this->assertOutputContains('<warning>dry-run mode enabled</warning>');
-        $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . $migrationPath);
         $this->assertOutputContains('MarkMigratedTest:</info> <comment>migrated');
         $this->assertOutputContains('All Done');
 
@@ -183,8 +171,6 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test --date 2020-01-01');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . $migrationPath);
         $this->assertOutputContains('MarkMigratedTest:</info> <comment>migrated');
         $this->assertOutputContains('All Done');
 
@@ -202,8 +188,6 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test --date 2000-01-01');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . $migrationPath);
         $this->assertOutputNotContains('MarkMigratedTest');
         $this->assertOutputContains('No migrations to run');
         $this->assertOutputContains('All Done');
@@ -222,8 +206,6 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test --target 20150416223600');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . $migrationPath);
         $this->assertOutputContains('MarkMigratedTest:</info> <comment>migrated');
         $this->assertOutputNotContains('MarkMigratedTestSecond');
         $this->assertOutputContains('All Done');
@@ -242,8 +224,6 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test --target 99');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . $migrationPath);
         $this->assertOutputNotContains('MarkMigratedTest');
         $this->assertOutputNotContains('MarkMigratedTestSecond');
         $this->assertOutputContains('<comment>warning</comment> 99 is not a valid version');
@@ -263,8 +243,6 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test --fake');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . $migrationPath);
         $this->assertOutputContains('warning</warning> performing fake migrations');
         $this->assertOutputContains('MarkMigratedTest:</info> <comment>migrated');
         $this->assertOutputContains('MarkMigratedTestSecond:</info> <comment>migrated');
@@ -285,8 +263,6 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test --plugin Migrator');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . $migrationPath);
         $this->assertOutputContains('Migrator:</info> <comment>migrated');
         $this->assertOutputContains('All Done');
 
@@ -295,7 +271,6 @@ class MigrateCommandTest extends TestCase
         $this->assertCount(1, $table->find()->all()->toArray());
 
         $dumpFile = $migrationPath . DS . 'schema-dump-test.lock';
-        $this->assertOutputContains('Writing dump file `' . $dumpFile);
         $this->createdFiles[] = $dumpFile;
         $this->assertFileExists($dumpFile);
     }
@@ -326,8 +301,6 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test --no-lock');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<info>using connection</info> test');
-        $this->assertOutputContains('<info>using paths</info> ' . $migrationPath);
         $this->assertOutputContains('MarkMigratedTest:</info> <comment>migrated');
         $this->assertOutputContains('All Done');
         $this->assertOutputNotContains('Dumping');

--- a/tests/TestCase/Command/RollbackCommandTest.php
+++ b/tests/TestCase/Command/RollbackCommandTest.php
@@ -70,8 +70,6 @@ class RollbackCommandTest extends TestCase
         $this->exec('migrations rollback -c test -s Missing --no-lock');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<info>using paths</info> ' . $migrationPath);
-        $this->assertOutputContains('<info>using connection</info> test');
         $this->assertOutputContains('No migrations to rollback');
         $this->assertOutputContains('All Done');
 
@@ -115,8 +113,6 @@ class RollbackCommandTest extends TestCase
         $this->exec('migrations rollback -c test --no-lock --dry-run');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<info>using paths</info> ' . $migrationPath);
-        $this->assertOutputContains('<info>using connection</info> test');
         $this->assertOutputContains('dry-run mode enabled');
         $this->assertOutputContains('20240309223600 MarkMigratedTestSecond:</info> <comment>reverting');
         $this->assertOutputContains('All Done');


### PR DESCRIPTION
Resolves #862 

Compared to what is linked in the issue this would now generate the following output (when no open migrations need to be applied):

```
bin/cake migrations migrate

All Done. Took 0.0140s
bin/cake migrations migrate -p AlfredDeploy

All Done. Took 0.0090s
bin/cake migrations migrate -p AlfredGoogle

All Done. Took 0.0109s
bin/cake migrations migrate -p AlfredDriversLogbook

All Done. Took 0.0105s
bin/cake migrations migrate -p AlfredEasybill

All Done. Took 0.0108s
bin/cake migrations migrate -p AlfredPublicTransport

All Done. Took 0.0094s
bin/cake migrations migrate -p AlfredStandBy

All Done. Took 0.0117s
bin/cake migrations migrate -p AlfredDashboard

All Done. Took 0.0089s
bin/cake migrations migrate -p AlfredDns

All Done. Took 0.0090s
bin/cake migrations migrate -p AlfredTools

All Done. Took 0.0085s
bin/cake migrations migrate -p AlfredMaintenances

All Done. Took 0.0090s
bin/cake migrations migrate -p AlfredDocumentations

All Done. Took 0.0091s
bin/cake migrations migrate -p AlfredMealOrders

All Done. Took 0.0096s
bin/cake migrations migrate -p AlfredStaffMembers

All Done. Took 0.0129s
bin/cake migrations migrate -p AlfredProjects

All Done. Took 0.0093s
bin/cake migrations migrate -p Queue

All Done. Took 0.0105s
bin/cake migrations migrate -p CakeDC/Users

All Done. Took 0.0119s
```

which is far more readable and to the point imho

Anyone who still wants/needs those verbose infos can simply add a `-v` to their command and get the same result as before.