### PR TITLE
cleanup ConsoleIO::out commands to use their named counterparts

### DIFF
--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -135,7 +135,7 @@ class MigrateCommand extends Command
 
         $versionOrder = $config->getVersionOrder();
         if ($dryRun) {
-            $io->out('<warning>dry-run mode enabled</warning>');
+            $io->warning('dry-run mode enabled');
         }
         $io->verbose('<info>using connection</info> ' . (string)$args->getOption('connection'));
         $io->verbose('<info>using paths</info> ' . $config->getMigrationPath());
@@ -156,17 +156,17 @@ class MigrateCommand extends Command
             $end = microtime(true);
         } catch (Exception $e) {
             $io->err('<error>' . $e->getMessage() . '</error>');
-            $io->out($e->getTraceAsString(), 1, ConsoleIo::VERBOSE);
+            $io->verbose($e->getTraceAsString());
 
             return self::CODE_ERROR;
         } catch (Throwable $e) {
             $io->err('<error>' . $e->getMessage() . '</error>');
-            $io->out($e->getTraceAsString(), 1, ConsoleIo::VERBOSE);
+            $io->verbose($e->getTraceAsString());
 
             return self::CODE_ERROR;
         }
 
-        $io->out('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+        $io->comment('All Done. Took ' . sprintf('%.4fs', $end - $start));
         $io->out('');
 
         $exitCode = self::CODE_SUCCESS;

--- a/src/Command/RollbackCommand.php
+++ b/src/Command/RollbackCommand.php
@@ -145,7 +145,7 @@ class RollbackCommand extends Command
         $io->verbose('<info>ordering by</info> ' . $versionOrder . ' time');
 
         if ($dryRun) {
-            $io->out('<warning>dry-run mode enabled</warning>');
+            $io->warning('dry-run mode enabled');
         }
         if ($fake) {
             $io->out('<warning>warning</warning> performing fake rollbacks');
@@ -166,17 +166,17 @@ class RollbackCommand extends Command
             $end = microtime(true);
         } catch (Exception $e) {
             $io->err('<error>' . $e->getMessage() . '</error>');
-            $io->out($e->getTraceAsString(), 1, ConsoleIo::VERBOSE);
+            $io->verbose($e->getTraceAsString());
 
             return self::CODE_ERROR;
         } catch (Throwable $e) {
             $io->err('<error>' . $e->getMessage() . '</error>');
-            $io->out($e->getTraceAsString(), 1, ConsoleIo::VERBOSE);
+            $io->verbose($e->getTraceAsString());
 
             return self::CODE_ERROR;
         }
 
-        $io->out('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+        $io->comment('All Done. Took ' . sprintf('%.4fs', $end - $start));
         $io->out('');
 
         $exitCode = self::CODE_SUCCESS;

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -135,7 +135,7 @@ class SeedCommand extends Command
         }
         $end = microtime(true);
 
-        $io->out('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+        $io->comment('All Done. Took ' . sprintf('%.4fs', $end - $start));
 
         return self::CODE_SUCCESS;
     }

--- a/tests/TestCase/Command/MigrateCommandTest.php
+++ b/tests/TestCase/Command/MigrateCommandTest.php
@@ -151,7 +151,7 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test --dry-run');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<warning>dry-run mode enabled</warning>');
+        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
         $this->assertOutputContains('MarkMigratedTest:</info> <comment>migrated');
         $this->assertOutputContains('All Done');
 

--- a/tests/TestCase/Command/RollbackCommandTest.php
+++ b/tests/TestCase/Command/RollbackCommandTest.php
@@ -113,7 +113,7 @@ class RollbackCommandTest extends TestCase
         $this->exec('migrations rollback -c test --no-lock --dry-run');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('dry-run mode enabled');
+        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
         $this->assertOutputContains('20240309223600 MarkMigratedTestSecond:</info> <comment>reverting');
         $this->assertOutputContains('All Done');
 


### PR DESCRIPTION
Refs: https://github.com/cakephp/migrations/pull/863

The only "major" difference here is now the fact, that dry-run mode will output on STDERR and not STDOUT any more.