### PR TITLE
5.x Fix timestampfractional and address some TODOs

### DIFF
--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -982,6 +982,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
             'double',
             'datetime',
             'timestamp',
+            'timestampfractional',
             'time',
             'date',
             'blob',

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -920,6 +920,25 @@ class MysqlAdapter extends AbstractAdapter
     }
 
     /**
+     * Get the default encoding for the current database.
+     *
+     * @return string The default encoding
+     */
+    public function getDefaultCollation(): string
+    {
+        $encodingRequest = 'SELECT DEFAULT_COLLATION_NAME
+            FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = :dbname';
+
+        $connection = $this->getConnection();
+        $connectionConfig = $connection->config();
+
+        $statement = $connection->execute($encodingRequest, ['dbname' => $connectionConfig['database']]);
+        $row = $statement->fetch('assoc');
+
+        return $row['DEFAULT_COLLATION_NAME'] ?? '';
+    }
+
+    /**
      * Whether the server has a native uuid type.
      * (MariaDB 10.7.0+)
      *

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -25,6 +25,7 @@ use Migrations\Db\Action\RemoveColumn;
 use Migrations\Db\Action\RenameColumn;
 use Migrations\Db\Action\RenameTable;
 use Migrations\Db\Adapter\AdapterInterface;
+use Migrations\Db\Adapter\MysqlAdapter;
 use Migrations\Db\Plan\Intent;
 use Migrations\Db\Plan\Plan;
 use Migrations\Db\Table\Column;
@@ -637,19 +638,10 @@ class Table
         }
 
         $adapter = $this->getAdapter();
-        if ($adapter->getAdapterType() === 'mysql' && empty($options['collation'])) {
-            // TODO this should be a method on the MySQL adapter.
-            // It could be a hook method on the adapter?
-            $encodingRequest = 'SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME
-                FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = :dbname';
-
-            $connection = $adapter->getConnection();
-            $connectionConfig = $connection->config();
-
-            $statement = $connection->execute($encodingRequest, ['dbname' => $connectionConfig['database']]);
-            $defaultEncoding = $statement->fetch('assoc');
-            if (!empty($defaultEncoding['DEFAULT_COLLATION_NAME'])) {
-                $options['collation'] = $defaultEncoding['DEFAULT_COLLATION_NAME'];
+        if ($adapter instanceof MysqlAdapter && empty($options['collation'])) {
+            $collation = $adapter->getDefaultCollation();
+            if ($collation) {
+                $options['collation'] = $collation;
             }
         }
 

--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -114,8 +114,6 @@ class Util
      */
     public static function mapClassNameToFileName(string $className): string
     {
-        // TODO it would be nice to replace this with Inflector::underscore
-        // but it will break compatibility for little end user gain.
         $snake = function ($matches) {
             return '_' . strtolower($matches[0]);
         };

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -359,12 +359,6 @@ class MigrationHelper extends Helper
     {
         $columnType = $tableSchema->getColumnType($column);
 
-        // TODO Remove this when we align with cakephp/database more.
-        // Phinx doesn't understand timestampfractional or datetimefractional types
-        if ($columnType === 'timestampfractional' || $columnType === 'datetimefractional') {
-            $columnType = 'timestamp';
-        }
-
         return [
             'columnType' => $columnType,
             'options' => $this->attributes($tableSchema, $column),

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -408,12 +408,13 @@ class MigrationHelper extends Helper
         }
 
         if (($isMysql || $isSqlserver) && !empty($columnOptions['collate'])) {
-            // TODO fix this when migrations is aligned with cakephp/database
+            // TODO deprecate this in 5.x
             // Change keys due to Phinx using different naming for the collation
             $columnOptions['collation'] = $columnOptions['collate'];
             unset($columnOptions['collate']);
         }
 
+        // TODO deprecate precision/scale and align with cakephp/database in 5.x
         // TODO this can be cleaned up when we stop using phinx data structures for column definitions
         if (!isset($columnOptions['precision']) || $columnOptions['precision'] == null) {
             unset($columnOptions['precision']);

--- a/tests/TestCase/Command/BakeMigrationSnapshotCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationSnapshotCommandTest.php
@@ -139,7 +139,7 @@ class BakeMigrationSnapshotCommandTest extends TestCase
     }
 
     /**
-     * Test baking a snapshot with the phinx auto-id feature disabled
+     * Test baking a snapshot with the auto-id feature disabled
      *
      * @return void
      */

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -1819,8 +1819,8 @@ OUTPUT;
 
     /**
      * Creates the table "table1".
-     * Then sets phinx to dry run mode and inserts a record.
-     * Asserts that phinx outputs the insert statement and doesn't insert a record.
+     * Then enables dry run mode and inserts a record.
+     * Asserts that the insert statement is output and doesn't insert a record.
      */
     public function testDumpInsert()
     {
@@ -1863,8 +1863,8 @@ OUTPUT;
 
     /**
      * Creates the table "table1".
-     * Then sets phinx to dry run mode and inserts some records.
-     * Asserts that phinx outputs the insert statement and doesn't insert any record.
+     * Then enables dry run mode and inserts some records.
+     * Asserts that output contains the insert statement and doesn't insert any record.
      */
     public function testDumpBulkinsert()
     {

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -2504,8 +2504,8 @@ class PostgresAdapterTest extends TestCase
 
     /**
      * Creates the table "table1".
-     * Then sets phinx to dry run mode and inserts a record.
-     * Asserts that phinx outputs the insert statement and doesn't insert a record.
+     * Then enables dry run mode and inserts a record.
+     * Asserts that output contains the insert statement and doesn't insert a record.
      */
     public function testDumpInsert()
     {
@@ -2559,8 +2559,8 @@ OUTPUT;
 
     /**
      * Creates the table "table1".
-     * Then sets phinx to dry run mode and inserts some records.
-     * Asserts that phinx outputs the insert statement and doesn't insert any record.
+     * Then enables dry run mode and inserts some records.
+     * Asserts that output contains the insert statement and doesn't insert any record.
      */
     public function testDumpBulkinsert()
     {

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -1086,7 +1086,7 @@ class MigrationsTest extends TestCase
      */
     public function testMigrateErrors()
     {
-        $this->expectException(Exception::class);
+        // $this->expectException(Exception::class);
         $this->migrations->markMigrated(20150704160200);
         $this->migrations->migrate();
     }

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -1086,7 +1086,7 @@ class MigrationsTest extends TestCase
      */
     public function testMigrateErrors()
     {
-        // $this->expectException(Exception::class);
+        $this->expectException(Exception::class);
         $this->migrations->markMigrated(20150704160200);
         $this->migrations->migrate();
     }

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -110,6 +110,9 @@ class MigrationHelperTest extends TestCase
                 'comment' => null,
                 'precision' => 6,
             ];
+            $this->types = [
+                'timestamp' => 'timestampfractional',
+            ];
         }
 
         if (getenv('DB') === 'sqlserver') {

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -123,6 +123,9 @@ class MigrationHelperTest extends TestCase
                 'comment' => null,
                 'precision' => 7,
             ];
+            $this->types = [
+                'timestamp' => 'datetimefractional',
+            ];
         }
     }
 

--- a/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
@@ -56,14 +56,14 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
                 'scale' => 6,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -99,14 +99,14 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
                 'limit' => 100,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
                 'scale' => 6,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -229,14 +229,14 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
                 'limit' => 10,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
                 'scale' => 6,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -304,7 +304,7 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addColumn('highlighted_time', 'timestamp', [
+            ->addColumn('highlighted_time', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -349,14 +349,14 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
                 'limit' => 256,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
                 'scale' => 6,
             ])
-            ->addColumn('updated', 'timestamp', [
+            ->addColumn('updated', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,

--- a/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
@@ -47,14 +47,14 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
                 'scale' => 6,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -83,14 +83,14 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
                 'limit' => 100,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
                 'scale' => 6,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -184,14 +184,14 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
                 'limit' => 10,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
                 'scale' => 6,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -251,7 +251,7 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addColumn('highlighted_time', 'timestamp', [
+            ->addColumn('highlighted_time', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -289,14 +289,14 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
                 'limit' => 256,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
                 'scale' => 6,
             ])
-            ->addColumn('updated', 'timestamp', [
+            ->addColumn('updated', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,

--- a/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
@@ -47,14 +47,14 @@ class TestSnapshotPluginBlogPgsql extends BaseMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
                 'scale' => 6,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -83,14 +83,14 @@ class TestSnapshotPluginBlogPgsql extends BaseMigration
                 'limit' => 100,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
                 'scale' => 6,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_auto_id_disabled_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_auto_id_disabled_sqlserver.php
@@ -58,14 +58,14 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 7,
                 'scale' => 7,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -103,14 +103,14 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
                 'limit' => 100,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 7,
                 'scale' => 7,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -240,14 +240,14 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
                 'limit' => 10,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 7,
                 'scale' => 7,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -316,7 +316,7 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addColumn('highlighted_time', 'timestamp', [
+            ->addColumn('highlighted_time', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -365,14 +365,14 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
                 'limit' => 256,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 7,
                 'scale' => 7,
             ])
-            ->addColumn('updated', 'timestamp', [
+            ->addColumn('updated', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_not_empty_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_not_empty_sqlserver.php
@@ -49,14 +49,14 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 7,
                 'scale' => 7,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -87,14 +87,14 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
                 'limit' => 100,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 7,
                 'scale' => 7,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -195,14 +195,14 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
                 'limit' => 10,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 7,
                 'scale' => 7,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -263,7 +263,7 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addColumn('highlighted_time', 'timestamp', [
+            ->addColumn('highlighted_time', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -305,14 +305,14 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
                 'limit' => 256,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 7,
                 'scale' => 7,
             ])
-            ->addColumn('updated', 'timestamp', [
+            ->addColumn('updated', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_plugin_blog_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_plugin_blog_sqlserver.php
@@ -49,14 +49,14 @@ class TestSnapshotPluginBlogSqlserver extends BaseMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 7,
                 'scale' => 7,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -87,14 +87,14 @@ class TestSnapshotPluginBlogSqlserver extends BaseMigration
                 'limit' => 100,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 7,
                 'scale' => 7,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'datetimefractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,


### PR DESCRIPTION
- Add support for `timestampfractional` as a migration column type.
- Move some platform specific code into the MySQL adapter.
- Remove some TODOs