### PR TITLE
Fix dry-run output to stdout.

### DIFF
--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -145,7 +145,7 @@ class MigrateCommand extends Command
         $io->verbose('<info>ordering by</info> ' . $versionOrder . ' time');
 
         if ($fake) {
-            $io->info('<warning>warning</warning> performing fake migrations');
+            $io->out('<warning>warning</warning> performing fake migrations');
         }
 
         try {

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -138,14 +138,14 @@ class MigrateCommand extends Command
 
         $versionOrder = $config->getVersionOrder();
         if ($dryRun) {
-            $io->out('<warning>warning</warning> dry-run mode enabled');
+            $io->info('DRY-RUN mode enabled');
         }
         $io->verbose('<info>using connection</info> ' . (string)$args->getOption('connection'));
         $io->verbose('<info>using paths</info> ' . $config->getMigrationPath());
         $io->verbose('<info>ordering by</info> ' . $versionOrder . ' time');
 
         if ($fake) {
-            $io->out('<warning>warning</warning> performing fake migrations');
+            $io->info('<warning>warning</warning> performing fake migrations');
         }
 
         try {

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -138,7 +138,7 @@ class MigrateCommand extends Command
 
         $versionOrder = $config->getVersionOrder();
         if ($dryRun) {
-            $io->warning('dry-run mode enabled');
+            $io->out('<warning>warning</warning> dry-run mode enabled');
         }
         $io->verbose('<info>using connection</info> ' . (string)$args->getOption('connection'));
         $io->verbose('<info>using paths</info> ' . $config->getMigrationPath());

--- a/src/Command/RollbackCommand.php
+++ b/src/Command/RollbackCommand.php
@@ -145,7 +145,7 @@ class RollbackCommand extends Command
         $io->verbose('<info>ordering by</info> ' . $versionOrder . ' time');
 
         if ($dryRun) {
-            $io->out('<warning>warning</warning> dry-runmode enabled');
+            $io->info('DRY-RUN mode enabled');
         }
         if ($fake) {
             $io->out('<warning>warning</warning> performing fake rollbacks');

--- a/src/Command/RollbackCommand.php
+++ b/src/Command/RollbackCommand.php
@@ -145,7 +145,7 @@ class RollbackCommand extends Command
         $io->verbose('<info>ordering by</info> ' . $versionOrder . ' time');
 
         if ($dryRun) {
-            $io->warning('dry-run mode enabled');
+            $io->out('<warning>warning</warning> dry-runmode enabled');
         }
         if ($fake) {
             $io->out('<warning>warning</warning> performing fake rollbacks');

--- a/tests/TestCase/Command/MigrateCommandTest.php
+++ b/tests/TestCase/Command/MigrateCommandTest.php
@@ -151,7 +151,7 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test --dry-run');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<warning>warning</warning> dry-run mode enabled');
+        $this->assertOutputContains('DRY-RUN mode enabled');
         $this->assertOutputContains('MarkMigratedTest:</info> <comment>migrated');
         $this->assertOutputContains('All Done');
 

--- a/tests/TestCase/Command/MigrateCommandTest.php
+++ b/tests/TestCase/Command/MigrateCommandTest.php
@@ -151,7 +151,7 @@ class MigrateCommandTest extends TestCase
         $this->exec('migrations migrate -c test --dry-run');
         $this->assertExitSuccess();
 
-        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('<warning>warning</warning> dry-run mode enabled');
         $this->assertOutputContains('MarkMigratedTest:</info> <comment>migrated');
         $this->assertOutputContains('All Done');
 

--- a/tests/TestCase/Command/RollbackCommandTest.php
+++ b/tests/TestCase/Command/RollbackCommandTest.php
@@ -113,7 +113,7 @@ class RollbackCommandTest extends TestCase
         $this->exec('migrations rollback -c test --no-lock --dry-run');
         $this->assertExitSuccess();
 
-        $this->assertOutputContains('<warning>warning</warning> dry-run mode enabled');
+        $this->assertOutputContains('DRY-RUN mode enabled');
         $this->assertOutputContains('20240309223600 MarkMigratedTestSecond:</info> <comment>reverting');
         $this->assertOutputContains('All Done');
 

--- a/tests/TestCase/Command/RollbackCommandTest.php
+++ b/tests/TestCase/Command/RollbackCommandTest.php
@@ -113,7 +113,7 @@ class RollbackCommandTest extends TestCase
         $this->exec('migrations rollback -c test --no-lock --dry-run');
         $this->assertExitSuccess();
 
-        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('<warning>warning</warning> dry-run mode enabled');
         $this->assertOutputContains('20240309223600 MarkMigratedTestSecond:</info> <comment>reverting');
         $this->assertOutputContains('All Done');
 

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -272,7 +272,7 @@ class SeedCommandTest extends TestCase
         $this->exec('migrations seed -c test --seed NumbersSeed --dry-run');
 
         $this->assertExitSuccess();
-        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('DRY-RUN mode enabled');
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
     }
@@ -283,7 +283,7 @@ class SeedCommandTest extends TestCase
         $this->exec('migrations seed -c test --seed NumbersSeed -x');
 
         $this->assertExitSuccess();
-        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('DRY-RUN mode enabled');
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
     }
@@ -309,7 +309,7 @@ class SeedCommandTest extends TestCase
         $this->exec('migrations seed -c test --source CallSeeds --seed LettersSeed --seed NumbersCallSeed --dry-run');
 
         $this->assertExitSuccess();
-        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('DRY-RUN mode enabled');
         $this->assertOutputContains('NumbersCallSeed:</info> <comment>seeding');
         $this->assertOutputContains('LettersSeed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
@@ -333,7 +333,7 @@ class SeedCommandTest extends TestCase
 
         $this->exec('migrations seed -c test --dry-run');
         $this->assertExitSuccess();
-        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('DRY-RUN mode enabled');
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
 
         $finalCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
@@ -354,7 +354,7 @@ class SeedCommandTest extends TestCase
         $this->createTables();
         $this->exec('migrations seed -c test --seed NumbersSeed --dry-run');
         $this->assertExitSuccess();
-        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('DRY-RUN mode enabled');
 
         $this->assertSame(['Migration.beforeSeed', 'Migration.afterSeed'], $fired);
     }
@@ -369,7 +369,7 @@ class SeedCommandTest extends TestCase
 
         $this->exec('migrations seed -c test --seed StoresSeed --dry-run');
         $this->assertExitSuccess();
-        $this->assertErrorContains('<warning>dry-run mode enabled</warning>');
+        $this->assertOutputContains('DRY-RUN mode enabled');
         $this->assertOutputContains('StoresSeed:</info> <comment>seeding');
 
         $finalCount = $connection->execute('SELECT COUNT(*) FROM stores')->fetchColumn(0);


### PR DESCRIPTION
@markstory 
Completes https://github.com/cakephp/migrations/pull/872

I was more thinking to make it an info message to have the warning reserved for fake, since thats an actual issue to warn.
Dry-Run is expected to always non perform as idempotent run (multiple times dont hurt).
We can DRY-RUN shout it to make it more visible of course.

Long term we should probably find a consistent output here across the code base.