### PR TITLE
Clean up code-sniffing violations in baked migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ error.log
 /tests/test_app/config/TestsMigrations/schema-dump-test.lock
 /tests/test_app/Plugin/TestBlog/config/Migrations/*
 .phpunit.cache
+.ddev
 
 # IDE and editor specific files #
 #################################

--- a/templates/bake/config/diff.twig
+++ b/templates/bake/config/diff.twig
@@ -42,6 +42,7 @@ class {{ name }} extends AbstractMigration
 {% else %}
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
 {% endif %}
+     *
      * @return void
      */
     public function up(): void
@@ -128,6 +129,7 @@ not empty %}
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/templates/bake/config/skeleton.twig
+++ b/templates/bake/config/skeleton.twig
@@ -43,6 +43,7 @@ class {{ name }} extends AbstractMigration
 {% else %}
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
 {% endif %}
+     *
      * @return void
      */
     public function change(): void

--- a/templates/bake/config/snapshot.twig
+++ b/templates/bake/config/snapshot.twig
@@ -41,6 +41,7 @@ class {{ name }} extends AbstractMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -58,6 +59,7 @@ class {{ name }} extends AbstractMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
+++ b/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
@@ -10,6 +10,7 @@ class TheDiffAddRemoveMysql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/migrations/4/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -42,6 +43,7 @@ class TheDiffAddRemoveMysql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Diff/addRemove/the_diff_add_remove_pgsql.php
+++ b/tests/comparisons/Diff/addRemove/the_diff_add_remove_pgsql.php
@@ -10,6 +10,7 @@ class TheDiffAddRemovePgsql extends AbstractMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -33,6 +34,7 @@ class TheDiffAddRemovePgsql extends AbstractMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Diff/default/the_diff_default_mysql.php
+++ b/tests/comparisons/Diff/default/the_diff_default_mysql.php
@@ -10,6 +10,7 @@ class TheDiffDefaultMysql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/migrations/4/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -147,6 +148,7 @@ class TheDiffDefaultMysql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Diff/default/the_diff_default_pgsql.php
+++ b/tests/comparisons/Diff/default/the_diff_default_pgsql.php
@@ -10,6 +10,7 @@ class TheDiffDefaultPgsql extends AbstractMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -126,6 +127,7 @@ class TheDiffDefaultPgsql extends AbstractMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
@@ -10,6 +10,7 @@ class TheDiffSimpleMysql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/migrations/4/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -74,6 +75,7 @@ class TheDiffSimpleMysql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Diff/simple/the_diff_simple_pgsql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_pgsql.php
@@ -10,6 +10,7 @@ class TheDiffSimplePgsql extends AbstractMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -62,6 +63,7 @@ class TheDiffSimplePgsql extends AbstractMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Diff/withAutoIdCompatibleSignedPrimaryKeys/the_diff_with_auto_id_compatible_signed_primary_keys_mysql.php
+++ b/tests/comparisons/Diff/withAutoIdCompatibleSignedPrimaryKeys/the_diff_with_auto_id_compatible_signed_primary_keys_mysql.php
@@ -10,6 +10,7 @@ class TheDiffWithAutoIdCompatibleSignedPrimaryKeysMysql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/migrations/4/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -25,6 +26,7 @@ class TheDiffWithAutoIdCompatibleSignedPrimaryKeysMysql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Diff/withAutoIdIncompatibleSignedPrimaryKeys/the_diff_with_auto_id_incompatible_signed_primary_keys_mysql.php
+++ b/tests/comparisons/Diff/withAutoIdIncompatibleSignedPrimaryKeys/the_diff_with_auto_id_incompatible_signed_primary_keys_mysql.php
@@ -12,6 +12,7 @@ class TheDiffWithAutoIdIncompatibleSignedPrimaryKeysMysql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/migrations/4/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -35,6 +36,7 @@ class TheDiffWithAutoIdIncompatibleSignedPrimaryKeysMysql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Diff/withAutoIdIncompatibleUnsignedPrimaryKeys/the_diff_with_auto_id_incompatible_unsigned_primary_keys_mysql.php
+++ b/tests/comparisons/Diff/withAutoIdIncompatibleUnsignedPrimaryKeys/the_diff_with_auto_id_incompatible_unsigned_primary_keys_mysql.php
@@ -12,6 +12,7 @@ class TheDiffWithAutoIdIncompatibleUnsignedPrimaryKeysMysql extends BaseMigratio
      *
      * More information on this method is available here:
      * https://book.cakephp.org/migrations/4/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -35,6 +36,7 @@ class TheDiffWithAutoIdIncompatibleUnsignedPrimaryKeysMysql extends BaseMigratio
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
@@ -12,6 +12,7 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -409,6 +410,7 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
@@ -10,6 +10,7 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -349,6 +350,7 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
@@ -10,6 +10,7 @@ class TestSnapshotPluginBlogPgsql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -133,6 +134,7 @@ class TestSnapshotPluginBlogPgsql extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
@@ -12,6 +12,7 @@ class TestSnapshotAutoIdDisabledSqlite extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -390,6 +391,7 @@ class TestSnapshotAutoIdDisabledSqlite extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
@@ -10,6 +10,7 @@ class TestSnapshotNotEmptySqlite extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -330,6 +331,7 @@ class TestSnapshotNotEmptySqlite extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
@@ -10,6 +10,7 @@ class TestSnapshotPluginBlogSqlite extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -124,6 +125,7 @@ class TestSnapshotPluginBlogSqlite extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_auto_id_disabled_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_auto_id_disabled_sqlserver.php
@@ -12,6 +12,7 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -425,6 +426,7 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_not_empty_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_not_empty_sqlserver.php
@@ -10,6 +10,7 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -365,6 +366,7 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_plugin_blog_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_plugin_blog_sqlserver.php
@@ -10,6 +10,7 @@ class TestSnapshotPluginBlogSqlserver extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -138,6 +139,7 @@ class TestSnapshotPluginBlogSqlserver extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/testCreate.php
+++ b/tests/comparisons/Migration/testCreate.php
@@ -10,6 +10,7 @@ class CreateUsers extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/migrations/4/en/migrations.html#the-change-method
+     *
      * @return void
      */
     public function change(): void

--- a/tests/comparisons/Migration/testCreateDatetime.php
+++ b/tests/comparisons/Migration/testCreateDatetime.php
@@ -10,6 +10,7 @@ class CreateUsers extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/migrations/4/en/migrations.html#the-change-method
+     *
      * @return void
      */
     public function change(): void

--- a/tests/comparisons/Migration/testCreateDropMigration.php
+++ b/tests/comparisons/Migration/testCreateDropMigration.php
@@ -10,6 +10,7 @@ class DropUsers extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/migrations/4/en/migrations.html#the-change-method
+     *
      * @return void
      */
     public function change(): void

--- a/tests/comparisons/Migration/testCreateFieldLength.php
+++ b/tests/comparisons/Migration/testCreateFieldLength.php
@@ -10,6 +10,7 @@ class CreateUsers extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/migrations/4/en/migrations.html#the-change-method
+     *
      * @return void
      */
     public function change(): void

--- a/tests/comparisons/Migration/testCreatePhinx.php
+++ b/tests/comparisons/Migration/testCreatePhinx.php
@@ -10,6 +10,7 @@ class CreateUsers extends AbstractMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
      * @return void
      */
     public function change(): void

--- a/tests/comparisons/Migration/testCreatePrimaryKey.php
+++ b/tests/comparisons/Migration/testCreatePrimaryKey.php
@@ -12,6 +12,7 @@ class CreateUsers extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/migrations/4/en/migrations.html#the-change-method
+     *
      * @return void
      */
     public function change(): void

--- a/tests/comparisons/Migration/testCreatePrimaryKeyUuid.php
+++ b/tests/comparisons/Migration/testCreatePrimaryKeyUuid.php
@@ -12,6 +12,7 @@ class CreateUsers extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/migrations/4/en/migrations.html#the-change-method
+     *
      * @return void
      */
     public function change(): void

--- a/tests/comparisons/Migration/testNoContents.php
+++ b/tests/comparisons/Migration/testNoContents.php
@@ -10,6 +10,7 @@ class NoContents extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/migrations/4/en/migrations.html#the-change-method
+     *
      * @return void
      */
     public function change(): void

--- a/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
+++ b/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
@@ -12,6 +12,7 @@ class TestSnapshotAutoIdDisabled extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -415,6 +416,7 @@ class TestSnapshotAutoIdDisabled extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/test_snapshot_not_empty.php
+++ b/tests/comparisons/Migration/test_snapshot_not_empty.php
@@ -10,6 +10,7 @@ class TestSnapshotNotEmpty extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -347,6 +348,7 @@ class TestSnapshotNotEmpty extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/test_snapshot_plugin_blog.php
+++ b/tests/comparisons/Migration/test_snapshot_plugin_blog.php
@@ -10,6 +10,7 @@ class TestSnapshotPluginBlog extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -134,6 +135,7 @@ class TestSnapshotPluginBlog extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_compatible_signed_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_compatible_signed_primary_keys.php
@@ -10,6 +10,7 @@ class TestSnapshotWithAutoIdCompatibleSignedPrimaryKeys extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -38,6 +39,7 @@ class TestSnapshotWithAutoIdCompatibleSignedPrimaryKeys extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_signed_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_signed_primary_keys.php
@@ -12,6 +12,7 @@ class TestSnapshotWithAutoIdIncompatibleSignedPrimaryKeys extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -48,6 +49,7 @@ class TestSnapshotWithAutoIdIncompatibleSignedPrimaryKeys extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_unsigned_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_unsigned_primary_keys.php
@@ -12,6 +12,7 @@ class TestSnapshotWithAutoIdIncompatibleUnsignedPrimaryKeys extends BaseMigratio
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -48,6 +49,7 @@ class TestSnapshotWithAutoIdIncompatibleUnsignedPrimaryKeys extends BaseMigratio
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void

--- a/tests/comparisons/Migration/test_snapshot_with_non_default_collation.php
+++ b/tests/comparisons/Migration/test_snapshot_with_non_default_collation.php
@@ -10,6 +10,7 @@ class TestSnapshotWithNonDefaultCollation extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
      * @return void
      */
     public function up(): void
@@ -39,6 +40,7 @@ class TestSnapshotWithNonDefaultCollation extends BaseMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
      * @return void
      */
     public function down(): void


### PR DESCRIPTION
This cleans up baked migrations to prevent:

"SlevomatCodingStandard.Commenting.DocCommentSpacing.IncorrectLinesCountBetweenDescriptionAndAnnotations" (Expected 1 line between description and annotations, found 0) complaints by codesniffing rules.