### PR TITLE
Fix Literal default values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
     },
     "require": {
         "php": ">=8.1",
-        "cakephp/cache": "5.x-dev as 5.2.3",
-        "cakephp/orm": "5.x-dev as 5.2.3",
+        "cakephp/cache": "^5.2",
+        "cakephp/orm": "^5.2",
         "robmorgan/phinx": "^0.16.10"
     },
     "require-dev": {
         "cakephp/bake": "^3.3",
-        "cakephp/cakephp": "5.x-dev as 5.2.3",
+        "cakephp/cakephp": "^5.2.5",
         "cakephp/cakephp-codesniffer": "^5.0",
         "phpunit/phpunit": "^10.5.5 || ^11.1.3 || ^12.2.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
     },
     "require": {
         "php": ">=8.1",
-        "cakephp/cache": "^5.2",
-        "cakephp/orm": "^5.2",
+        "cakephp/cache": "5.x-dev as 5.2.3",
+        "cakephp/orm": "5.x-dev as 5.2.3",
         "robmorgan/phinx": "^0.16.10"
     },
     "require-dev": {
         "cakephp/bake": "^3.3",
-        "cakephp/cakephp": "^5.2.5",
+        "cakephp/cakephp": "5.x-dev as 5.2.3",
         "cakephp/cakephp-codesniffer": "^5.0",
         "phpunit/phpunit": "^10.5.5 || ^11.1.3 || ^12.2.4"
     },

--- a/src/Db/Table/Column.php
+++ b/src/Db/Table/Column.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Migrations\Db\Table;
 
 use Cake\Core\Configure;
+use Cake\Database\Expression\QueryExpression;
 use Migrations\Db\Adapter\AdapterInterface;
 use Migrations\Db\Adapter\PostgresAdapter;
 use Migrations\Db\Literal;
@@ -814,7 +815,7 @@ class Column
     {
         $default = $this->getDefault();
         if ($default instanceof Literal) {
-            $default = (string)$default;
+            $default = new QueryExpression((string)$default);
         }
 
         $type = $this->getType();

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -735,11 +735,14 @@ class MysqlAdapterTest extends TestCase
     {
         $table = new Table('table1', [], $this->adapter);
         $table->save();
-        $table->addColumn('default_ts', 'timestamp', ['null' => false, 'default' => Literal::from('CURRENT_TIMESTAMP')])
-              ->save();
+        $table
+            ->addColumn('default_ts', 'timestamp', ['null' => false, 'default' => Literal::from('CURRENT_TIMESTAMP')])
+            ->addColumn('char_default', 'string', ['null' => false, 'default' => Literal::from('"oh hi"')])
+            ->save();
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM table1');
         // MariaDB returns current_timestamp()
-        $this->assertTrue($rows[1]['Default'] === 'CURRENT_TIMESTAMP' || $rows[1]['Default'] === 'current_timestamp()');
+        $this->assertContains($rows[1]['Default'], ['CURRENT_TIMESTAMP', 'current_timestamp()']);
+        $this->assertTrue($rows[2]['Default'] === 'oh hi');
     }
 
     public function testAddColumnFirst()

--- a/tests/TestCase/Db/Table/ColumnTest.php
+++ b/tests/TestCase/Db/Table/ColumnTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 namespace Migrations\Test\TestCase\Db\Table;
 
 use Cake\Core\Configure;
+use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ValueBinder;
+use Migrations\Db\Literal;
 use Migrations\Db\Table\Column;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
@@ -41,5 +44,16 @@ class ColumnTest extends TestCase
         Configure::write('Migrations.column_null_default', false);
         $column = new Column();
         $this->assertFalse($column->isNull());
+    }
+
+    public function testToArrayDefaultLiteralValue(): void
+    {
+        $column = new Column();
+        $column->setName('created')
+            ->setType('datetime')
+            ->setDefault(new Literal('CURRENT_TIMESTAMP'));
+        $result = $column->toArray();
+        $this->assertInstanceOf(QueryExpression::class, $result['default']);
+        $this->assertEquals('CURRENT_TIMESTAMP', $result['default']->sql(new ValueBinder()));
     }
 }


### PR DESCRIPTION
With the changes from cakephp/cakephp#18858 these changes should resolve the regressions around `Literal` values raised in cakephp/cakephp#18845

Leaving as a draft until the cakephp change is merged and released.