### PR TITLE
Only include plugin tables (with files) in diff.

### DIFF
--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -26,6 +26,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Migrations\Command\Phinx\Dump;
+use Migrations\Util\TableFinder;
 use Migrations\Util\UtilTrait;
 use Symfony\Component\Console\Input\ArrayInput;
 
@@ -553,7 +554,19 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
         assert($connection instanceof Connection);
         $connection->cacheMetadata(false);
         $collection = $connection->getSchemaCollection();
-        foreach ($this->tables as $table) {
+
+        // Filter tables based on plugin option
+        $tablesToDescribe = $this->tables;
+        if ($this->plugin) {
+            $tableFinder = new TableFinder($this->connection);
+            $options = [
+                'plugin' => $this->plugin,
+                'require-table' => true,
+            ];
+            $tablesToDescribe = $tableFinder->getTablesToBake($collection, $options);
+        }
+
+        foreach ($tablesToDescribe as $table) {
             if (preg_match('/^.*phinxlog$/', $table) === 1) {
                 continue;
             }

--- a/src/Migration/ManagerFactory.php
+++ b/src/Migration/ManagerFactory.php
@@ -96,6 +96,7 @@ class ManagerFactory
                 ConnectionManager::setConfig($connectionName, $connectionConfig);
             }
         } else {
+            /** @var array<string, string> $connectionConfig */
             $connectionConfig = ConnectionManager::getConfig($connectionName);
         }
         if (!$connectionConfig) {
@@ -105,7 +106,6 @@ class ManagerFactory
             throw new RuntimeException("The `{$connectionName}` connection has no `database` key defined.");
         }
 
-        /** @var array<string, string> $connectionConfig */
         $adapter = $connectionConfig['scheme'] ?? null;
         $adapterConfig = [
             'adapter' => $adapter,

--- a/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
@@ -201,6 +201,71 @@ class BakeMigrationDiffCommandTest extends TestCase
         $this->runDiffBakingTest('WithAutoIdIncompatibleUnsignedPrimaryKeys');
     }
 
+    /**
+     * Tests that baking a diff with --plugin option only includes tables with Table classes
+     */
+    public function testBakingDiffWithPluginOnlyIncludesTablesWithTableClasses(): void
+    {
+        $this->skipIf(!env('DB_URL_COMPARE'));
+
+        // Create some test tables in the comparison database
+        $connection = ConnectionManager::get('test_comparisons');
+
+        // Create a table that has a Table class in the TestBlog plugin
+        $connection->execute('CREATE TABLE IF NOT EXISTS articles (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            title VARCHAR(255)
+        )');
+
+        // Create a table that does NOT have a Table class in the TestBlog plugin
+        $connection->execute('CREATE TABLE IF NOT EXISTS orphan_table (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(255)
+        )');
+
+        // Create plugin migration history table
+        $connection->execute('CREATE TABLE IF NOT EXISTS test_blog_phinxlog (
+            version BIGINT NOT NULL,
+            migration_name VARCHAR(100) DEFAULT NULL,
+            start_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            end_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            breakpoint TINYINT(1) NOT NULL DEFAULT 0,
+            PRIMARY KEY (version)
+        )');
+
+        // Create a schema dump for the initial state (empty)
+        $pluginPath = Plugin::path('TestBlog');
+        $dumpPath = $pluginPath . 'config' . DS . 'Migrations' . DS . 'schema-dump-test_comparisons.lock';
+        if (!is_dir(dirname($dumpPath))) {
+            mkdir(dirname($dumpPath), 0777, true);
+        }
+        file_put_contents($dumpPath, serialize([]));
+        $this->generatedFiles[] = $dumpPath;
+
+        // Run the diff command with --plugin option
+        $this->exec('bake migration_diff TestPluginDiff -c test_comparisons -p TestBlog');
+
+        // Find the generated migration file
+        $migrationPath = $pluginPath . 'config' . DS . 'Migrations' . DS;
+        $files = glob($migrationPath . '*_TestPluginDiff.php');
+        $this->assertNotEmpty($files, 'Migration file was not generated');
+        $this->generatedFiles[] = $files[0];
+
+        // Read the generated migration content
+        $content = file_get_contents($files[0]);
+
+        // Assert that only the articles table is included (which has ArticlesTable.php)
+        $this->assertStringContainsString('createTable(\'articles\')', $content);
+
+        // Assert that orphan_table is NOT included (no Table class)
+        $this->assertStringNotContainsString('orphan_table', $content);
+
+        // Cleanup
+        $connection->execute('DROP TABLE IF EXISTS articles');
+        $connection->execute('DROP TABLE IF EXISTS orphan_table');
+        $connection->execute('DROP TABLE IF EXISTS test_blog_phinxlog');
+    }
+
     protected function runDiffBakingTest(string $scenario): void
     {
         $this->skipIf(!env('DB_URL_COMPARE'));

--- a/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationDiffCommandTest.php
@@ -17,6 +17,7 @@ use Cake\Cache\Cache;
 use Cake\Console\BaseCommand;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
+use Cake\Database\Driver\Mysql;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\StringCompareTrait;
 use Cake\Utility\Inflector;
@@ -60,7 +61,7 @@ class BakeMigrationDiffCommandTest extends TestCase
         if (env('DB_URL_COMPARE')) {
             // Clean up the comparison database each time. Table order is important.
             $connection = ConnectionManager::get('test_comparisons');
-            $tables = ['articles', 'categories', 'comments', 'users', 'phinxlog'];
+            $tables = ['articles', 'categories', 'comments', 'users', 'orphan_table', 'phinxlog'];
             foreach ($tables as $table) {
                 $connection->execute("DROP TABLE IF EXISTS $table");
             }
@@ -211,6 +212,12 @@ class BakeMigrationDiffCommandTest extends TestCase
         // Create some test tables in the comparison database
         $connection = ConnectionManager::get('test_comparisons');
 
+        // For now, only test MySQL as the original test was MySQL-specific
+        $driver = $connection->getDriver();
+        if (!($driver instanceof Mysql)) {
+            $this->markTestSkipped('This test currently only works with MySQL');
+        }
+
         // Create a table that has a Table class in the TestBlog plugin
         $connection->execute('CREATE TABLE IF NOT EXISTS articles (
             id INT AUTO_INCREMENT PRIMARY KEY,
@@ -223,22 +230,38 @@ class BakeMigrationDiffCommandTest extends TestCase
             name VARCHAR(255)
         )');
 
-        // Create plugin migration history table
-        $connection->execute('CREATE TABLE IF NOT EXISTS test_blog_phinxlog (
-            version BIGINT NOT NULL,
-            migration_name VARCHAR(100) DEFAULT NULL,
-            start_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            end_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            breakpoint TINYINT(1) NOT NULL DEFAULT 0,
-            PRIMARY KEY (version)
-        )');
+        // Don't create phinxlog - let the migration system handle it
 
         // Create a schema dump for the initial state (empty)
         $pluginPath = Plugin::path('TestBlog');
-        $dumpPath = $pluginPath . 'config' . DS . 'Migrations' . DS . 'schema-dump-test_comparisons.lock';
-        if (!is_dir(dirname($dumpPath))) {
-            mkdir(dirname($dumpPath), 0777, true);
+        $migrationsPath = $pluginPath . 'config' . DS . 'Migrations' . DS;
+        if (!is_dir($migrationsPath)) {
+            mkdir($migrationsPath, 0777, true);
         }
+
+        // Create an initial dummy migration to establish migration history
+        $initialMigration = $migrationsPath . '20200101000000_Initial.php';
+        file_put_contents($initialMigration, '<?php
+use Migrations\BaseMigration;
+
+class Initial extends BaseMigration
+{
+    public function up(): void
+    {
+    }
+
+    public function down(): void
+    {
+    }
+}
+');
+        $this->generatedFiles[] = $initialMigration;
+
+        // Run the initial migration to establish history
+        $this->exec('migrations migrate -c test_comparisons -p TestBlog');
+
+        // Now create a schema dump after the initial migration
+        $dumpPath = $migrationsPath . 'schema-dump-test_comparisons.lock';
         file_put_contents($dumpPath, serialize([]));
         $this->generatedFiles[] = $dumpPath;
 
@@ -255,7 +278,7 @@ class BakeMigrationDiffCommandTest extends TestCase
         $content = file_get_contents($files[0]);
 
         // Assert that only the articles table is included (which has ArticlesTable.php)
-        $this->assertStringContainsString('createTable(\'articles\')', $content);
+        $this->assertStringContainsString('$this->table(\'articles\')', $content);
 
         // Assert that orphan_table is NOT included (no Table class)
         $this->assertStringNotContainsString('orphan_table', $content);
@@ -263,7 +286,6 @@ class BakeMigrationDiffCommandTest extends TestCase
         // Cleanup
         $connection->execute('DROP TABLE IF EXISTS articles');
         $connection->execute('DROP TABLE IF EXISTS orphan_table');
-        $connection->execute('DROP TABLE IF EXISTS test_blog_phinxlog');
     }
 
     protected function runDiffBakingTest(string $scenario): void


### PR DESCRIPTION
Resolves https://github.com/cakephp/migrations/issues/325

I gave claude.ai the following instructions
```
Can you make a fix out of https://github.com/cakephp/migrations/issues/325 proposal?
```

@ADmad What do you think?

In general this should probably be a flag/option of sorts, as this could be useful in both directions, and also for app (to exclude plugin ones?)