### PR TITLE
Add support for generating enum/set columns

### DIFF
--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -347,7 +347,7 @@ class MysqlAdapter extends AbstractAdapter
         if (in_array($columnData['type'], $deprecatedTypes, true)) {
             $sql = $this->quoteColumnName($columnData['name']) . ' ' . $columnData['type'];
             $values = $column->getValues();
-            if ($values && is_array($values)) {
+            if ($values) {
                 $sql .= '(' . implode(', ', array_map(function ($value) {
                     // Special case NULL to trigger errors as it isn't allowed
                     // in enum values.

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -11,6 +11,7 @@ namespace Migrations\Db\Adapter;
 use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Exception\QueryException;
+use Cake\Database\Schema\SchemaDialect;
 use Cake\Database\Schema\TableSchema;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
@@ -231,8 +232,7 @@ class MysqlAdapter extends AbstractAdapter
         $sql = 'CREATE TABLE ';
         $sql .= $this->quoteTableName($table->getName()) . ' (';
         foreach ($columns as $column) {
-            $columnData = $this->mapColumnData($column->toArray());
-            $sql .= $dialect->columnDefinitionSql($columnData) . ', ';
+            $sql .= $this->columnDefinitionSql($dialect, $column) . ', ';
         }
 
         // set the primary key(s)
@@ -327,6 +327,38 @@ class MysqlAdapter extends AbstractAdapter
         }
 
         return $data;
+    }
+
+    /**
+     * Get the SQL fragment for a column definition.
+     *
+     * This method provides backwards compatibility for enum and set types
+     * as userland migrations use those types, but they are not supported
+     * in cakephp/database.
+     *
+     * @param \Cake\Database\Schema\SchemaDialect $dialect The dialect to use.
+     * @param \Migrations\Db\Table\Column $column The column to get the SQL for.
+     * @return string
+     */
+    protected function columnDefinitionSql(SchemaDialect $dialect, Column $column): string
+    {
+        $columnData = $column->toArray();
+        $deprecatedTypes = [self::PHINX_TYPE_ENUM, self::PHINX_TYPE_SET];
+        if (in_array($columnData['type'], $deprecatedTypes, true)) {
+            $sql = $this->quoteColumnName($columnData['name']) . ' ' . $columnData['type'];
+            $values = $column->getValues();
+            if ($values && is_array($values)) {
+                $sql .= '(' . implode(', ', array_map(function ($value) {
+                    // Special case NULL to trigger errors as it isn't allowed
+                    // in enum values.
+                    return $value === null ? 'NULL' : $this->quoteString($value);
+                }, $values)) . ')';
+            }
+
+            return $sql;
+        }
+
+        return $dialect->columnDefinitionSql($this->mapColumnData($columnData));
     }
 
     /**
@@ -502,7 +534,7 @@ class MysqlAdapter extends AbstractAdapter
         $dialect = $this->getSchemaDialect();
         $alter = sprintf(
             'ADD %s',
-            $dialect->columnDefinitionSql($this->mapColumnData($column->toArray())),
+            $this->columnDefinitionSql($dialect, $column),
         );
 
         $alter .= $this->afterClause($column);
@@ -585,7 +617,7 @@ class MysqlAdapter extends AbstractAdapter
         $alter = sprintf(
             'CHANGE %s %s%s',
             $this->quoteColumnName($columnName),
-            $dialect->columnDefinitionSql($this->mapColumnData($newColumn->toArray())),
+            $this->columnDefinitionSql($dialect, $newColumn),
             $this->afterClause($newColumn),
         );
 

--- a/src/Db/Table/Column.php
+++ b/src/Db/Table/Column.php
@@ -852,6 +852,7 @@ class Column
             'timezone' => $this->getTimezone(),
             'comment' => $this->getComment(),
             'autoIncrement' => $this->getIdentity(),
+            'values' => $this->getValues(),
         ];
     }
 }

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -496,6 +496,18 @@ class MysqlAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
     }
 
+    public function testCreateTableWithSetEnumTypes()
+    {
+        $table = new Table('enum_test', [], $this->adapter);
+        $table->addColumn('status', 'enum', ['values' => ['pending', 'active', 'archived']])
+              ->addColumn('kind', 'set', ['values' => ['a', 'b']])
+              ->save();
+
+        $this->assertTrue($this->adapter->hasTable('enum_test'));
+        $this->assertTrue($this->adapter->hasColumn('enum_test', 'status'));
+        $this->assertTrue($this->adapter->hasColumn('enum_test', 'kind'));
+    }
+
     #[RunInSeparateProcess]
     public function testUnsignedPksFeatureFlag()
     {
@@ -966,6 +978,21 @@ class MysqlAdapterTest extends TestCase
         $table->changeColumn('column1', $newColumn1)->save();
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM t');
         $this->assertNull($rows[1]['Default']);
+    }
+
+    public function testChangeColumnEnum()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'string')
+              ->save();
+        $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
+
+        $table->changeColumn('column1', 'enum', ['values' => ['a', 'b']])->save();
+        $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
+
+        $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM t');
+        $this->assertNull($rows[1]['Default']);
+        $this->assertEquals("enum('a','b')", $rows[1]['Type']);
     }
 
     public static function sqlTypeIntConversionProvider()
@@ -1913,6 +1940,20 @@ class MysqlAdapterTest extends TestCase
 
         $this->assertSame('column1', $columnWithComment['COLUMN_NAME'], "Didn't set column name correctly");
         $this->assertEquals($comment, $columnWithComment['COLUMN_COMMENT'], "Didn't set column comment correctly");
+    }
+
+    public function testAddColumnEnum()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'string')
+              ->save();
+        $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
+
+        $table->addColumn('column2', 'enum', ['values' => ['a', 'b']])->save();
+        $this->assertTrue($this->adapter->hasColumn('t', 'column2'));
+
+        $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM t');
+        $this->assertEquals("enum('a','b')", $rows[2]['Type']);
     }
 
     public function testAddGeoSpatialColumns()


### PR DESCRIPTION
Add shim logic to extend support for enum and set column types. There have been a few issues opened about the removal of enum columns from migrations. With these changes migrations can once again generate create table, add column and change column operations for enum columns.

Reflection of enum columns and values has not been added.

Fixes #907
Fixes #895