### PR TITLE
Output dry-run warning on stdout

### DIFF
--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -138,7 +138,7 @@ class MigrateCommand extends Command
 
         $versionOrder = $config->getVersionOrder();
         if ($dryRun) {
-            $io->warning('dry-run mode enabled');
+            $io->out('<warning>warning</warning> dry-run mode enabled');
         }
         $io->verbose('<info>using connection</info> ' . (string)$args->getOption('connection'));
         $io->verbose('<info>using paths</info> ' . $config->getMigrationPath());

--- a/src/Command/RollbackCommand.php
+++ b/src/Command/RollbackCommand.php
@@ -145,7 +145,7 @@ class RollbackCommand extends Command
         $io->verbose('<info>ordering by</info> ' . $versionOrder . ' time');
 
         if ($dryRun) {
-            $io->out('<warning>warning</warning> dry-runmode enabled');
+            $io->out('<warning>warning</warning> dry-run mode enabled');
         }
         if ($fake) {
             $io->out('<warning>warning</warning> performing fake rollbacks');

--- a/src/Command/RollbackCommand.php
+++ b/src/Command/RollbackCommand.php
@@ -145,7 +145,7 @@ class RollbackCommand extends Command
         $io->verbose('<info>ordering by</info> ' . $versionOrder . ' time');
 
         if ($dryRun) {
-            $io->warning('dry-run mode enabled');
+            $io->out('<warning>warning</warning> dry-runmode enabled');
         }
         if ($fake) {
             $io->out('<warning>warning</warning> performing fake rollbacks');

--- a/tests/TestCase/Command/MigrateCommandTest.php
+++ b/tests/TestCase/Command/MigrateCommandTest.php
@@ -151,7 +151,7 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test --dry-run');
         $this->assertExitSuccess();
 
-        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('<warning>warning</warning> dry-run mode enabled');
         $this->assertOutputContains('MarkMigratedTest:</info> <comment>migrated');
         $this->assertOutputContains('All Done');
 

--- a/tests/TestCase/Command/RollbackCommandTest.php
+++ b/tests/TestCase/Command/RollbackCommandTest.php
@@ -113,7 +113,7 @@ class RollbackCommandTest extends TestCase
         $this->exec('migrations rollback -c test --no-lock --dry-run');
         $this->assertExitSuccess();
 
-        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('<warning>warning</warning> dry-run mode enabled');
         $this->assertOutputContains('20240309223600 MarkMigratedTestSecond:</info> <comment>reverting');
         $this->assertOutputContains('All Done');
 


### PR DESCRIPTION
Go back go outputing dry-run warnings on stdout. If someone pipes stdout to file it should all go there.

Refs #864
