### PR TITLE
5.x - Use cakephp/database for more reflection

### DIFF
--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -483,8 +483,6 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
         $newArgs[] = $name;
 
         $newArgs = array_merge($newArgs, $this->parseOptions($args));
-
-        // TODO(mark) This nested command call always uses phinx backend.
         $exitCode = $this->executeCommand(BakeMigrationSnapshotCommand::class, $newArgs, $io);
 
         if ($exitCode === 1) {

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -1160,6 +1160,27 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     abstract protected function getDropIndexByNameInstructions(string $tableName, string $indexName): AlterInstructions;
 
     /**
+     * @inheritDoc
+     */
+    public function hasIndex(string $tableName, string|array $columns): bool
+    {
+        $dialect = $this->getSchemaDialect();
+        $columns = is_array($columns) ? $columns : [$columns];
+
+        return $dialect->hasIndex($tableName, $columns);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasIndexByName(string $tableName, string $indexName): bool
+    {
+        $dialect = $this->getSchemaDialect();
+
+        return $dialect->hasIndex($tableName, [], $indexName);
+    }
+
+    /**
      * @inheritdoc
      */
     public function addForeignKey(TableMetadata $table, ForeignKey $foreignKey): void
@@ -1208,6 +1229,17 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
      * @return \Migrations\Db\AlterInstructions
      */
     abstract protected function getDropForeignKeyByColumnsInstructions(string $tableName, array $columns): AlterInstructions;
+
+    /**
+     * @inheritDoc
+     */
+    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
+    {
+        $dialect = $this->getSchemaDialect();
+        $columns = is_array($columns) ? $columns : [$columns];
+
+        return $dialect->hasForeignKey($tableName, $columns, $constraint);
+    }
 
     /**
      * @inheritdoc

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -596,6 +596,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
      */
     protected function generateInsertSql(TableMetadata $table, array $row): string
     {
+        // TODO use cakephp/database InsertQuery here.
         $sql = sprintf(
             'INSERT INTO %s ',
             $this->quoteTableName($table->getName()),
@@ -649,11 +650,9 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
         }
 
         if ($value instanceof DateTime) {
-            return $value->toDateTimeString();
-        }
-
-        if ($value instanceof Date) {
-            return $value->toDateString();
+            $value = $value->toDateTimeString();
+        } elseif ($value instanceof Date) {
+            $value = $value->toDateString();
         }
 
         $driver = $this->getConnection()->getDriver();
@@ -717,6 +716,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
      */
     protected function generateBulkInsertSql(TableMetadata $table, array $rows): string
     {
+        // TODO use cakephp/database InsertQuery here.
         $sql = sprintf(
             'INSERT INTO %s ',
             $this->quoteTableName($table->getName()),
@@ -772,6 +772,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     {
         $result = [];
 
+        // TODO use cakephp/database SelectQuery here.
         switch ($this->options['version_order']) {
             case Config::VERSION_ORDER_CREATION_TIME:
                 $orderBy = 'version ASC';
@@ -807,6 +808,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     public function migrated(MigrationInterface $migration, string $direction, string $startTime, string $endTime): AdapterInterface
     {
         if (strcasecmp($direction, MigrationInterface::UP) === 0) {
+            // TODO use cakephp/database InsertQuery here.
             // up
             $sql = sprintf(
                 'INSERT INTO %s (%s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?);',
@@ -827,6 +829,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
 
             $this->execute($sql, $params);
         } else {
+            // TODO use cakephp/database DeleteQuery here.
             // down
             $sql = sprintf(
                 'DELETE FROM %s WHERE %s = ?',
@@ -868,6 +871,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
      */
     public function resetAllBreakpoints(): int
     {
+        // TODO use cakephp/database UpdateQuery here.
         return $this->execute(
             sprintf(
                 'UPDATE %1$s SET %2$s = %3$s, %4$s = %4$s WHERE %2$s <> %3$s;',
@@ -912,6 +916,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
             $this->castToBool($state),
             $migration->getVersion(),
         ];
+        // TODO use cakephp/database UpdateQuery here.
         $this->query(
             sprintf(
                 'UPDATE %1$s SET %2$s = ?, %3$s = %3$s WHERE %4$s = ?;',

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -335,6 +335,16 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
 
     /**
      * @inheritDoc
+     */
+    public function hasColumn(string $tableName, string $columnName): bool
+    {
+        $dialect = $this->getSchemaDialect();
+
+        return $dialect->hasColumn($tableName, $columnName);
+    }
+
+    /**
+     * @inheritDoc
      * @throws \InvalidArgumentException
      * @return void
      */

--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -63,15 +63,13 @@ interface AdapterInterface
     ];
 
     // only for mysql so far
-    // TODO This can be aliased to TableSchema constants with cakephp 5.3
-    public const PHINX_TYPE_YEAR = 'year';
+    public const PHINX_TYPE_YEAR = TableSchemaInterface::TYPE_YEAR;
 
     // only for postgresql so far
-    // TODO These can be aliased to TableSchema constants with cakephp 5.3
-    public const PHINX_TYPE_CIDR = 'cidr';
-    public const PHINX_TYPE_INET = 'inet';
-    public const PHINX_TYPE_MACADDR = 'macaddr';
-    public const PHINX_TYPE_INTERVAL = 'interval';
+    public const PHINX_TYPE_CIDR = TableSchemaInterface::TYPE_CIDR;
+    public const PHINX_TYPE_INET = TableSchemaInterface::TYPE_INET;
+    public const PHINX_TYPE_MACADDR = TableSchemaInterface::TYPE_MACADDR;
+    public const PHINX_TYPE_INTERVAL = TableSchemaInterface::TYPE_INTERVAL;
 
     /**
      * Get all migrated version numbers.

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -121,19 +121,8 @@ class MysqlAdapter extends AbstractAdapter
     protected function hasTableWithSchema(string $schema, string $tableName): bool
     {
         $dialect = $this->getSchemaDialect();
-        [$query, $params] = $dialect->listTablesSql(['database' => $schema]);
 
-        try {
-            $statement = $this->query($query, $params);
-        } catch (QueryException $e) {
-            return false;
-        }
-        $tables = [];
-        foreach ($statement->fetchAll() as $row) {
-            $tables[] = $row[0];
-        }
-
-        return in_array($tableName, $tables, true);
+        return $dialect->hasTable($tableName, $schema);
     }
 
     /**
@@ -443,14 +432,9 @@ class MysqlAdapter extends AbstractAdapter
      */
     public function hasColumn(string $tableName, string $columnName): bool
     {
-        $rows = $this->fetchAll(sprintf('SHOW COLUMNS FROM %s', $this->quoteTableName($tableName)));
-        foreach ($rows as $column) {
-            if (strcasecmp($column['Field'], $columnName) === 0) {
-                return true;
-            }
-        }
+        $dialect = $this->getSchemaDialect();
 
-        return false;
+        return $dialect->hasColumn($tableName, $columnName);
     }
 
     /**
@@ -580,20 +564,9 @@ class MysqlAdapter extends AbstractAdapter
      */
     public function hasIndex(string $tableName, string|array $columns): bool
     {
-        if (is_string($columns)) {
-            $columns = [$columns]; // str to array
-        }
+        $dialect = $this->getSchemaDialect();
 
-        $columns = array_map('strtolower', $columns);
-        $indexes = $this->getIndexes($tableName);
-
-        foreach ($indexes as $index) {
-            if ($columns == $index['columns']) {
-                return true;
-            }
-        }
-
-        return false;
+        return $dialect->hasIndex($tableName, $columns);
     }
 
     /**
@@ -601,15 +574,9 @@ class MysqlAdapter extends AbstractAdapter
      */
     public function hasIndexByName(string $tableName, string $indexName): bool
     {
-        $indexes = $this->getIndexes($tableName);
+        $dialect = $this->getSchemaDialect();
 
-        foreach ($indexes as $index) {
-            if ($index['name'] === $indexName) {
-                return true;
-            }
-        }
-
-        return false;
+        return $dialect->hasIndex($tableName, [], $indexName);
     }
 
     /**
@@ -742,21 +709,9 @@ class MysqlAdapter extends AbstractAdapter
      */
     public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
     {
-        $foreignKeys = $this->getForeignKeys($tableName);
-        $names = array_map(fn($key) => $key['name'], $foreignKeys);
-        if ($constraint) {
-            return in_array($constraint, $names, true);
-        }
+        $dialect = $this->getSchemaDialect();
 
-        $columns = array_map('mb_strtolower', (array)$columns);
-
-        foreach ($foreignKeys as $key) {
-            if (array_map('mb_strtolower', $key['columns']) === $columns) {
-                return true;
-            }
-        }
-
-        return false;
+        return $dialect->hasForeignKey($tableName, $columns, $constraint);
     }
 
     /**

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -122,7 +122,11 @@ class MysqlAdapter extends AbstractAdapter
     {
         $dialect = $this->getSchemaDialect();
 
-        return $dialect->hasTable($tableName, $schema);
+        try {
+            return $dialect->hasTable($tableName, $schema);
+        } catch (QueryException) {
+            return false;
+        }
     }
 
     /**
@@ -562,26 +566,6 @@ class MysqlAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    public function hasIndex(string $tableName, string|array $columns): bool
-    {
-        $dialect = $this->getSchemaDialect();
-
-        return $dialect->hasIndex($tableName, $columns);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function hasIndexByName(string $tableName, string $indexName): bool
-    {
-        $dialect = $this->getSchemaDialect();
-
-        return $dialect->hasIndex($tableName, [], $indexName);
-    }
-
-    /**
-     * @inheritDoc
-     */
     protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
     {
         $instructions = new AlterInstructions();
@@ -702,16 +686,6 @@ class MysqlAdapter extends AbstractAdapter
         }
 
         return $primaryKey;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
-    {
-        $dialect = $this->getSchemaDialect();
-
-        return $dialect->hasForeignKey($tableName, $columns, $constraint);
     }
 
     /**

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -105,12 +105,8 @@ class PostgresAdapter extends AbstractAdapter
         $tableName = $parts['table'];
 
         $dialect = $this->getSchemaDialect();
-        [$query, $params] = $dialect->listTablesSql(['schema' => $parts['schema']]);
 
-        $rows = $this->query($query, $params)->fetchAll();
-        $tables = array_column($rows, 0);
-
-        return in_array($tableName, $tables, true);
+        return $dialect->hasTable($tableName, $parts['schema']);
     }
 
     /**
@@ -366,17 +362,9 @@ class PostgresAdapter extends AbstractAdapter
      */
     public function hasColumn(string $tableName, string $columnName): bool
     {
-        $parts = $this->getSchemaName($tableName);
-        $connection = $this->getConnection();
-        $sql = 'SELECT count(*)
-            FROM information_schema.columns
-            WHERE table_schema = ? AND table_name = ? AND column_name = ?';
+        $dialect = $this->getSchemaDialect();
 
-        $result = $connection->execute($sql, [$parts['schema'], $parts['table'], $columnName]);
-        $row = $result->fetch('assoc');
-        $result->closeCursor();
-
-        return $row['count'] > 0;
+        return $dialect->hasColumn($tableName, $columnName);
     }
 
     /**
@@ -605,17 +593,9 @@ class PostgresAdapter extends AbstractAdapter
      */
     public function hasIndex(string $tableName, string|array $columns): bool
     {
-        if (is_string($columns)) {
-            $columns = [$columns];
-        }
-        $indexes = $this->getIndexes($tableName);
-        foreach ($indexes as $index) {
-            if (array_diff($index['columns'], $columns) === array_diff($columns, $index['columns'])) {
-                return true;
-            }
-        }
+        $dialect = $this->getSchemaDialect();
 
-        return false;
+        return $dialect->hasIndex($tableName, $columns);
     }
 
     /**
@@ -623,14 +603,9 @@ class PostgresAdapter extends AbstractAdapter
      */
     public function hasIndexByName(string $tableName, string $indexName): bool
     {
-        $indexes = $this->getIndexes($tableName);
-        foreach ($indexes as $index) {
-            if ($index['name'] === $indexName || (isset($index['constraint']) && $index['constraint'] === $indexName)) {
-                return true;
-            }
-        }
+        $dialect = $this->getSchemaDialect();
 
-        return false;
+        return $dialect->hasIndex($tableName, [], $indexName);
     }
 
     /**
@@ -735,23 +710,9 @@ class PostgresAdapter extends AbstractAdapter
      */
     public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
     {
-        $foreignKeys = $this->getForeignKeys($tableName);
-        $names = array_column($foreignKeys, 'name');
-        if ($constraint) {
-            return in_array($constraint, $names);
-        }
+        $dialect = $this->getSchemaDialect();
 
-        if (is_string($columns)) {
-            $columns = [$columns];
-        }
-
-        foreach ($foreignKeys as $key) {
-            if ($key['columns'] === $columns) {
-                return true;
-            }
-        }
-
-        return false;
+        return $dialect->hasForeignKey($tableName, $columns, $constraint);
     }
 
     /**

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -360,16 +360,6 @@ class PostgresAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    public function hasColumn(string $tableName, string $columnName): bool
-    {
-        $dialect = $this->getSchemaDialect();
-
-        return $dialect->hasColumn($tableName, $columnName);
-    }
-
-    /**
-     * @inheritDoc
-     */
     protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions
     {
         $dialect = $this->getSchemaDialect();

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -591,26 +591,6 @@ class PostgresAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    public function hasIndex(string $tableName, string|array $columns): bool
-    {
-        $dialect = $this->getSchemaDialect();
-
-        return $dialect->hasIndex($tableName, $columns);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function hasIndexByName(string $tableName, string $indexName): bool
-    {
-        $dialect = $this->getSchemaDialect();
-
-        return $dialect->hasIndex($tableName, [], $indexName);
-    }
-
-    /**
-     * @inheritDoc
-     */
     protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
     {
         $instructions = new AlterInstructions();
@@ -703,16 +683,6 @@ class PostgresAdapter extends AbstractAdapter
         }
 
         return ['constraint' => '', 'columns' => []];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
-    {
-        $dialect = $this->getSchemaDialect();
-
-        return $dialect->hasForeignKey($tableName, $columns, $constraint);
     }
 
     /**

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -544,16 +544,6 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    public function hasColumn(string $tableName, string $columnName): bool
-    {
-        $dialect = $this->getSchemaDialect();
-
-        return $dialect->hasColumn($tableName, $columnName);
-    }
-
-    /**
-     * @inheritDoc
-     */
     protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions
     {
         $tableName = $table->getName();
@@ -1210,26 +1200,6 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    public function hasIndex(string $tableName, string|array $columns): bool
-    {
-        $dialect = $this->getSchemaDialect();
-
-        return $dialect->hasIndex($tableName, $columns);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function hasIndexByName(string $tableName, string $indexName): bool
-    {
-        $dialect = $this->getSchemaDialect();
-
-        return $dialect->hasIndex($tableName, [], $indexName);
-    }
-
-    /**
-     * @inheritDoc
-     */
     protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
     {
         $indexColumnArray = [];
@@ -1344,16 +1314,6 @@ PCRE_PATTERN;
         }
 
         return [];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
-    {
-        $dialect = $this->getSchemaDialect();
-
-        return $dialect->hasForeignKey($tableName, $columns, $constraint);
     }
 
     /**

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -546,13 +546,9 @@ PCRE_PATTERN;
      */
     public function hasColumn(string $tableName, string $columnName): bool
     {
-        foreach ($this->getColumnData($tableName) as $column) {
-            if (strcasecmp($column['name'], $columnName) === 0) {
-                return true;
-            }
-        }
+        $dialect = $this->getSchemaDialect();
 
-        return false;
+        return $dialect->hasColumn($tableName, $columnName);
     }
 
     /**
@@ -682,6 +678,7 @@ PCRE_PATTERN;
             $state['triggers'] = [];
 
             $params = [$tableName];
+            // TODO use cakephp/database SelectQuery here
             $rows = $this->query(
                 "SELECT *
                 FROM sqlite_master
@@ -1215,7 +1212,9 @@ PCRE_PATTERN;
      */
     public function hasIndex(string $tableName, string|array $columns): bool
     {
-        return (bool)$this->resolveIndex($tableName, $columns);
+        $dialect = $this->getSchemaDialect();
+
+        return $dialect->hasIndex($tableName, $columns);
     }
 
     /**
@@ -1223,16 +1222,9 @@ PCRE_PATTERN;
      */
     public function hasIndexByName(string $tableName, string $indexName): bool
     {
-        $indexName = strtolower($indexName);
-        $indexes = $this->getIndexes($tableName);
+        $dialect = $this->getSchemaDialect();
 
-        foreach ($indexes as $index) {
-            if ($indexName === strtolower($index['name'])) {
-                return true;
-            }
-        }
-
-        return false;
+        return $dialect->hasIndex($tableName, [], $indexName);
     }
 
     /**
@@ -1359,18 +1351,9 @@ PCRE_PATTERN;
      */
     public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
     {
-        $columns = array_map('mb_strtolower', (array)$columns);
+        $dialect = $this->getSchemaDialect();
 
-        foreach ($this->getForeignKeys($tableName) as $key) {
-            if ($constraint !== null && $key['name'] == $constraint) {
-                return true;
-            }
-            if (array_map('mb_strtolower', $key['columns']) === $columns) {
-                return true;
-            }
-        }
-
-        return false;
+        return $dialect->hasForeignKey($tableName, $columns, $constraint);
     }
 
     /**

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -69,15 +69,10 @@ class SqlserverAdapter extends AbstractAdapter
         if ($this->hasCreatedTable($tableName)) {
             return true;
         }
+        $parts = $this->getSchemaName($tableName);
         $dialect = $this->getSchemaDialect();
 
-        $parts = $this->getSchemaName($tableName);
-        [$query, $params] = $dialect->listTablesSql(['schema' => $parts['schema']]);
-
-        $rows = $this->query($query, $params)->fetchAll();
-        $tables = array_column($rows, 0);
-
-        return in_array($parts['table'], $tables, true);
+        return $dialect->hasTable($tableName, $parts['schema']);
     }
 
     /**
@@ -591,21 +586,9 @@ ORDER BY IC.[key_ordinal]';
      */
     public function hasIndex(string $tableName, string|array $columns): bool
     {
-        if (is_string($columns)) {
-            $columns = [$columns]; // str to array
-        }
+        $dialect = $this->getSchemaDialect();
 
-        $columns = array_map('strtolower', $columns);
-        $indexes = $this->getIndexes($tableName);
-
-        foreach ($indexes as $index) {
-            $a = array_diff($columns, $index['columns']);
-            if (!$a) {
-                return true;
-            }
-        }
-
-        return false;
+        return $dialect->hasIndex($tableName, $columns);
     }
 
     /**
@@ -613,15 +596,9 @@ ORDER BY IC.[key_ordinal]';
      */
     public function hasIndexByName(string $tableName, string $indexName): bool
     {
-        $indexes = $this->getIndexes($tableName);
+        $dialect = $this->getSchemaDialect();
 
-        foreach ($indexes as $index) {
-            if ($index['name'] === $indexName) {
-                return true;
-            }
-        }
-
-        return false;
+        return $dialect->hasIndex($tableName, [], $indexName);
     }
 
     /**
@@ -739,28 +716,9 @@ ORDER BY IC.[key_ordinal]';
      */
     public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
     {
-        $foreignKeys = $this->getForeignKeys($tableName);
-        if ($constraint) {
-            foreach ($foreignKeys as $key) {
-                if ($key['name'] === $constraint) {
-                    return true;
-                }
-            }
+        $dialect = $this->getSchemaDialect();
 
-            return false;
-        }
-
-        if (is_string($columns)) {
-            $columns = [$columns];
-        }
-
-        foreach ($foreignKeys as $key) {
-            if ($key['columns'] === $columns) {
-                return true;
-            }
-        }
-
-        return false;
+        return $dialect->hasForeignKey($tableName, $columns, $constraint);
     }
 
     /**

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -345,21 +345,6 @@ class SqlserverAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    public function hasColumn(string $tableName, string $columnName): bool
-    {
-        $parts = $this->getSchemaName($tableName);
-        $sql = "SELECT count(*) as [count]
-             FROM INFORMATION_SCHEMA.COLUMNS
-             WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = ?";
-        /** @var array<string, mixed> $result */
-        $result = $this->query($sql, [$parts['schema'], $parts['table'], $columnName])->fetch('assoc');
-
-        return $result['count'] > 0;
-    }
-
-    /**
-     * @inheritDoc
-     */
     protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions
     {
         $dialect = $this->getSchemaDialect();
@@ -584,26 +569,6 @@ ORDER BY IC.[key_ordinal]';
     /**
      * @inheritDoc
      */
-    public function hasIndex(string $tableName, string|array $columns): bool
-    {
-        $dialect = $this->getSchemaDialect();
-
-        return $dialect->hasIndex($tableName, $columns);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function hasIndexByName(string $tableName, string $indexName): bool
-    {
-        $dialect = $this->getSchemaDialect();
-
-        return $dialect->hasIndex($tableName, [], $indexName);
-    }
-
-    /**
-     * @inheritDoc
-     */
     protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
     {
         $sql = $this->getIndexSqlDefinition($index, $table->getName());
@@ -709,16 +674,6 @@ ORDER BY IC.[key_ordinal]';
         }
 
         return $primaryKey;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
-    {
-        $dialect = $this->getSchemaDialect();
-
-        return $dialect->hasForeignKey($tableName, $columns, $constraint);
     }
 
     /**

--- a/tests/TestCase/Db/Adapter/DefaultAdapterTrait.php
+++ b/tests/TestCase/Db/Adapter/DefaultAdapterTrait.php
@@ -76,7 +76,7 @@ trait DefaultAdapterTrait
         return false;
     }
 
-    public function hasForeignKey(string $tableName, array|string $columns, ?string $constraint = null): bool
+    public function hasForeignKey(string $tableName, $columns, ?string $constraint = null): bool
     {
         return false;
     }

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -295,7 +295,7 @@ class MysqlAdapterTest extends TestCase
               ->addColumn('tag_id', 'integer', ['null' => false])
               ->save();
         $this->assertTrue($this->adapter->hasIndex('table1', ['user_id', 'tag_id']));
-        $this->assertTrue($this->adapter->hasIndex('table1', ['USER_ID', 'tag_id']));
+        $this->assertFalse($this->adapter->hasIndex('table1', ['USER_ID', 'tag_id']));
         $this->assertFalse($this->adapter->hasIndex('table1', ['tag_id', 'user_id']));
         $this->assertFalse($this->adapter->hasIndex('table1', ['tag_id', 'user_email']));
     }
@@ -1510,8 +1510,8 @@ class MysqlAdapterTest extends TestCase
             ['create table t(a int, b int, foreign key(a,b) references other(a,b))', 'a', false],
             ['create table t(a int, b int, foreign key(a,b) references other(a,b))', ['a', 'b'], true],
             ['create table t(a int, b int, foreign key(a,b) references other(a,b))', ['b', 'a'], false],
-            ['create table t(a int, `B` int, foreign key(a,`B`) references other(a,b))', ['a', 'b'], true],
-            ['create table t(a int, b int, foreign key(a,b) references other(a,b))', ['a', 'B'], true],
+            ['create table t(a int, `B` int, foreign key(a,`B`) references other(a,b))', ['a', 'b'], false],
+            ['create table t(a int, `B` int, foreign key(a,`B`) references other(a,b))', ['a', 'B'], true],
             ['create table t(a int, b int, c int, foreign key(a,b,c) references other(a,b,c))', ['a', 'b'], false],
             ['create table t(a int, foreign key(a) references other(a))', ['a', 'b'], false],
             ['create table t(a int, b int, foreign key(a) references other(a), foreign key(b) references other(b))', ['a', 'b'], false],

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -290,7 +290,7 @@ class PostgresAdapterTest extends TestCase
               ->addColumn('tag_id', 'integer')
               ->save();
         $this->assertTrue($this->adapter->hasIndex('table1', ['user_id', 'tag_id']));
-        $this->assertTrue($this->adapter->hasIndex('table1', ['tag_id', 'user_id']));
+        $this->assertFalse($this->adapter->hasIndex('table1', ['tag_id', 'user_id']));
         $this->assertFalse($this->adapter->hasIndex('table1', ['tag_id', 'user_email']));
     }
 
@@ -307,7 +307,7 @@ class PostgresAdapterTest extends TestCase
             ->addColumn('tag_id', 'integer')
             ->save();
         $this->assertTrue($this->adapter->hasIndex('schema1.table1', ['user_id', 'tag_id']));
-        $this->assertTrue($this->adapter->hasIndex('schema1.table1', ['tag_id', 'user_id']));
+        $this->assertFalse($this->adapter->hasIndex('schema1.table1', ['tag_id', 'user_id']));
         $this->assertFalse($this->adapter->hasIndex('schema1.table1', ['tag_id', 'user_email']));
 
         $this->adapter->dropSchema('schema1');

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -213,7 +213,8 @@ class SqliteAdapterTest extends TestCase
             ->addColumn('tag_id', 'integer')
             ->save();
         $this->assertTrue($this->adapter->hasIndex('table1', ['user_id', 'tag_id']));
-        $this->assertTrue($this->adapter->hasIndex('table1', ['USER_ID', 'tag_id']));
+        $this->assertFalse($this->adapter->hasIndex('table1', ['USER_ID', 'tag_id']));
+        $this->assertFalse($this->adapter->hasIndex('table1', ['tag_id', 'user_id']));
         $this->assertFalse($this->adapter->hasIndex('table1', ['tag_id', 'USER_ID']));
         $this->assertFalse($this->adapter->hasIndex('table1', ['tag_id', 'user_email']));
     }
@@ -1518,7 +1519,7 @@ class SqliteAdapterTest extends TestCase
             ->addForeignKey(['ref_table_id'], 'ref_table', ['id'])
             ->save();
 
-        $this->adapter->dropForeignKey($table->getName(), ['REF_TABLE_ID']);
+        $this->adapter->dropForeignKey($table->getName(), ['ref_table_id']);
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), ['ref_table_id']));
     }
 
@@ -2383,9 +2384,10 @@ INPUT;
             ['create table t(a text, b text); create index test on t(a,b)', ['b', 'a'], false],
             ['create table t(a text, b text); create index test on t(a,b)', ['a'], false],
             ['create table t(a text, b text); create index test on t(a)', ['a', 'b'], false],
-            ['create table t(a text, b text); create index test on t(a,b)', ['A', 'B'], true],
-            ['create table t("A" text, "B" text); create index test on t("A","B")', ['a', 'b'], true],
-            ['create table not_t(a text, b text, unique(a,b))', ['A', 'B'], false], // test checks table t which does not exist
+            ['create table t(a text, b text); create index test on t(a,b)', ['A', 'B'], false],
+            ['create table t(a text, b text); create index test on t(a,b)', ['a', 'b'], true],
+            ['create table t("A" text, "B" text); create index test on t("A","B")', ['A', 'B'], true],
+            ['create table not_t(a text, b text, unique(a,b))', ['a', 'b'], false], // test checks table t which does not exist
             ['create table t(a text, b text); create index test on t(a)', ['a', 'a'], false],
             ['create table t(a text unique); create temp table t(a text)', 'a', false],
         ];
@@ -2413,8 +2415,9 @@ INPUT;
         return [
             ['create table t(a text)', 'test', false],
             ['create table t(a text); create index test on t(a)', 'test', true],
-            ['create table t(a text); create index test on t(a)', 'TEST', true],
-            ['create table t(a text); create index "TEST" on t(a)', 'test', true],
+            ['create table t(a text); create index test on t(a)', 'TEST', false],
+            ['create table t(a text); create index "TEST" on t(a)', 'test', false],
+            ['create table t(a text); create index "TEST" on t(a)', 'TEST', true],
             ['create table t(a text unique)', 'sqlite_autoindex_t_1', true],
             ['create table t(a text primary key)', 'sqlite_autoindex_t_1', true],
             ['create table not_t(a text); create index test on not_t(a)', 'test', false], // test checks table t which does not exist
@@ -2522,8 +2525,9 @@ INPUT;
             ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', 'a', false],
             ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['a', 'b'], true],
             ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['b', 'a'], false],
-            ['create table t(a integer, "B" integer, foreign key(a,"B") references other(a,b))', ['a', 'b'], true],
-            ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['a', 'B'], true],
+            ['create table t(a integer, "B" integer, foreign key(a,"B") references other(a,b))', ['a', 'B'], true],
+            ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['a', 'b'], true],
+            ['create table t(a integer, b integer, foreign key(a,b) references other(a,b))', ['a', 'B'], false],
             ['create table t(a integer, b integer, c integer, foreign key(a,b,c) references other(a,b,c))', ['a', 'b'], false],
             ['create table t(a integer, foreign key(a) references other(a))', ['a', 'b'], false],
             ['create table t(a integer references other(a), b integer references other(b))', ['a', 'b'], false],
@@ -2728,12 +2732,13 @@ INPUT;
     {
         return [
             ['create table t(a text)', 'a', true],
-            ['create table t(A text)', 'a', true],
+            ['create table t(A text)', 'a', false],
+            ['create table t(A text)', 'A', true],
             ['create table t("a" text)', 'a', true],
             ['create table t([a] text)', 'a', true],
             ['create table t(\'a\' text)', 'a', true],
-            ['create table t("A" text)', 'a', true],
-            ['create table t(a text)', 'A', true],
+            ['create table t("A" text)', 'A', true],
+            ['create table t(a text)', 'a', true],
             ['create table t(b text)', 'a', false],
             ['create table t(b text, a text)', 'a', true],
             ['create table t("0" text)', '0', true],

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -1068,6 +1068,7 @@ class SqlserverAdapterTest extends TestCase
             ['create table t(a int, b int, foreign key(a,b) references other(a,b))', ['b', 'a'], false],
             ['create table t(a int, [B] int, foreign key(a,[B]) references other(a,b))', ['a', 'b'], false],
             ['create table t(a int, b int, foreign key(a,b) references other(a,b))', ['a', 'B'], false],
+            ['create table t(a int, b int, foreign key(a,b) references other(a,b))', ['a', 'b'], true],
             ['create table t(a int, b int, c int, foreign key(a,b,c) references other(a,b,c))', ['a', 'b'], false],
             ['create table t(a int, foreign key(a) references other(a))', ['a', 'b'], false],
             ['create table t(a int, b int, foreign key(a) references other(a), foreign key(b) references other(b))', ['a', 'b'], false],

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -229,7 +229,7 @@ class SqlserverAdapterTest extends TestCase
             ->addColumn('tag_id', 'integer', ['null' => false])
             ->save();
         $this->assertTrue($this->adapter->hasIndex('table1', ['user_id', 'tag_id']));
-        $this->assertTrue($this->adapter->hasIndex('table1', ['tag_id', 'USER_ID']));
+        $this->assertFalse($this->adapter->hasIndex('table1', ['tag_id', 'USER_ID']));
         $this->assertFalse($this->adapter->hasIndex('table1', ['tag_id', 'user_email']));
     }
 
@@ -717,10 +717,10 @@ class SqlserverAdapterTest extends TestCase
             ->addColumn('firstname', 'string')
             ->addColumn('lastname', 'string')
             ->save();
-        $this->assertFalse($table->hasIndex('email'));
+        $this->assertFalse($table->hasIndex(['email']));
         $table->addIndex(['email'], ['include' => ['firstname', 'lastname']])
             ->save();
-        $this->assertTrue($table->hasIndex('email'));
+        $this->assertTrue($table->hasIndex(['email']));
         $rows = $this->adapter->fetchAll("SELECT ic.is_included_column AS included
                         FROM   sys.indexes AS i
                         INNER JOIN sys.index_columns AS ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id


### PR DESCRIPTION
Use the additional schema reflection methods added in 5.3. There are some minor behavior differences such as column names are now case-sensitive and column order always matters now.