### PR TITLE
Add jsonb type shim for postgres adapter

### DIFF
--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -220,6 +220,10 @@ class PostgresAdapter extends AbstractAdapter
         ) {
             $data['type'] = 'timestamptimezone';
         }
+        // CakePHP only has a json type (which uses the JSONB storage type)
+        if ($data['type'] === self::PHINX_TYPE_JSONB) {
+            $data['type'] = 'json';
+        }
 
         return $data;
     }

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -653,6 +653,19 @@ class PostgresAdapterTest extends TestCase
         }
     }
 
+    /**
+     * Test that shims from PHINX_TYPE_JSONB to 'json' type work.
+     */
+    public function testAddColumnJsonbCompat()
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->save();
+        $this->assertFalse($table->hasColumn('config'));
+        $table->addColumn('config', 'jsonb')
+              ->save();
+        $this->assertTrue($table->hasColumn('config'));
+    }
+
     public static function providerAddColumnIdentity(): array
     {
         return [


### PR DESCRIPTION
Restore backwards compatibility for PHINX_TYPE_JSONB with the postgres adapter. The `jsonb` type from phinx is equivalent to the `json` type in cakephp/database.

Fixes #897
