### PR TITLE
Fix up deprecation warning.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "cakephp/bake": "^3.0",
         "cakephp/cakephp": "^5.0.11",
         "cakephp/cakephp-codesniffer": "^5.0",
-        "phpunit/phpunit": "^10.5.5 || ^11.1.3"
+        "phpunit/phpunit": "^10.5.5 || ^11.1.3 || ^12.2.4"
     },
     "suggest": {
         "cakephp/bake": "If you want to generate migrations.",

--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -221,15 +221,20 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
         )->addOption('no-test', [
             'boolean' => true,
             'help' => 'Do not generate a test skeleton.',
-        ])->addOption('force', [
-            'short' => 'f',
-            'boolean' => true,
-            'help' => 'Force overwriting existing file if a migration already exists with the same name.',
         ])->addOption('source', [
             'short' => 's',
             'default' => self::DEFAULT_MIGRATION_FOLDER,
             'help' => 'Name of the folder in which the migration should be saved.',
         ]);
+
+        $options = $parser->options();
+        if (!isset($options['force'])) {
+            $parser->addOption('force', [
+                'short' => 'f',
+                'boolean' => true,
+                'help' => 'Force overwriting existing file if a migration already exists with the same name.',
+            ]);
+        }
 
         return $parser;
     }


### PR DESCRIPTION
I propose this dynamic fix to the deprecation warning issues instead of
https://github.com/cakephp/migrations/compare/4.x...4.next#diff-95ee3850797051650617a77bbc9cb2f047a0ce5997f32ce2582a5d9df8253fb0L228
As it seems force is just being re-added a 2nd time in cases.

