### PR TITLE
Fix up dependency issue.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": ">=8.1",
         "cakephp/cache": "^5.0",
         "cakephp/orm": "^5.0",
-        "robmorgan/phinx": "^0.16.0"
+        "robmorgan/phinx": "^0.16.10"
     },
     "require-dev": {
         "cakephp/bake": "^3.0",


### PR DESCRIPTION
Follow https://github.com/cakephp/migrations/commit/1363686fde3f7e7217e5972fbb9578947624e3d2

I assume we need to bump, as the count option available now on the public CLI API is only working with the latest code.

It still doesnt resolve the BC break when using it from older versions.
Maybe we need to check for phinx version and if lower only add the shim but not the API part of it..

We should then release one more patch, before we can do our planned minor.