### PR TITLE
Add (initial) support for Dry run mode

### DIFF
--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -125,19 +125,20 @@ class MigrateCommand extends Command
         $version = $args->getOption('target') !== null ? (int)$args->getOption('target') : null;
         $date = $args->getOption('date');
         $fake = (bool)$args->getOption('fake');
-        $dryRun = (bool)$args->getOption('dry-run');
 
         $factory = new ManagerFactory([
             'plugin' => $args->getOption('plugin'),
             'source' => $args->getOption('source'),
             'connection' => $args->getOption('connection'),
-            'dry-run' => $dryRun,
+            'dry-run' => (bool)$args->getOption('dry-run'),
         ]);
+
         $manager = $factory->createManager($io);
         $config = $manager->getConfig();
 
         $versionOrder = $config->getVersionOrder();
-        if ($dryRun) {
+
+        if ($config->isDryRun()) {
             $io->warning('dry-run mode enabled');
         }
         $io->verbose('<info>using connection</info> ' . (string)$args->getOption('connection'));

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -128,7 +128,7 @@ class SeedCommand extends Command
         $versionOrder = $config->getVersionOrder();
 
         if ($config->isDryRun()) {
-            $io->warning('<warning>dry-run mode enabled</warning>');
+            $io->warning('dry-run mode enabled');
         }
         $io->verbose('<info>using connection</info> ' . (string)$args->getOption('connection'));
         $io->verbose('<info>using paths</info> ' . $config->getMigrationPath());

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -19,6 +19,7 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
 use Cake\Event\EventDispatcherTrait;
+use Cake\Utility\Hash;
 use Migrations\Config\ConfigInterface;
 use Migrations\Migration\ManagerFactory;
 
@@ -65,6 +66,10 @@ class SeedCommand extends Command
             'short' => 'c',
             'help' => 'The datasource connection to use',
             'default' => 'default',
+        ])->addOption('dry-run', [
+            'short' => 'x',
+            'help' => 'Dump queries to stdout instead of executing them',
+            'boolean' => true,
         ])->addOption('source', [
             'short' => 's',
             'default' => ConfigInterface::DEFAULT_SEED_FOLDER,
@@ -109,9 +114,11 @@ class SeedCommand extends Command
             'plugin' => $args->getOption('plugin'),
             'source' => $args->getOption('source'),
             'connection' => $args->getOption('connection'),
+            'dry-run' => $args->getOption('dry-run'),
         ]);
         $manager = $factory->createManager($io);
         $config = $manager->getConfig();
+
         if (version_compare(Configure::version(), '5.2.0', '>=')) {
             $seeds = (array)$args->getArrayOption('seed');
         } else {
@@ -119,6 +126,10 @@ class SeedCommand extends Command
         }
 
         $versionOrder = $config->getVersionOrder();
+
+        if (Hash::get($config, 'environment.dryrun') === true) {
+            $io->warning('<warning>dry-run mode enabled</warning>');
+        }
         $io->verbose('<info>using connection</info> ' . (string)$args->getOption('connection'));
         $io->verbose('<info>using paths</info> ' . $config->getMigrationPath());
         $io->verbose('<info>ordering by</info> ' . $versionOrder . ' time');

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -19,7 +19,6 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
 use Cake\Event\EventDispatcherTrait;
-use Cake\Utility\Hash;
 use Migrations\Config\ConfigInterface;
 use Migrations\Migration\ManagerFactory;
 

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -127,7 +127,7 @@ class SeedCommand extends Command
 
         $versionOrder = $config->getVersionOrder();
 
-        if (Hash::get($config, 'environment.dryrun') === true) {
+        if ($config->isDryRun()) {
             $io->warning('<warning>dry-run mode enabled</warning>');
         }
         $io->verbose('<info>using connection</info> ' . (string)$args->getOption('connection'));

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -114,8 +114,9 @@ class SeedCommand extends Command
             'plugin' => $args->getOption('plugin'),
             'source' => $args->getOption('source'),
             'connection' => $args->getOption('connection'),
-            'dry-run' => $args->getOption('dry-run'),
+            'dry-run' => (bool)$args->getOption('dry-run'),
         ]);
+
         $manager = $factory->createManager($io);
         $config = $manager->getConfig();
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -179,6 +179,14 @@ class Config implements ConfigInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public function isDryRun(): bool
+    {
+        return $this->values['environment']['dryrun'] ?? false;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @param mixed $offset ID

--- a/src/Config/ConfigInterface.php
+++ b/src/Config/ConfigInterface.php
@@ -108,4 +108,11 @@ interface ConfigInterface extends ArrayAccess
      * @return string|null
      */
     public function getSeedTemplateFile(): ?string;
+
+    /**
+     * Get the dry run setting.
+     *
+     * @return void
+     */
+    public function isDryRun(): bool;
 }

--- a/src/Config/ConfigInterface.php
+++ b/src/Config/ConfigInterface.php
@@ -110,7 +110,7 @@ interface ConfigInterface extends ArrayAccess
     public function getSeedTemplateFile(): ?string;
 
     /**
-     * Get the dry run setting.
+     * Should queries be sent to the database or just print to stdout?
      *
      * @return bool
      */

--- a/src/Config/ConfigInterface.php
+++ b/src/Config/ConfigInterface.php
@@ -112,7 +112,7 @@ interface ConfigInterface extends ArrayAccess
     /**
      * Get the dry run setting.
      *
-     * @return void
+     * @return bool
      */
     public function isDryRun(): bool;
 }

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -679,9 +679,19 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
         if ($value === null) {
             return 'null';
         }
+
         if ($value instanceof Literal || $value instanceof PhinxLiteral) {
             return (string)$value;
         }
+
+        if ($value instanceof DateTime) {
+            return $value->toDateTimeString();
+        }
+
+        if ($value instanceof Date) {
+            return $value->toDateString();
+        }
+
         $driver = $this->getConnection()->getDriver();
 
         return $driver->quote($value);

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -272,7 +272,7 @@ class SeedCommandTest extends TestCase
         $this->exec('migrations seed -c test --seed NumbersSeed --dry-run');
 
         $this->assertExitSuccess();
-        $this->assertErrorContains('dry-run mode enabled');
+        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
     }
@@ -283,7 +283,7 @@ class SeedCommandTest extends TestCase
         $this->exec('migrations seed -c test --seed NumbersSeed -x');
 
         $this->assertExitSuccess();
-        $this->assertErrorContains('dry-run mode enabled');
+        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
     }
@@ -309,7 +309,7 @@ class SeedCommandTest extends TestCase
         $this->exec('migrations seed -c test --source CallSeeds --seed LettersSeed --seed NumbersCallSeed --dry-run');
 
         $this->assertExitSuccess();
-        $this->assertErrorContains('dry-run mode enabled');
+        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
         $this->assertOutputContains('NumbersCallSeed:</info> <comment>seeding');
         $this->assertOutputContains('LettersSeed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
@@ -323,9 +323,6 @@ class SeedCommandTest extends TestCase
         $this->assertEquals(0, $lettersCount, 'Dry-run mode should not insert into letters table');
     }
 
-    /**
-     * TODO: Currently failing with "TypeError: PDO::quote(): Argument #1 ($string) must be of type string, Cake\I18n\Date given"
-     */
     public function testDryRunModeAllSeeds(): void
     {
         $this->createTables();
@@ -336,7 +333,7 @@ class SeedCommandTest extends TestCase
 
         $this->exec('migrations seed -c test --dry-run');
         $this->assertExitSuccess();
-        $this->assertErrorContains('dry-run mode enabled');
+        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
 
         $finalCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
@@ -357,14 +354,11 @@ class SeedCommandTest extends TestCase
         $this->createTables();
         $this->exec('migrations seed -c test --seed NumbersSeed --dry-run');
         $this->assertExitSuccess();
-        $this->assertErrorContains('dry-run mode enabled');
+        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
 
         $this->assertSame(['Migration.beforeSeed', 'Migration.afterSeed'], $fired);
     }
 
-    /**
-     * TODO: Currently failing with "TypeError: PDO::quote(): Argument #1 ($string) must be of type string, Cake\I18n\Date given"
-     */
     public function testDryRunModeWithStoresSeed(): void
     {
         $this->createTables();
@@ -375,7 +369,7 @@ class SeedCommandTest extends TestCase
 
         $this->exec('migrations seed -c test --seed StoresSeed --dry-run');
         $this->assertExitSuccess();
-        $this->assertErrorContains('dry-run mode enabled');
+        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
         $this->assertOutputContains('StoresSeed:</info> <comment>seeding');
 
         $finalCount = $connection->execute('SELECT COUNT(*) FROM stores')->fetchColumn(0);

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -272,7 +272,7 @@ class SeedCommandTest extends TestCase
         $this->exec('migrations seed -c test --seed NumbersSeed --dry-run');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('<warning>dry-run mode enabled</warning>');
+        $this->assertErrorContains('dry-run mode enabled');
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
     }
@@ -283,7 +283,7 @@ class SeedCommandTest extends TestCase
         $this->exec('migrations seed -c test --seed NumbersSeed -x');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('<warning>dry-run mode enabled</warning>');
+        $this->assertErrorContains('dry-run mode enabled');
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
     }
@@ -309,7 +309,7 @@ class SeedCommandTest extends TestCase
         $this->exec('migrations seed -c test --source CallSeeds --seed LettersSeed --seed NumbersCallSeed --dry-run');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('<warning>dry-run mode enabled</warning>');
+        $this->assertErrorContains('dry-run mode enabled');
         $this->assertOutputContains('NumbersCallSeed:</info> <comment>seeding');
         $this->assertOutputContains('LettersSeed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
@@ -336,7 +336,7 @@ class SeedCommandTest extends TestCase
 
         $this->exec('migrations seed -c test --dry-run');
         $this->assertExitSuccess();
-        $this->assertOutputContains('<warning>dry-run mode enabled</warning>');
+        $this->assertErrorContains('dry-run mode enabled');
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
 
         $finalCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
@@ -357,7 +357,7 @@ class SeedCommandTest extends TestCase
         $this->createTables();
         $this->exec('migrations seed -c test --seed NumbersSeed --dry-run');
         $this->assertExitSuccess();
-        $this->assertOutputContains('<warning>dry-run mode enabled</warning>');
+        $this->assertErrorContains('dry-run mode enabled');
 
         $this->assertSame(['Migration.beforeSeed', 'Migration.afterSeed'], $fired);
     }
@@ -375,7 +375,7 @@ class SeedCommandTest extends TestCase
 
         $this->exec('migrations seed -c test --seed StoresSeed --dry-run');
         $this->assertExitSuccess();
-        $this->assertOutputContains('<warning>dry-run mode enabled</warning>');
+        $this->assertErrorContains('dry-run mode enabled');
         $this->assertOutputContains('StoresSeed:</info> <comment>seeding');
 
         $finalCount = $connection->execute('SELECT COUNT(*) FROM stores')->fetchColumn(0);

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -265,4 +265,120 @@ class SeedCommandTest extends TestCase
         $this->assertNotEmpty($store['created']);
         $this->assertNotEmpty($store['modified']);
     }
+
+    public function testDryRunModeWarning(): void
+    {
+        $this->createTables();
+        $this->exec('migrations seed -c test --seed NumbersSeed --dry-run');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('All Done');
+    }
+
+    public function testDryRunModeShortOption(): void
+    {
+        $this->createTables();
+        $this->exec('migrations seed -c test --seed NumbersSeed -x');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('All Done');
+    }
+
+    public function testDryRunModeNoDataChanges(): void
+    {
+        $this->createTables();
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $initialCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
+
+        $this->exec('migrations seed -c test --seed NumbersSeed --dry-run');
+        $this->assertExitSuccess();
+
+        $finalCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
+        $this->assertEquals($initialCount, $finalCount, 'Dry-run mode should not modify database');
+    }
+
+    public function testDryRunModeMultipleSeeds(): void
+    {
+        $this->createTables();
+        $this->exec('migrations seed -c test --source CallSeeds --seed LettersSeed --seed NumbersCallSeed --dry-run');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('NumbersCallSeed:</info> <comment>seeding');
+        $this->assertOutputContains('LettersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('All Done');
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $numbersCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
+        $lettersCount = $connection->execute('SELECT COUNT(*) FROM letters')->fetchColumn(0);
+
+        $this->assertEquals(0, $numbersCount, 'Dry-run mode should not insert into numbers table');
+        $this->assertEquals(0, $lettersCount, 'Dry-run mode should not insert into letters table');
+    }
+
+    /**
+     * TODO: Currently failing with "TypeError: PDO::quote(): Argument #1 ($string) must be of type string, Cake\I18n\Date given"
+     */
+    public function testDryRunModeAllSeeds(): void
+    {
+        $this->createTables();
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $initialCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
+
+        $this->exec('migrations seed -c test --dry-run');
+        $this->assertExitSuccess();
+        $this->assertOutputContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
+
+        $finalCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
+        $this->assertEquals($initialCount, $finalCount, 'Dry-run mode should not modify database when running all seeds');
+    }
+
+    public function testDryRunModeWithEvents(): void
+    {
+        /** @var array<int, string> $fired */
+        $fired = [];
+        EventManager::instance()->on('Migration.beforeSeed', function (EventInterface $event) use (&$fired): void {
+            $fired[] = $event->getName();
+        });
+        EventManager::instance()->on('Migration.afterSeed', function (EventInterface $event) use (&$fired): void {
+            $fired[] = $event->getName();
+        });
+
+        $this->createTables();
+        $this->exec('migrations seed -c test --seed NumbersSeed --dry-run');
+        $this->assertExitSuccess();
+        $this->assertOutputContains('<warning>dry-run mode enabled</warning>');
+
+        $this->assertSame(['Migration.beforeSeed', 'Migration.afterSeed'], $fired);
+    }
+
+    /**
+     * TODO: Currently failing with "TypeError: PDO::quote(): Argument #1 ($string) must be of type string, Cake\I18n\Date given"
+     */
+    public function testDryRunModeWithStoresSeed(): void
+    {
+        $this->createTables();
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $initialCount = $connection->execute('SELECT COUNT(*) FROM stores')->fetchColumn(0);
+
+        $this->exec('migrations seed -c test --seed StoresSeed --dry-run');
+        $this->assertExitSuccess();
+        $this->assertOutputContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('StoresSeed:</info> <comment>seeding');
+
+        $finalCount = $connection->execute('SELECT COUNT(*) FROM stores')->fetchColumn(0);
+        $this->assertEquals($initialCount, $finalCount, 'Dry-run mode should not modify stores table');
+    }
 }

--- a/tests/TestCase/Config/ConfigTest.php
+++ b/tests/TestCase/Config/ConfigTest.php
@@ -176,4 +176,40 @@ class ConfigTest extends AbstractConfigTestCase
         $config = new Config(['templates' => ['style' => $style]]);
         $this->assertSame($expected, $config->getTemplateStyle());
     }
+
+    public function testIsDryRunDefaultFalse(): void
+    {
+        $config = new Config([]);
+        $this->assertFalse($config->isDryRun());
+    }
+
+    public function testIsDryRunWhenTrue(): void
+    {
+        $config = new Config([
+            'environment' => [
+                'dryrun' => true,
+            ],
+        ]);
+        $this->assertTrue($config->isDryRun());
+    }
+
+    public function testIsDryRunWhenFalse(): void
+    {
+        $config = new Config([
+            'environment' => [
+                'dryrun' => false,
+            ],
+        ]);
+        $this->assertFalse($config->isDryRun());
+    }
+
+    public function testIsDryRunWhenNotSet(): void
+    {
+        $config = new Config([
+            'environment' => [
+                'adapter' => 'mysql',
+            ],
+        ]);
+        $this->assertFalse($config->isDryRun());
+    }
 }


### PR DESCRIPTION
At $MYJOB, we approach seeds a little differently. We have created a custom `AppSeed` that all seeds inherit from that only runs INSERT and UPDATE queries as needed, rather than the more typical DELETE ALL/INSERT style.

Like with migrations, we want the ability to be able to run seeds in dry-run mode, so we can see the queries that would run before executing them. This PR attempts to add this behavior to the plugin.

I added some new tests and they are MOSTLY passing (save for two, but seemingly for an unrelated reason). The ones that are outright failing are _existing tests_ for reasons like "database is locked" which I'm unsure how to resolve. Any tips would be appreciated.

