### PR TITLE
Fix up short name to work with seeding.

### DIFF
--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -1426,7 +1426,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
 
                 default:
                     throw new InvalidArgumentException(
-                        sprintf("Don't know how to execute action: '%s'", get_class($action)),
+                        sprintf("Don't know how to execute action `%s`", get_class($action)),
                     );
             }
         }

--- a/src/Db/Adapter/AdapterFactory.php
+++ b/src/Db/Adapter/AdapterFactory.php
@@ -75,7 +75,7 @@ class AdapterFactory
             !($class instanceof Closure || is_subclass_of($class, AdapterInterface::class))
         ) {
             throw new RuntimeException(sprintf(
-                'Adapter class "%s" must implement Migrations\\Db\\Adapter\\AdapterInterface',
+                'Adapter class `%s` must implement `Migrations\\Db\\Adapter\\AdapterInterface`',
                 $class,
             ));
         }
@@ -119,7 +119,7 @@ class AdapterFactory
     {
         if (!is_subclass_of($class, WrapperInterface::class)) {
             throw new RuntimeException(sprintf(
-                'Wrapper class "%s" must implement Migrations\\Db\\Adapter\\WrapperInterface',
+                'Wrapper class `%s` must implement `Migrations\\Db\\Adapter\\WrapperInterface`',
                 $class,
             ));
         }

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -643,7 +643,7 @@ class MysqlAdapter extends AbstractAdapter
         }
 
         throw new InvalidArgumentException(sprintf(
-            "The specified index on columns '%s' does not exist",
+            'The specified index on columns `%s` does not exist',
             implode(',', $columns),
         ));
     }
@@ -667,7 +667,7 @@ class MysqlAdapter extends AbstractAdapter
         }
 
         throw new InvalidArgumentException(sprintf(
-            "The specified index name '%s' does not exist",
+            'The specified index name `%s` does not exist',
             $indexName,
         ));
     }

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -709,7 +709,7 @@ class PostgresAdapter extends AbstractAdapter
         }
 
         throw new InvalidArgumentException(sprintf(
-            "The specified index on columns '%s' does not exist",
+            'The specified index on columns `%s` does not exist',
             implode(',', $columns),
         ));
     }

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -702,7 +702,7 @@ ORDER BY IC.[key_ordinal]';
         }
 
         throw new InvalidArgumentException(sprintf(
-            "The specified index on columns '%s' does not exist",
+            'The specified index on columns `%s` does not exist',
             implode(',', $columns),
         ));
     }
@@ -730,7 +730,7 @@ ORDER BY IC.[key_ordinal]';
         }
 
         throw new InvalidArgumentException(sprintf(
-            "The specified index name '%s' does not exist",
+            'The specified index name `%s` does not exist',
             $indexName,
         ));
     }

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -669,10 +669,13 @@ class Manager
             }
         } else {
             // run only one seeder
-            if (array_key_exists($seed, $seeds)) {
+            if (array_key_exists($seed . 'Seed', $seeds)) {
+                $seed = $seed . 'Seed';
+                $this->executeSeed($seeds[$seed]);
+            } elseif (array_key_exists($seed, $seeds)) {
                 $this->executeSeed($seeds[$seed]);
             } else {
-                throw new InvalidArgumentException(sprintf('The seed class "%s" does not exist', $seed));
+                throw new InvalidArgumentException(sprintf('The seed `%s` does not exist', $seed));
             }
         }
     }
@@ -825,7 +828,7 @@ class Manager
                     ini_set('display_errors', $orig_display_errors_setting);
                     if (!class_exists($class)) {
                         throw new InvalidArgumentException(sprintf(
-                            'Could not find class "%s" in file "%s"',
+                            'Could not find class `%s` in file `%s`',
                             $class,
                             $filePath,
                         ));
@@ -953,7 +956,7 @@ class Manager
                     require_once $filePath;
                     if (!class_exists($class)) {
                         throw new InvalidArgumentException(sprintf(
-                            'Could not find class "%s" in file "%s"',
+                            'Could not find class `%s` in file `%s`',
                             $class,
                             $filePath,
                         ));

--- a/src/Util/SchemaTrait.php
+++ b/src/Util/SchemaTrait.php
@@ -39,8 +39,8 @@ trait SchemaTrait
 
         if (!method_exists($connection, 'getSchemaCollection')) {
             $msg = sprintf(
-                'The "%s" connection is not compatible with orm caching, ' .
-                'as it does not implement a "getSchemaCollection()" method.',
+                'The `%s` connection is not compatible with orm caching, ' .
+                'as it does not implement a `getSchemaCollection()` method.',
                 $connectionName,
             );
             $output->writeln('<error>' . $msg . '</error>');

--- a/src/Util/SchemaTrait.php
+++ b/src/Util/SchemaTrait.php
@@ -39,7 +39,7 @@ trait SchemaTrait
 
         if (!method_exists($connection, 'getSchemaCollection')) {
             $msg = sprintf(
-                'The `%s` connection is not compatible with orm caching, ' .
+                'The `%s` connection is not compatible with ORM caching, ' .
                 'as it does not implement a `getSchemaCollection()` method.',
                 $connectionName,
             );

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -112,7 +112,7 @@ class SeedCommandTest extends TestCase
     public function testSeederUnknown(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The seed class "NotThere" does not exist');
+        $this->expectExceptionMessage('The seed `NotThere` does not exist');
         $this->exec('migrations seed -c test --seed NotThere');
     }
 
@@ -170,7 +170,7 @@ class SeedCommandTest extends TestCase
         $this->createTables();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The seed class "NotThere" does not exist');
+        $this->expectExceptionMessage('The seed `NotThere` does not exist');
         $this->exec('migrations seed -c test --seed NumbersSeed --seed NotThere');
     }
 
@@ -197,7 +197,7 @@ class SeedCommandTest extends TestCase
     {
         $this->createTables();
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The seed class "LettersSeed" does not exist');
+        $this->expectExceptionMessage('The seed `LettersSeed` does not exist');
 
         $this->exec('migrations seed -c test --source NotThere --seed LettersSeed');
     }

--- a/tests/TestCase/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/TestCase/Db/Adapter/AdapterFactoryTest.php
@@ -51,7 +51,7 @@ class AdapterFactoryTest extends TestCase
         $adapter = static::class;
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Adapter class "Migrations\Test\Db\Adapter\AdapterFactoryTest" must implement Migrations\Db\Adapter\AdapterInterface');
+        $this->expectExceptionMessage('Adapter class `Migrations\Test\Db\Adapter\AdapterFactoryTest` must implement `Migrations\Db\Adapter\AdapterInterface`');
 
         $this->factory->registerAdapter('test', $adapter);
     }
@@ -89,7 +89,7 @@ class AdapterFactoryTest extends TestCase
         $wrapper = static::class;
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Wrapper class "Migrations\Test\Db\Adapter\AdapterFactoryTest" must implement Migrations\Db\Adapter\WrapperInterface');
+        $this->expectExceptionMessage('Wrapper class `Migrations\Test\Db\Adapter\AdapterFactoryTest` must implement `Migrations\Db\Adapter\WrapperInterface`');
 
         $this->factory->registerWrapper('test', $wrapper);
     }

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -2177,7 +2177,7 @@ class ManagerTest extends TestCase
         $this->manager->setEnvironment($envStub);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The seed class "NonExistentSeeder" does not exist');
+        $this->expectExceptionMessage('The seed `NonExistentSeeder` does not exist');
 
         $this->manager->seed('NonExistentSeeder');
     }

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -964,6 +964,59 @@ class MigrationsTest extends TestCase
      *
      * @return void
      */
+    public function testSeedOneSeederShortName()
+    {
+        // This only works for Migrations built in.
+        $backend = 'builtin';
+        Configure::write('Migrations.backend', $backend);
+
+        $this->migrations->migrate();
+
+        $seed = $this->migrations->seed(['source' => 'AltSeeds', 'seed' => 'AnotherNumbers']);
+        $this->assertTrue($seed);
+        $result = $this->Connection->selectQuery()
+            ->select(['*'])
+            ->from('numbers')
+            ->execute()->fetchAll('assoc');
+
+        $expected = [
+            [
+                'id' => '1',
+                'number' => '2',
+                'radix' => '10',
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+
+        $seed = $this->migrations->seed(['source' => 'AltSeeds', 'seed' => 'NumbersAlt']);
+        $this->assertTrue($seed);
+        $result = $this->Connection->selectQuery()
+            ->select(['*'])
+            ->from('numbers')
+            ->execute()->fetchAll('assoc');
+
+        $expected = [
+            [
+                'id' => '1',
+                'number' => '2',
+                'radix' => '10',
+            ],
+            [
+                'id' => '2',
+                'number' => '5',
+                'radix' => '10',
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+
+        $this->migrations->rollback(['target' => 'all']);
+    }
+
+    /**
+     * Tests seeding the database with seeder
+     *
+     * @return void
+     */
     #[DataProvider('backendProvider')]
     public function testSeedCallSeeder($backend)
     {
@@ -1034,7 +1087,12 @@ class MigrationsTest extends TestCase
         Configure::write('Migrations.backend', $backend);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The seed class "DerpSeed" does not exist');
+        if ($backend === 'builtin') {
+            $this->expectExceptionMessage('The seed `DerpSeed` does not exist');
+        } else {
+            $this->expectExceptionMessage('The seed class "DerpSeed" does not exist');
+        }
+
         $this->migrations->seed(['source' => 'AltSeeds', 'seed' => 'DerpSeed']);
     }
 


### PR DESCRIPTION
This always bothered me.
The whole framework works with aliases (short name) without the need of the suffix.
But seeders need it.
While I can understand that they could be also called differently, the convention and normal approach would be to use
{name}Seed.
And as such I would expect it to work with `--seed MyName` etc.

Also fixed some of the exception messages to proper code fencing for copy and paste.

This also links to Bake which also accepts the same short name and auto adds the suffix:
https://book.cakephp.org/migrations/4/en/index.html#seed-seeding-your-database