### PR TITLE
Use line stripping tags in templates and reformat templates

### DIFF
--- a/templates/bake/config/diff.twig
+++ b/templates/bake/config/diff.twig
@@ -47,81 +47,81 @@ class {{ name }} extends AbstractMigration
      */
     public function up(): void
     {
-{%    for tableName, tableDiff in data %}
-{%        set hasRemoveFK = tableDiff['constraints']['remove'] is not empty or tableDiff['indexes']['remove'] is
+{% for tableName, tableDiff in data %}
+    {%~ set hasRemoveFK = tableDiff['constraints']['remove'] is not empty or tableDiff['indexes']['remove'] is
 not empty %}
-{%        if hasRemoveFK %}
+    {%~ if hasRemoveFK %}
         $this->table('{{ tableName }}')
-{%        endif %}
-{%        if tableDiff['constraints']['remove'] is not empty %}
-{%            for constraintName, constraintDefinition in tableDiff['constraints']['remove'] %}
+    {%~ endif %}
+    {%~ if tableDiff['constraints']['remove'] is not empty %}
+        {%~ for constraintName, constraintDefinition in tableDiff['constraints']['remove'] %}
             ->dropForeignKey([], '{{ constraintName }}')
-{%            endfor %}
-{%        endif %}
-{%        if tableDiff['indexes']['remove'] is not empty %}
-{%            for indexName, indexDefinition in tableDiff['indexes']['remove'] %}
+        {%~ endfor %}
+    {%~ endif %}
+    {%~ if tableDiff['indexes']['remove'] is not empty %}
+        {%~ for indexName, indexDefinition in tableDiff['indexes']['remove'] %}
             ->removeIndexByName('{{ indexName  }}')
-{%            endfor %}
-{%        endif %}
-{%        if hasRemoveFK %}
+        {%~ endfor %}
+    {%~ endif %}
+    {%~ if hasRemoveFK %}
             ->update();
-{%        endif %}
-{%        if tableDiff['columns']['remove'] is not empty or tableDiff['columns']['changed'] is not empty %}
+    {%~ endif %}
+    {%~ if tableDiff['columns']['remove'] is not empty or tableDiff['columns']['changed'] is not empty %}
 
         {{ Migration.tableStatement(tableName, true) | raw }}
-{%            if tableDiff['columns']['remove'] is not empty  %}
-{%                for columnName, columnDefinition in tableDiff['columns']['remove'] %}
+        {%~ if tableDiff['columns']['remove'] is not empty  %}
+            {%~ for columnName, columnDefinition in tableDiff['columns']['remove'] %}
             ->removeColumn('{{ columnName }}')
-{%                endfor %}
-{%            endif %}
-{%            if tableDiff['columns']['changed'] is not empty  %}
-{%                for columnName, columnAttributes in tableDiff['columns']['changed'] %}
-{%                    set type = columnAttributes['type'] %}
-{%                    set columnAttributes = Migration.getColumnOption(columnAttributes) %}
-{%                    set columnAttributes = Migration.stringifyList(columnAttributes, {'indent': 4, 'remove':
+            {%~ endfor %}
+        {%~ endif %}
+        {%~ if tableDiff['columns']['changed'] is not empty  %}
+            {%~ for columnName, columnAttributes in tableDiff['columns']['changed'] %}
+                {%~ set type = columnAttributes['type'] %}
+                {%~ set columnAttributes = Migration.getColumnOption(columnAttributes) %}
+                {%~ set columnAttributes = Migration.stringifyList(columnAttributes, {'indent': 4, 'remove':
     ['type']}) %}
             ->changeColumn('{{ columnName }}', '{{ type }}', [{{ columnAttributes | raw }}])
-{%                endfor %}
-{%            endif -%}
-{%            if Migration.wasTableStatementGeneratedFor(tableName) %}
+            {%~ endfor %}
+        {%~ endif -%}
+        {%~ if Migration.wasTableStatementGeneratedFor(tableName) %}
             ->update();
-{%            endif %}
-{%        endif %}
-{%    endfor %}
-{%    if tables['add'] is not empty %}
-{{        Migration.element('Migrations.create-tables', {'tables': tables['add'], 'autoId': autoId, 'useSchema':
+        {%~ endif %}
+    {%~ endif %}
+{% endfor %}
+{% if tables['add'] is not empty %}
+    {{~ Migration.element('Migrations.create-tables', {'tables': tables['add'], 'autoId': autoId, 'useSchema':
     true}) | raw -}}
-{%    endif %}
-{%    for tableName, tableDiff in data  %}
-{%        if tableDiff['columns']['add'] is not empty or tableDiff['indexes']['add'] is not empty %}
+{% endif %}
+{% for tableName, tableDiff in data  %}
+    {%~ if tableDiff['columns']['add'] is not empty or tableDiff['indexes']['add'] is not empty %}
 
         {{ Migration.tableStatement(tableName, true) | raw }}
-{%            if tableDiff['columns']['add'] is not empty %}
-{{                Migration.element('Migrations.add-columns', {'columns': tableDiff['columns']['add']}) | raw -}}
-{%            endif -%}
-{%            if tableDiff['indexes']['add'] is not empty %}
-{{                Migration.element('Migrations.add-indexes', {'backend': backend, 'indexes': tableDiff['indexes']['add']}) | raw -}}
-{%            endif -%}
-{%            if Migration.wasTableStatementGeneratedFor(tableName) %}
+        {%~ if tableDiff['columns']['add'] is not empty %}
+            {{~ Migration.element('Migrations.add-columns', {'columns': tableDiff['columns']['add']}) | raw -}}
+        {%~ endif -%}
+        {%~ if tableDiff['indexes']['add'] is not empty %}
+            {{~ Migration.element('Migrations.add-indexes', {'backend': backend, 'indexes': tableDiff['indexes']['add']}) | raw -}}
+        {%~ endif -%}
+        {%~ if Migration.wasTableStatementGeneratedFor(tableName) %}
             ->update();
-{%            endif -%}
-{%        endif -%}
-{%    endfor -%}
-{%    for tableName, tableDiff in data -%}
-{%        if tableDiff['constraints']['add'] is not empty -%}
+        {%~ endif -%}
+    {%~ endif -%}
+{% endfor -%}
+{% for tableName, tableDiff in data -%}
+    {% if tableDiff['constraints']['add'] is not empty -%}
 
-{{ Migration.element(
-                'Migrations.add-foreign-keys',
-                {'constraints': tableDiff['constraints']['add'], 'table': tableName, 'backend': backend}
-            ) | raw -}}
-{%        endif -%}
-{%    endfor -%}
-{%    if tables['remove'] is not empty %}
-{%       for tableName, table in tables['remove'] %}
+        {{~ Migration.element(
+            'Migrations.add-foreign-keys',
+            {'constraints': tableDiff['constraints']['add'], 'table': tableName, 'backend': backend}
+        ) | raw -}}
+    {%~ endif -%}
+{% endfor -%}
+{% if tables['remove'] is not empty %}
+    {%~ for tableName, table in tables['remove'] %}
 
         $this->table('{{ tableName }}')->drop()->save();
-{%        endfor %}
-{%     endif %}
+    {%~ endfor %}
+{% endif %}
     }
 
     /**
@@ -134,87 +134,87 @@ not empty %}
      */
     public function down(): void
     {
-{%  set returnedData = Migration.getReturnedData() %}
-{%  set constraints = [] %}
-{%  set emptyLine = false %}
-{%  if returnedData['dropForeignKeys'] is not empty %}
-{%      for table, columnsList in returnedData['dropForeignKeys'] %}
-{%              set maxKey = columnsList | length - 1 %}
-{%              if emptyLine %}
+{% set returnedData = Migration.getReturnedData() %}
+{% set constraints = [] %}
+{% set emptyLine = false %}
+{% if returnedData['dropForeignKeys'] is not empty %}
+    {%~ for table, columnsList in returnedData['dropForeignKeys'] %}
+        {%~ set maxKey = columnsList | length - 1 %}
+        {%~ if emptyLine %}
 
-{%              else %}
-{%                 set emptyLine = true %}
-{%              endif %}
+        {%~ else %}
+            {%~ set emptyLine = true %}
+        {%~ endif %}
         $this->table('{{ table }}')
-{%              for key, columns in columnsList %}
+        {%~ for key, columns in columnsList %}
             ->dropForeignKey(
                 {{ columns | raw }}
             ){{ (key == maxKey) ? '->save();' : '' }}
-{%              endfor -%}
-{%      endfor -%}
-{%  endif -%}
-{%  if tables['remove'] is not empty -%}
-{{      Migration.element('Migrations.create-tables', {
+        {%~ endfor -%}
+    {%~ endfor -%}
+{% endif -%}
+{% if tables['remove'] is not empty -%}
+    {{~ Migration.element('Migrations.create-tables', {
           'tables': tables['remove'],
           'autoId': autoId,
           'useSchema': true
         }) |  raw -}}
-{%  endif -%}
-{%  for tableName, tableDiff in data -%}
-{%  do Migration.resetTableStatementGenerationFor(tableName) %}
-{%      if tableDiff['indexes']['add'] is not empty %}
+{% endif -%}
+{% for tableName, tableDiff in data -%}
+    {%~ do Migration.resetTableStatementGenerationFor(tableName) %}
+    {%~ if tableDiff['indexes']['add'] is not empty %}
 
         $this->table('{{ tableName }}')
-{%          for indexName, index in tableDiff['indexes']['add'] %}
+        {%~ for indexName, index in tableDiff['indexes']['add'] %}
             ->removeIndexByName('{{ indexName }}')
-{%          endfor %}
+        {%~ endfor %}
             ->update();
-{%      endif %}
-{%      if (tableDiff['columns']['remove'] is not empty or
+    {%~ endif %}
+    {%~ if (tableDiff['columns']['remove'] is not empty or
             tableDiff['columns']['changed'] is not empty or
             tableDiff['columns']['add'] is not empty or
             tableDiff['indexes']['remove'] is not empty) %}
 
         {{ Migration.tableStatement(tableName, true) | raw}}
-{%      endif %}
-{%      if tableDiff['columns']['remove'] is not empty -%}
-{{          Migration.element('Migrations.add-columns', {'columns': tableDiff['columns']['remove']}) | raw -}}
-{%      endif -%}
-{%      if tableDiff['columns']['changed'] is not empty -%}
-{%          set oldTableDef = dumpSchema[tableName] -%}
-{%          for columnName, columnAttributes in tableDiff['columns']['changed'] -%}
-{%              set columnAttributes = oldTableDef.getColumn(columnName) -%}
-{%              set type = columnAttributes['type'] -%}
-{%              set columnAttributes = Migration.getColumnOption(columnAttributes) -%}
-{%              set columnAttributes = Migration.stringifyList(columnAttributes, {'indent': 4, 'remove': ['type']}) %}
+    {%~ endif %}
+    {%~ if tableDiff['columns']['remove'] is not empty -%}
+        {{~ Migration.element('Migrations.add-columns', {'columns': tableDiff['columns']['remove']}) | raw -}}
+    {%~ endif -%}
+    {%~ if tableDiff['columns']['changed'] is not empty -%}
+        {%~ set oldTableDef = dumpSchema[tableName] -%}
+        {%~ for columnName, columnAttributes in tableDiff['columns']['changed'] -%}
+            {%~ set columnAttributes = oldTableDef.getColumn(columnName) -%}
+            {%~ set type = columnAttributes['type'] -%}
+            {%~ set columnAttributes = Migration.getColumnOption(columnAttributes) -%}
+            {%~ set columnAttributes = Migration.stringifyList(columnAttributes, {'indent': 4, 'remove': ['type']}) %}
             ->changeColumn('{{ columnName }}', '{{ type }}', [{{ columnAttributes | raw }}])
-{%          endfor -%}
-{%      endif -%}
-{%      if tableDiff['columns']['add'] is not empty %}
-{%          for columnName, columnAttributes in tableDiff['columns']['add'] %}
+        {%~ endfor -%}
+    {%~ endif -%}
+    {%~ if tableDiff['columns']['add'] is not empty %}
+        {%~ for columnName, columnAttributes in tableDiff['columns']['add'] %}
             ->removeColumn('{{ columnName }}')
-{%          endfor -%}
-{%      endif -%}
-{%      if tableDiff['indexes']['remove'] is not empty -%}
-{{         Migration.element('Migrations.add-indexes', {'indexes': tableDiff['indexes']['remove']}) | raw -}}
-{%      endif -%}
-{%      if Migration.wasTableStatementGeneratedFor(tableName) %}
+        {%~ endfor -%}
+    {%~ endif -%}
+    {%~ if tableDiff['indexes']['remove'] is not empty -%}
+        {{~ Migration.element('Migrations.add-indexes', {'indexes': tableDiff['indexes']['remove']}) | raw -}}
+    {%~ endif -%}
+    {%~ if Migration.wasTableStatementGeneratedFor(tableName) %}
             ->update();
-{%      endif %}
-{%  endfor %}
-{%  for tableName, tableDiff in data  %}
-{%      if tableDiff['constraints']['remove'] is not empty %}
-{{          Migration.element(
-                'Migrations.add-foreign-keys',
-                {'constraints': tableDiff['constraints']['remove'], 'table': tableName}
+    {%~ endif %}
+{% endfor %}
+{% for tableName, tableDiff in data  %}
+    {%~ if tableDiff['constraints']['remove'] is not empty %}
+        {{~ Migration.element(
+            'Migrations.add-foreign-keys',
+            {'constraints': tableDiff['constraints']['remove'], 'table': tableName}
             ) | raw -}}
-{%      endif %}
-{%  endfor %}
-{%  if tables['add'] is not empty %}
+    {%~ endif %}
+{% endfor %}
+{% if tables['add'] is not empty %}
 
-{%      for tableName, table in tables['add'] %}
+    {%~ for tableName, table in tables['add'] %}
         $this->table('{{ tableName }}')->drop()->save();
-{%      endfor %}
-{%  endif %}
+    {%~ endfor %}
+{% endif %}
     }
 }

--- a/templates/bake/config/skeleton.twig
+++ b/templates/bake/config/skeleton.twig
@@ -50,35 +50,35 @@ class {{ name }} extends AbstractMigration
     {
 {% for table in tables %}
         $table = $this->table('{{ table }}');
-{% if tableMethod != 'drop' %}
-{% if columnMethod == 'removeColumn' %}
-{% for column, config in columns['fields'] %}
+    {%~ if tableMethod != 'drop' %}
+        {%~ if columnMethod == 'removeColumn' %}
+            {%~ for column, config in columns['fields'] %}
         $table->{{ columnMethod }}('{{ column }}');
-{% endfor %}
-{% for column, config in columns['indexes'] %}
+            {%~ endfor %}
+            {%~ for column, config in columns['indexes'] %}
         $table->{{ indexMethod }}([{{
             Migration.stringifyList(config['columns'])  | raw
         }}]);
-{% endfor %}
-{% else %}
-{% for column, config in columns['fields'] %}
+            {%~ endfor %}
+    {%~ else %}
+        {%~ for column, config in columns['fields'] %}
         $table->{{ columnMethod }}('{{ column }}', '{{ config['columnType'] }}', [{{
             Migration.stringifyList(config['options'], {'indent': 3}, wantedOptions) | raw
         }}]);
-{% endfor %}
-{% for column, config in columns['indexes'] %}
+        {%~ endfor %}
+        {%~ for column, config in columns['indexes'] %}
         $table->{{ indexMethod }}([{{
              Migration.stringifyList(config['columns'], {'indent': 3}) | raw }}
             ], [{{
                 Migration.stringifyList(config['options'], {'indent': 3})  | raw
         }}]);
-{% endfor %}
-{% if tableMethod == 'create' and columns['primaryKey'] is not empty %}
+        {%~ endfor %}
+        {%~ if tableMethod == 'create' and columns['primaryKey'] is not empty %}
         $table->addPrimaryKey([{{
             Migration.stringifyList(columns['primaryKey'], {'indent': 3}) | raw
         }}]);
-{% endif %}
-{% endif %}
+        {%~ endif %}
+    {%~ endif %}
 {% endif %}
         $table->{{ tableMethod }}(){% if tableMethod == 'drop' %}->save(){% endif %};
 {% endfor %}

--- a/templates/bake/config/snapshot.twig
+++ b/templates/bake/config/snapshot.twig
@@ -64,21 +64,21 @@ class {{ name }} extends AbstractMigration
      */
     public function down(): void
     {
-{%  set returnedData = Migration.getReturnedData() %}
-{%  if returnedData and returnedData['dropForeignKeys'] is not empty %}
-{%      for table, columnsList in Migration.returnedData['dropForeignKeys'] %}
-{%          set maxKey = columnsList|length - 1 %}
+{%~ set returnedData = Migration.getReturnedData() %}
+{%~ if returnedData and returnedData['dropForeignKeys'] is not empty %}
+    {%~ for table, columnsList in Migration.returnedData['dropForeignKeys'] %}
+        {%~ set maxKey = columnsList|length - 1 %}
         $this->table('{{ table }}')
-{%          for key, columns in columnsList %}
+        {%~ for key, columns in columnsList %}
             ->dropForeignKey(
                 {{ columns|raw }}
             ){{ (key == maxKey) ? '->save();' : '' }}
-{%          endfor %}
+        {%~ endfor %}
 
-{%      endfor %}
-{%  endif %}
-{%      for table in tables %}
+    {%~ endfor %}
+{% endif %}
+{% for table in tables %}
         $this->table('{{ table }}')->drop()->save();
-{%      endfor %}
+{% endfor %}
     }
 }

--- a/templates/bake/element/add-columns.twig
+++ b/templates/bake/element/add-columns.twig
@@ -1,10 +1,10 @@
 {% for columnName, columnAttributes in columns %}
-{%     set type = columnAttributes['type'] %}
-{%     set columnAttributes = Migration.getColumnOption(columnAttributes) %}
-{%     set columnAttributes = Migration.stringifyList(columnAttributes, {'indent': 4, 'remove': ['type']}) %}
-{%     if columnAttributes is not empty %}
+    {%~ set type = columnAttributes['type'] %}
+    {%~ set columnAttributes = Migration.getColumnOption(columnAttributes) %}
+    {%~ set columnAttributes = Migration.stringifyList(columnAttributes, {'indent': 4, 'remove': ['type']}) %}
+    {%~ if columnAttributes is not empty %}
             ->addColumn('{{ columnName }}', '{{ type }}', [{{ columnAttributes | raw }}])
-{%     else %}
+    {%~ else %}
             ->addColumn('{{ columnName }}', '{{ type }}')
-{%     endif -%}
+    {%~ endif -%}
 {% endfor -%}

--- a/templates/bake/element/add-foreign-keys.twig
+++ b/templates/bake/element/add-foreign-keys.twig
@@ -1,31 +1,31 @@
 {% set statement = Migration.tableStatement(table, true) %}
 {% set hasProcessedConstraint = false %}
 {% for constraintName, constraint in constraints %}
-{%     set constraintColumns = constraint['columns']|sort %}
-{%     if constraint['type'] == 'foreign' %}
-{%         set hasProcessedConstraint = true %}
-{%         set columnsList = '\'' ~ constraint['columns'][0] ~ '\'' %}
-{%         set storedColumnList = columnsList %}
-{%         set indent = backend == 'builtin' ? 6 : 5 %}
-{%         if constraint['columns']|length > 1 %}
-{%             set storedColumnList = '[' ~ Migration.stringifyList(constraint['columns'], {'indent': 5}) ~ ']' %}
-{%             set columnsList = '[' ~ Migration.stringifyList(constraint['columns'], {'indent': indent}) ~ ']' %}
-{%         endif %}
-{%         set record = Migration.storeReturnedData(table, storedColumnList) %}
-{%         if constraint['references'][1] is iterable %}
-{%             set columnsReference = '[' ~ Migration.stringifyList(constraint['references'][1], {'indent': indent}) ~ ']' %}
-{%         else %}
-{%             set columnsReference = '\'' ~ constraint['references'][1] ~ '\'' %}
-{%         endif %}
-{%         if statement is not defined %}
-{%             set statement = Migration.tableStatement(table) %}
-{%         endif %}
-{%         if statement is not empty %}
+    {%~ set constraintColumns = constraint['columns']|sort %}
+    {%~ if constraint['type'] == 'foreign' %}
+        {%~ set hasProcessedConstraint = true %}
+        {%~ set columnsList = '\'' ~ constraint['columns'][0] ~ '\'' %}
+        {%~ set storedColumnList = columnsList %}
+        {%~ set indent = backend == 'builtin' ? 6 : 5 %}
+        {%~ if constraint['columns']|length > 1 %}
+            {%~ set storedColumnList = '[' ~ Migration.stringifyList(constraint['columns'], {'indent': 5}) ~ ']' %}
+            {%~ set columnsList = '[' ~ Migration.stringifyList(constraint['columns'], {'indent': indent}) ~ ']' %}
+        {%~ endif %}
+        {%~ set record = Migration.storeReturnedData(table, storedColumnList) %}
+        {%~ if constraint['references'][1] is iterable %}
+            {%~ set columnsReference = '[' ~ Migration.stringifyList(constraint['references'][1], {'indent': indent}) ~ ']' %}
+        {%~ else %}
+            {%~ set columnsReference = '\'' ~ constraint['references'][1] ~ '\'' %}
+        {%~ endif %}
+        {%~ if statement is not defined %}
+            {%~ set statement = Migration.tableStatement(table) %}
+        {%~ endif %}
+        {%~ if statement is not empty %}
 
         {{ statement | raw }}
-{%             set statement = null %}
-{%         endif %}
-{%         if backend == 'builtin' %}
+            {%~ set statement = null %}
+        {%~ endif %}
+        {%~ if backend == 'builtin' %}
             ->addForeignKey(
                 $this->foreignKey({{ columnsList | raw }})
                     ->setReferencedTable('{{ constraint['references'][0] }}')
@@ -34,7 +34,7 @@
                     ->setOnUpdate('{{ Migration.formatConstraintAction(constraint['update']) | raw }}')
                     ->setName('{{ constraintName }}')
             )
-{%          else %}
+        {%~ else %}
             ->addForeignKey(
                 {{ columnsList  | raw }},
                 '{{ constraint['references'][0] }}',
@@ -45,8 +45,8 @@
                     'constraint' => '{{ constraintName }}'
                 ]
             )
-{%          endif %}
-{%     endif %}
+        {%~ endif %}
+    {%~ endif %}
 {% endfor %}
 {% if Migration.wasTableStatementGeneratedFor(table) and hasProcessedConstraint %}
             ->update();

--- a/templates/bake/element/add-indexes.twig
+++ b/templates/bake/element/add-indexes.twig
@@ -1,28 +1,28 @@
 {% for indexName, index in indexes %}
-{%     set columnsList = '\'' ~ index['columns'][0] ~ '\'' %}
-{%     if index['columns']|length > 1 %}
-{%         set columnsList = '[' ~ Migration.stringifyList(index['columns'], {'indent': 6}) ~ ']' %}
-{%     endif %}
+    {%~ set columnsList = '\'' ~ index['columns'][0] ~ '\'' %}
+    {%~ if index['columns']|length > 1 %}
+        {%~ set columnsList = '[' ~ Migration.stringifyList(index['columns'], {'indent': 6}) ~ ']' %}
+    {%~ endif %}
             ->addIndex(
-{%     if backend == 'builtin' %}
+    {%~ if backend == 'builtin' %}
                 $this->index({{ columnsList | raw }})
                     ->setName('{{ indexName }}')
-{%         if index['type'] == 'unique' %}
+        {%~ if index['type'] == 'unique' %}
                     ->setType('unique')
-{%         elseif index['type'] == 'fulltext' %}
+        {%~ elseif index['type'] == 'fulltext' %}
                     ->setType('fulltext')
-{%         endif %}
-{%         if index['options'] %}
+        {%~ endif %}
+        {%~ if index['options'] %}
                     ->setOptions([{{ Migration.stringifyList(index['options'], {'indent': 6}) | raw }}])
-{%         endif %}
+        {%~ endif %}
             )
-{%     else %}
+    {%~ else %}
                 [{{ Migration.stringifyList(index['columns'], {'indent': 5}) | raw }}],
-{%         set params = {'name': indexName} %}
-{%         if index['type'] == 'unique' %}
-{%             set params = params|merge({'unique': true}) %}
-{%         endif %}
+        {%~ set params = {'name': indexName} %}
+        {%~ if index['type'] == 'unique' %}
+            {%~ set params = params|merge({'unique': true}) %}
+        {%~ endif %}
                 [{{ Migration.stringifyList(params, {'indent': 5}) | raw }}]
             )
-{%     endif %}
+    {%~ endif %}
 {% endfor %}

--- a/templates/bake/element/create-tables.twig
+++ b/templates/bake/element/create-tables.twig
@@ -46,18 +46,18 @@
             {%~ endif %}
         {%~ endfor %}
     {%~ endif %}
-    {{-     element('Migrations.add-indexes', {
-               indexes: createData.tables[table].indexes,
-               backend: backend,
+    {{- element('Migrations.add-indexes', {
+            indexes: createData.tables[table].indexes,
+            backend: backend,
     }) }}            ->create();
 {% endfor -%}
 {% if createData.constraints %}
     {%~ for table, tableConstraints in createData.constraints %}
-        {{-     element('Migrations.add-foreign-keys', {
-                 constraints: tableConstraints,
-                 table: table,
-                 backend: backend,
-               })
+        {{- element('Migrations.add-foreign-keys', {
+                constraints: tableConstraints,
+                table: table,
+                backend: backend,
+            })
         -}}
     {%~ endfor %}
 {% endif -%}

--- a/templates/bake/element/create-tables.twig
+++ b/templates/bake/element/create-tables.twig
@@ -1,63 +1,63 @@
 {% set createData = Migration.getCreateTablesElementData(tables) %}
 {% for table, schema in tables %}
-{%     set tableArgForMethods = useSchema ? schema : table %}
-{%     set tableArgForArray = useSchema ? table : schema %}
-{%     set foreignKeys = [] %}
-{%     set primaryKeysColumns = Migration.primaryKeysColumnsList(tableArgForMethods) %}
-{%     set primaryKeys = Migration.primaryKeys(tableArgForMethods) %}
-{%     set specialPk = primaryKeys and (primaryKeys|length > 1 or primaryKeys[0]['name'] != 'id' or primaryKeys[0]['info']['columnType'] != 'integer') and autoId %}
-{%     if loop.index > 1 %}
+    {%~ set tableArgForMethods = useSchema ? schema : table %}
+    {%~ set tableArgForArray = useSchema ? table : schema %}
+    {%~ set foreignKeys = [] %}
+    {%~ set primaryKeysColumns = Migration.primaryKeysColumnsList(tableArgForMethods) %}
+    {%~ set primaryKeys = Migration.primaryKeys(tableArgForMethods) %}
+    {%~ set specialPk = primaryKeys and (primaryKeys|length > 1 or primaryKeys[0]['name'] != 'id' or primaryKeys[0]['info']['columnType'] != 'integer') and autoId %}
+    {%~ if loop.index > 1 %}
 
-{%     endif -%}
-{%     if specialPk %}
+    {%~ endif -%}
+    {%~ if specialPk %}
         $this->table('{{ tableArgForArray }}', ['id' => false, 'primary_key' => ['{{ Migration.extract(primaryKeys)|join("', '")|raw }}']])
-{%     elseif not primaryKeys and autoId %}
+    {%~ elseif not primaryKeys and autoId %}
         $this->table('{{ tableArgForArray }}', ['id' => false])
-{%     else %}
+    {%~ else %}
         $this->table('{{ tableArgForArray }}')
-{%     endif %}
-{%     if specialPk or not autoId %}
-{%         for primaryKey in primaryKeys %}
-{%             set columnOptions = Migration.getColumnOption(primaryKey['info']['options']) %}
+    {%~ endif %}
+    {%~ if specialPk or not autoId %}
+        {%~ for primaryKey in primaryKeys %}
+            {%~ set columnOptions = Migration.getColumnOption(primaryKey['info']['options']) %}
             ->addColumn('{{ primaryKey['name'] }}', '{{ primaryKey['info']['columnType'] }}', [{{ Migration.stringifyList(columnOptions, {'indent': 4}) | raw }}])
-{%         endfor %}
-{%         if not autoId and primaryKeys %}
+        {%~ endfor %}
+        {%~ if not autoId and primaryKeys %}
             ->addPrimaryKey(['{{ Migration.extract(primaryKeys)
             | join("', '") | raw }}'])
-{%         endif %}
-{%     endif %}
-{%     for column, config in Migration.columns(tableArgForMethods) %}
-{%         set columnOptions = Migration.getColumnOption(config['options']) %}
-{%         if config['columnType'] == 'boolean' and columnOptions['default'] is defined and (Migration.value(columnOptions['default'])) is not same as('null') %}
-{%             set default = columnOptions['default'] ? true : false %}
-{%             set columnOptions = columnOptions|merge({'default': default}) %}
-{%         endif %}
+        {%~ endif %}
+    {%~ endif %}
+    {%~ for column, config in Migration.columns(tableArgForMethods) %}
+        {%~ set columnOptions = Migration.getColumnOption(config['options']) %}
+        {%~ if config['columnType'] == 'boolean' and columnOptions['default'] is defined and (Migration.value(columnOptions['default'])) is not same as('null') %}
+            {%~ set default = columnOptions['default'] ? true : false %}
+            {%~ set columnOptions = columnOptions|merge({'default': default}) %}
+        {%~ endif %}
             ->addColumn('{{ column }}', '{{ config['columnType'] }}', [{{
             Migration.stringifyList(columnOptions, {'indent': 4}) | raw
             }}])
-{%     endfor %}
-{%     if createData.tables[table].constraints is not empty %}
-{%         for name, constraint in createData.tables[table].constraints %}
-{%             if constraint['type'] == 'unique' %}
-{{                 element('Migrations.add-indexes', {
-                     indexes: {(name): constraint},
-                     backend: backend,
-                  }) -}}
-{%             endif %}
-{%         endfor %}
-{%     endif %}
-{{-     element('Migrations.add-indexes', {
-           indexes: createData.tables[table].indexes,
-           backend: backend,
-}) }}            ->create();
+    {%~ endfor %}
+    {%~ if createData.tables[table].constraints is not empty %}
+        {%~ for name, constraint in createData.tables[table].constraints %}
+            {%~ if constraint['type'] == 'unique' %}
+                {{~ element('Migrations.add-indexes', {
+                    indexes: {(name): constraint},
+                    backend: backend,
+                }) -}}
+            {%~ endif %}
+        {%~ endfor %}
+    {%~ endif %}
+    {{-     element('Migrations.add-indexes', {
+               indexes: createData.tables[table].indexes,
+               backend: backend,
+    }) }}            ->create();
 {% endfor -%}
 {% if createData.constraints %}
-{%   for table, tableConstraints in createData.constraints %}
-{{-     element('Migrations.add-foreign-keys', {
-         constraints: tableConstraints,
-         table: table,
-         backend: backend,
-       })
--}}
-{%   endfor -%}
+    {%~ for table, tableConstraints in createData.constraints %}
+        {{-     element('Migrations.add-foreign-keys', {
+                 constraints: tableConstraints,
+                 table: table,
+                 backend: backend,
+               })
+        -}}
+    {%~ endfor %}
 {% endif -%}

--- a/tests/test_app/App/Command/CustomBakeMigrationDiffCommand.php
+++ b/tests/test_app/App/Command/CustomBakeMigrationDiffCommand.php
@@ -63,6 +63,6 @@ class CustomBakeMigrationDiffCommand extends BakeMigrationDiffCommand
         $diffConfigFolder = Plugin::path('Migrations') . 'tests' . DS . 'comparisons' . DS . 'Diff' . DS . $comparison . DS;
         $diffDumpPath = $diffConfigFolder . 'schema-dump-test_comparisons_' . env('DB') . '.lock';
 
-        return unserialize(file_get_contents($diffDumpPath));
+        return unserialize(trim(file_get_contents($diffDumpPath)));
     }
 }


### PR DESCRIPTION
By using the line stripping twig tags we can use normal indenting for template control structures which makes templates a bit easier to read and maintain.