### PR TITLE
Add deprecation for getDecoratedConnection()

### DIFF
--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -48,6 +48,7 @@ use Phinx\Util\Literal as PhinxLiteral;
 use RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function Cake\Core\deprecationWarning;
 
 /**
  * Base Abstract Database Adapter.
@@ -208,12 +209,16 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     /**
      * Backwards compatibility shim for migrations 3.x
      *
-     * TODO add deprecation for this. Use getConnection() instead.
-     *
      * @return \Cake\Database\Connection
+     * @deprecated 4.8.0 Use getConnection() instead.
      */
     public function getDecoratedConnection(): Connection
     {
+        deprecationWarning(
+            '4.8.0',
+            'Using getDecoratedConnection() is deprecated. Use getConnection() instead.',
+        );
+
         return $this->getConnection();
     }
 

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -9,6 +9,7 @@ use Cake\Console\TestSuite\StubConsoleInput;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
 use Exception;
 use InvalidArgumentException;
 use Migrations\Db\Adapter\SqliteAdapter;
@@ -21,7 +22,6 @@ use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
 use PDOException;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 use RuntimeException;
 
@@ -81,9 +81,12 @@ class SqliteAdapterTest extends TestCase
 
     public function testGetConnection()
     {
-        $connection = $this->adapter->getConnection();
-        $this->assertInstanceOf(Connection::class, $connection);
-        $this->assertSame($connection, $this->adapter->getDecoratedConnection());
+        error_reporting(E_ALL);
+        $this->deprecated(function () {
+            $connection = $this->adapter->getConnection();
+            $this->assertInstanceOf(Connection::class, $connection);
+            $this->assertSame($connection, $this->adapter->getDecoratedConnection());
+        });
     }
 
     public function testBeginTransaction()


### PR DESCRIPTION
This method is just an alias at this point and can be replaced with getConnection().
