### PR TITLE
Rename Db\Table\Table to TableMetadata

### DIFF
--- a/src/Db/Action/Action.php
+++ b/src/Db/Action/Action.php
@@ -8,21 +8,21 @@ declare(strict_types=1);
 
 namespace Migrations\Db\Action;
 
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 abstract class Action
 {
     /**
-     * @var \Migrations\Db\Table\Table
+     * @var \Migrations\Db\Table\TableMetadata
      */
-    protected Table $table;
+    protected TableMetadata $table;
 
     /**
      * Constructor
      *
-     * @param \Migrations\Db\Table\Table $table the Table to apply the action to
+     * @param \Migrations\Db\Table\TableMetadata $table the Table to apply the action to
      */
-    public function __construct(Table $table)
+    public function __construct(TableMetadata $table)
     {
         $this->table = $table;
     }
@@ -30,9 +30,9 @@ abstract class Action
     /**
      * The table this action will be applied to
      *
-     * @return \Migrations\Db\Table\Table
+     * @return \Migrations\Db\Table\TableMetadata
      */
-    public function getTable(): Table
+    public function getTable(): TableMetadata
     {
         return $this->table;
     }

--- a/src/Db/Action/AddColumn.php
+++ b/src/Db/Action/AddColumn.php
@@ -10,7 +10,7 @@ namespace Migrations\Db\Action;
 
 use Migrations\Db\Literal;
 use Migrations\Db\Table\Column;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 class AddColumn extends Action
 {
@@ -24,10 +24,10 @@ class AddColumn extends Action
     /**
      * Constructor
      *
-     * @param \Migrations\Db\Table\Table $table The table to add the column to
+     * @param \Migrations\Db\Table\TableMetadata $table The table to add the column to
      * @param \Migrations\Db\Table\Column $column The column to add
      */
-    public function __construct(Table $table, Column $column)
+    public function __construct(TableMetadata $table, Column $column)
     {
         parent::__construct($table);
         $this->column = $column;
@@ -36,13 +36,13 @@ class AddColumn extends Action
     /**
      * Returns a new AddColumn object after assembling the given commands
      *
-     * @param \Migrations\Db\Table\Table $table The table to add the column to
+     * @param \Migrations\Db\Table\TableMetadata $table The table to add the column to
      * @param string $columnName The column name
      * @param string|\Migrations\Db\Literal $type The column type
      * @param array<string, mixed> $options The column options
      * @return self
      */
-    public static function build(Table $table, string $columnName, string|Literal $type, array $options = []): self
+    public static function build(TableMetadata $table, string $columnName, string|Literal $type, array $options = []): self
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Db/Action/AddForeignKey.php
+++ b/src/Db/Action/AddForeignKey.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Migrations\Db\Action;
 
 use Migrations\Db\Table\ForeignKey;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 class AddForeignKey extends Action
 {
@@ -23,10 +23,10 @@ class AddForeignKey extends Action
     /**
      * Constructor
      *
-     * @param \Migrations\Db\Table\Table $table The table to add the foreign key to
+     * @param \Migrations\Db\Table\TableMetadata $table The table to add the foreign key to
      * @param \Migrations\Db\Table\ForeignKey $fk The foreign key to add
      */
-    public function __construct(Table $table, ForeignKey $fk)
+    public function __construct(TableMetadata $table, ForeignKey $fk)
     {
         parent::__construct($table);
         $this->foreignKey = $fk;
@@ -36,22 +36,28 @@ class AddForeignKey extends Action
      * Creates a new AddForeignKey object after building the foreign key with
      * the passed attributes
      *
-     * @param \Migrations\Db\Table\Table $table The table object to add the foreign key to
+     * @param \Migrations\Db\Table\TableMetadata $table The table object to add the foreign key to
      * @param string|string[] $columns The columns for the foreign key
-     * @param \Migrations\Db\Table\Table|string $referencedTable The table the foreign key references
+     * @param \Migrations\Db\Table\TableMetadata|string $referencedTable The table the foreign key references
      * @param string|string[] $referencedColumns The columns in the referenced table
      * @param array<string, mixed> $options Extra options for the foreign key
      * @param string|null $name The name of the foreign key
      * @return self
      */
-    public static function build(Table $table, string|array $columns, Table|string $referencedTable, string|array $referencedColumns = ['id'], array $options = [], ?string $name = null): self
-    {
+    public static function build(
+        TableMetadata $table,
+        string|array $columns,
+        TableMetadata|string $referencedTable,
+        string|array $referencedColumns = ['id'],
+        array $options = [],
+        ?string $name = null,
+    ): self {
         if (is_string($referencedColumns)) {
             $referencedColumns = [$referencedColumns]; // str to array
         }
 
         if (is_string($referencedTable)) {
-            $referencedTable = new Table($referencedTable);
+            $referencedTable = new TableMetadata($referencedTable);
         }
 
         // Shimming old 4.x

--- a/src/Db/Action/AddIndex.php
+++ b/src/Db/Action/AddIndex.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Migrations\Db\Action;
 
 use Migrations\Db\Table\Index;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 class AddIndex extends Action
 {
@@ -23,10 +23,10 @@ class AddIndex extends Action
     /**
      * Constructor
      *
-     * @param \Migrations\Db\Table\Table $table The table to add the index to
+     * @param \Migrations\Db\Table\TableMetadata $table The table to add the index to
      * @param \Migrations\Db\Table\Index $index The index to be added
      */
-    public function __construct(Table $table, Index $index)
+    public function __construct(TableMetadata $table, Index $index)
     {
         parent::__construct($table);
         $this->index = $index;
@@ -36,12 +36,12 @@ class AddIndex extends Action
      * Creates a new AddIndex object after building the index object with the
      * provided arguments
      *
-     * @param \Migrations\Db\Table\Table $table The table to add the index to
+     * @param \Migrations\Db\Table\TableMetadata $table The table to add the index to
      * @param string|string[]|\Migrations\Db\Table\Index $columns The columns to index
      * @param array<string, mixed> $options Additional options for the index creation
      * @return self
      */
-    public static function build(Table $table, string|array|Index $columns, array $options = []): self
+    public static function build(TableMetadata $table, string|array|Index $columns, array $options = []): self
     {
         // create a new index object if strings or an array of strings were supplied
         if (!($columns instanceof Index)) {

--- a/src/Db/Action/ChangeColumn.php
+++ b/src/Db/Action/ChangeColumn.php
@@ -10,7 +10,7 @@ namespace Migrations\Db\Action;
 
 use Migrations\Db\Literal;
 use Migrations\Db\Table\Column;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 class ChangeColumn extends Action
 {
@@ -31,11 +31,11 @@ class ChangeColumn extends Action
     /**
      * Constructor
      *
-     * @param \Migrations\Db\Table\Table $table The table to alter
+     * @param \Migrations\Db\Table\TableMetadata $table The table to alter
      * @param string $columnName The name of the column to change
      * @param \Migrations\Db\Table\Column $column The column definition
      */
-    public function __construct(Table $table, string $columnName, Column $column)
+    public function __construct(TableMetadata $table, string $columnName, Column $column)
     {
         parent::__construct($table);
         $this->columnName = $columnName;
@@ -51,13 +51,13 @@ class ChangeColumn extends Action
      * Creates a new ChangeColumn object after building the column definition
      * out of the provided arguments
      *
-     * @param \Migrations\Db\Table\Table $table The table to alter
+     * @param \Migrations\Db\Table\TableMetadata $table The table to alter
      * @param string $columnName The name of the column to change
      * @param string|\Migrations\Db\Literal $type The type of the column
      * @param array<string, mixed> $options Additional options for the column
      * @return self
      */
-    public static function build(Table $table, string $columnName, string|Literal $type, array $options = []): self
+    public static function build(TableMetadata $table, string $columnName, string|Literal $type, array $options = []): self
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Db/Action/ChangeComment.php
+++ b/src/Db/Action/ChangeComment.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Migrations\Db\Action;
 
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 class ChangeComment extends Action
 {
@@ -22,10 +22,10 @@ class ChangeComment extends Action
     /**
      * Constructor
      *
-     * @param \Migrations\Db\Table\Table $table The table to be changed
+     * @param \Migrations\Db\Table\TableMetadata $table The table to be changed
      * @param string|null $newComment The new comment for the table
      */
-    public function __construct(Table $table, ?string $newComment)
+    public function __construct(TableMetadata $table, ?string $newComment)
     {
         parent::__construct($table);
         $this->newComment = $newComment;

--- a/src/Db/Action/ChangePrimaryKey.php
+++ b/src/Db/Action/ChangePrimaryKey.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Migrations\Db\Action;
 
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 class ChangePrimaryKey extends Action
 {
@@ -22,10 +22,10 @@ class ChangePrimaryKey extends Action
     /**
      * Constructor
      *
-     * @param \Migrations\Db\Table\Table $table The table to be changed
+     * @param \Migrations\Db\Table\TableMetadata $table The table to be changed
      * @param string|string[]|null $newColumns The new columns for the primary key
      */
-    public function __construct(Table $table, string|array|null $newColumns)
+    public function __construct(TableMetadata $table, string|array|null $newColumns)
     {
         parent::__construct($table);
         $this->newColumns = $newColumns;

--- a/src/Db/Action/DropForeignKey.php
+++ b/src/Db/Action/DropForeignKey.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Migrations\Db\Action;
 
 use Migrations\Db\Table\ForeignKey;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 class DropForeignKey extends Action
 {
@@ -23,10 +23,10 @@ class DropForeignKey extends Action
     /**
      * Constructor
      *
-     * @param \Migrations\Db\Table\Table $table The table to remove the constraint from
+     * @param \Migrations\Db\Table\TableMetadata $table The table to remove the constraint from
      * @param \Migrations\Db\Table\ForeignKey $foreignKey The foreign key to remove
      */
-    public function __construct(Table $table, ForeignKey $foreignKey)
+    public function __construct(TableMetadata $table, ForeignKey $foreignKey)
     {
         parent::__construct($table);
         $this->foreignKey = $foreignKey;
@@ -36,12 +36,12 @@ class DropForeignKey extends Action
      * Creates a new DropForeignKey object after building the ForeignKey
      * definition out of the passed arguments.
      *
-     * @param \Migrations\Db\Table\Table $table The table to delete the foreign key from
+     * @param \Migrations\Db\Table\TableMetadata $table The table to delete the foreign key from
      * @param string|string[] $columns The columns participating in the foreign key
      * @param string|null $constraint The constraint name
      * @return self
      */
-    public static function build(Table $table, string|array $columns, ?string $constraint = null): self
+    public static function build(TableMetadata $table, string|array $columns, ?string $constraint = null): self
     {
         if (is_string($columns)) {
             $columns = [$columns];

--- a/src/Db/Action/DropIndex.php
+++ b/src/Db/Action/DropIndex.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Migrations\Db\Action;
 
 use Migrations\Db\Table\Index;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 class DropIndex extends Action
 {
@@ -23,10 +23,10 @@ class DropIndex extends Action
     /**
      * Constructor
      *
-     * @param \Migrations\Db\Table\Table $table The table owning the index
+     * @param \Migrations\Db\Table\TableMetadata $table The table owning the index
      * @param \Migrations\Db\Table\Index $index The index to be dropped
      */
-    public function __construct(Table $table, Index $index)
+    public function __construct(TableMetadata $table, Index $index)
     {
         parent::__construct($table);
         $this->index = $index;
@@ -36,11 +36,11 @@ class DropIndex extends Action
      * Creates a new DropIndex object after assembling the passed
      * arguments.
      *
-     * @param \Migrations\Db\Table\Table $table The table where the index is
+     * @param \Migrations\Db\Table\TableMetadata $table The table where the index is
      * @param string[] $columns the indexed columns
      * @return self
      */
-    public static function build(Table $table, array $columns = []): self
+    public static function build(TableMetadata $table, array $columns = []): self
     {
         $index = new Index();
         $index->setColumns($columns);
@@ -52,11 +52,11 @@ class DropIndex extends Action
      * Creates a new DropIndex when the name of the index to drop
      * is known.
      *
-     * @param \Migrations\Db\Table\Table $table The table where the index is
+     * @param \Migrations\Db\Table\TableMetadata $table The table where the index is
      * @param string $name The name of the index
      * @return self
      */
-    public static function buildFromName(Table $table, string $name): self
+    public static function buildFromName(TableMetadata $table, string $name): self
     {
         $index = new Index();
         $index->setName($name);

--- a/src/Db/Action/RemoveColumn.php
+++ b/src/Db/Action/RemoveColumn.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Migrations\Db\Action;
 
 use Migrations\Db\Table\Column;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 class RemoveColumn extends Action
 {
@@ -23,10 +23,10 @@ class RemoveColumn extends Action
     /**
      * Constructor
      *
-     * @param \Migrations\Db\Table\Table $table The table where the column is
+     * @param \Migrations\Db\Table\TableMetadata $table The table where the column is
      * @param \Migrations\Db\Table\Column $column The column to be removed
      */
-    public function __construct(Table $table, Column $column)
+    public function __construct(TableMetadata $table, Column $column)
     {
         parent::__construct($table);
         $this->column = $column;
@@ -36,11 +36,11 @@ class RemoveColumn extends Action
      * Creates a new RemoveColumn object after assembling the
      * passed arguments.
      *
-     * @param \Migrations\Db\Table\Table $table The table where the column is
+     * @param \Migrations\Db\Table\TableMetadata $table The table where the column is
      * @param string $columnName The name of the column to drop
      * @return self
      */
-    public static function build(Table $table, string $columnName): self
+    public static function build(TableMetadata $table, string $columnName): self
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Db/Action/RenameColumn.php
+++ b/src/Db/Action/RenameColumn.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Migrations\Db\Action;
 
 use Migrations\Db\Table\Column;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 class RenameColumn extends Action
 {
@@ -30,11 +30,11 @@ class RenameColumn extends Action
     /**
      * Constructor
      *
-     * @param \Migrations\Db\Table\Table $table The table where the column is
+     * @param \Migrations\Db\Table\TableMetadata $table The table where the column is
      * @param \Migrations\Db\Table\Column $column The column to be renamed
      * @param string $newName The new name for the column
      */
-    public function __construct(Table $table, Column $column, string $newName)
+    public function __construct(TableMetadata $table, Column $column, string $newName)
     {
         parent::__construct($table);
         $this->newName = $newName;
@@ -45,12 +45,12 @@ class RenameColumn extends Action
      * Creates a new RenameColumn object after building the passed
      * arguments
      *
-     * @param \Migrations\Db\Table\Table $table The table where the column is
+     * @param \Migrations\Db\Table\TableMetadata $table The table where the column is
      * @param string $columnName The name of the column to be changed
      * @param string $newName The new name for the column
      * @return self
      */
-    public static function build(Table $table, string $columnName, string $newName): self
+    public static function build(TableMetadata $table, string $columnName, string $newName): self
     {
         $column = new Column();
         $column->setName($columnName);

--- a/src/Db/Action/RenameTable.php
+++ b/src/Db/Action/RenameTable.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Migrations\Db\Action;
 
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 class RenameTable extends Action
 {
@@ -22,10 +22,10 @@ class RenameTable extends Action
     /**
      * Constructor
      *
-     * @param \Migrations\Db\Table\Table $table The table to be renamed
+     * @param \Migrations\Db\Table\TableMetadata $table The table to be renamed
      * @param string $newName The new name for the table
      */
-    public function __construct(Table $table, string $newName)
+    public function __construct(TableMetadata $table, string $newName)
     {
         parent::__construct($table);
         $this->newName = $newName;

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -40,7 +40,7 @@ use Migrations\Db\Table;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
-use Migrations\Db\Table\Table as TableMetadata;
+use Migrations\Db\Table\TableMetadata;
 use Migrations\MigrationInterface;
 use PDOException;
 use RuntimeException;
@@ -623,7 +623,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     /**
      * Generates the SQL for an insert.
      *
-     * @param \Migrations\Db\Table\Table $table The table to insert into
+     * @param \Migrations\Db\Table\TableMetadata $table The table to insert into
      * @param array $row The row to insert
      * @return string
      */
@@ -742,7 +742,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     /**
      * Generates the SQL for a bulk insert.
      *
-     * @param \Migrations\Db\Table\Table $table The table to insert into
+     * @param \Migrations\Db\Table\TableMetadata $table The table to insert into
      * @param array $rows The rows to insert
      * @return string
      */
@@ -1060,7 +1060,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     /**
      * Returns the instructions to add the specified column to a database table.
      *
-     * @param \Migrations\Db\Table\Table $table Table
+     * @param \Migrations\Db\Table\TableMetadata $table Table
      * @param \Migrations\Db\Table\Column $column Column
      * @return \Migrations\Db\AlterInstructions
      */
@@ -1134,7 +1134,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     /**
      * Returns the instructions to add the specified index to a database table.
      *
-     * @param \Migrations\Db\Table\Table $table Table
+     * @param \Migrations\Db\Table\TableMetadata $table Table
      * @param \Migrations\Db\Table\Index $index Index
      * @return \Migrations\Db\AlterInstructions
      */
@@ -1209,7 +1209,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     /**
      * Returns the instructions to adds the specified foreign key to a database table.
      *
-     * @param \Migrations\Db\Table\Table $table The table to add the constraint to
+     * @param \Migrations\Db\Table\TableMetadata $table The table to add the constraint to
      * @param \Migrations\Db\Table\ForeignKey $foreignKey The foreign key to add
      * @return \Migrations\Db\AlterInstructions
      */
@@ -1305,7 +1305,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     /**
      * Returns the instructions to change the primary key for the specified database table.
      *
-     * @param \Migrations\Db\Table\Table $table Table
+     * @param \Migrations\Db\Table\TableMetadata $table Table
      * @param string|string[]|null $newColumns Column name(s) to belong to the primary key, or null to drop the key
      * @return \Migrations\Db\AlterInstructions
      */
@@ -1323,7 +1323,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     /**
      * Returns the instruction to change the comment for the specified database table.
      *
-     * @param \Migrations\Db\Table\Table $table Table
+     * @param \Migrations\Db\Table\TableMetadata $table Table
      * @param string|null $newComment New comment string, or null to drop the comment
      * @return \Migrations\Db\AlterInstructions
      */

--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -17,7 +17,7 @@ use Cake\Database\Query\SelectQuery;
 use Cake\Database\Query\UpdateQuery;
 use Cake\Database\Schema\TableSchemaInterface;
 use Migrations\Db\Table\Column;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 use Migrations\MigrationInterface;
 
 /**
@@ -238,11 +238,11 @@ interface AdapterInterface
     /**
      * Executes a list of migration actions for the given table
      *
-     * @param \Migrations\Db\Table\Table $table The table to execute the actions for
+     * @param \Migrations\Db\Table\TableMetadata $table The table to execute the actions for
      * @param \Migrations\Db\Action\Action[] $actions The table to execute the actions for
      * @return void
      */
-    public function executeActions(Table $table, array $actions): void;
+    public function executeActions(TableMetadata $table, array $actions): void;
 
     /**
      * Returns a new Query object
@@ -310,20 +310,20 @@ interface AdapterInterface
     /**
      * Inserts data into a table.
      *
-     * @param \Migrations\Db\Table\Table $table Table where to insert data
+     * @param \Migrations\Db\Table\TableMetadata $table Table where to insert data
      * @param array $row Row
      * @return void
      */
-    public function insert(Table $table, array $row): void;
+    public function insert(TableMetadata $table, array $row): void;
 
     /**
      * Inserts data into a table in a bulk.
      *
-     * @param \Migrations\Db\Table\Table $table Table where to insert data
+     * @param \Migrations\Db\Table\TableMetadata $table Table where to insert data
      * @param array $rows Rows
      * @return void
      */
-    public function bulkinsert(Table $table, array $rows): void;
+    public function bulkinsert(TableMetadata $table, array $rows): void;
 
     /**
      * Quotes a table name for use in a query.
@@ -352,12 +352,12 @@ interface AdapterInterface
     /**
      * Creates the specified database table.
      *
-     * @param \Migrations\Db\Table\Table $table Table
+     * @param \Migrations\Db\Table\TableMetadata $table Table
      * @param \Migrations\Db\Table\Column[] $columns List of columns in the table
      * @param \Migrations\Db\Table\Index[] $indexes List of indexes for the table
      * @return void
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = []): void;
+    public function createTable(TableMetadata $table, array $columns = [], array $indexes = []): void;
 
     /**
      * Truncates the specified table

--- a/src/Db/Adapter/AdapterWrapper.php
+++ b/src/Db/Adapter/AdapterWrapper.php
@@ -16,7 +16,7 @@ use Cake\Database\Query\InsertQuery;
 use Cake\Database\Query\SelectQuery;
 use Cake\Database\Query\UpdateQuery;
 use Migrations\Db\Table\Column;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 use Migrations\MigrationInterface;
 
 /**
@@ -135,7 +135,7 @@ abstract class AdapterWrapper implements WrapperInterface
     /**
      * @inheritDoc
      */
-    public function insert(Table $table, array $row): void
+    public function insert(TableMetadata $table, array $row): void
     {
         $this->getAdapter()->insert($table, $row);
     }
@@ -143,7 +143,7 @@ abstract class AdapterWrapper implements WrapperInterface
     /**
      * @inheritDoc
      */
-    public function bulkinsert(Table $table, array $rows): void
+    public function bulkinsert(TableMetadata $table, array $rows): void
     {
         $this->getAdapter()->bulkinsert($table, $rows);
     }
@@ -311,7 +311,7 @@ abstract class AdapterWrapper implements WrapperInterface
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = []): void
+    public function createTable(TableMetadata $table, array $columns = [], array $indexes = []): void
     {
         $this->getAdapter()->createTable($table, $columns, $indexes);
     }
@@ -431,7 +431,7 @@ abstract class AdapterWrapper implements WrapperInterface
     /**
      * @inheritDoc
      */
-    public function executeActions(Table $table, array $actions): void
+    public function executeActions(TableMetadata $table, array $actions): void
     {
         $this->getAdapter()->executeActions($table, $actions);
     }

--- a/src/Db/Adapter/DirectActionInterface.php
+++ b/src/Db/Adapter/DirectActionInterface.php
@@ -11,7 +11,7 @@ namespace Migrations\Db\Adapter;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 /**
  * Represents an adapter that is capable of directly executing alter
@@ -39,29 +39,29 @@ interface DirectActionInterface
     /**
      * Changes the primary key of the specified database table.
      *
-     * @param \Migrations\Db\Table\Table $table Table
+     * @param \Migrations\Db\Table\TableMetadata $table Table
      * @param string|string[]|null $newColumns Column name(s) to belong to the primary key, or null to drop the key
      * @return void
      */
-    public function changePrimaryKey(Table $table, string|array|null $newColumns): void;
+    public function changePrimaryKey(TableMetadata $table, string|array|null $newColumns): void;
 
     /**
      * Changes the comment of the specified database table.
      *
-     * @param \Migrations\Db\Table\Table $table Table
+     * @param \Migrations\Db\Table\TableMetadata $table Table
      * @param string|null $newComment New comment string, or null to drop the comment
      * @return void
      */
-    public function changeComment(Table $table, ?string $newComment): void;
+    public function changeComment(TableMetadata $table, ?string $newComment): void;
 
     /**
      * Adds the specified column to a database table.
      *
-     * @param \Migrations\Db\Table\Table $table Table
+     * @param \Migrations\Db\Table\TableMetadata $table Table
      * @param \Migrations\Db\Table\Column $column Column
      * @return void
      */
-    public function addColumn(Table $table, Column $column): void;
+    public function addColumn(TableMetadata $table, Column $column): void;
 
     /**
      * Renames the specified column.
@@ -95,11 +95,11 @@ interface DirectActionInterface
     /**
      * Adds the specified index to a database table.
      *
-     * @param \Migrations\Db\Table\Table $table Table
+     * @param \Migrations\Db\Table\TableMetadata $table Table
      * @param \Migrations\Db\Table\Index $index Index
      * @return void
      */
-    public function addIndex(Table $table, Index $index): void;
+    public function addIndex(TableMetadata $table, Index $index): void;
 
     /**
      * Drops the specified index from a database table.
@@ -122,11 +122,11 @@ interface DirectActionInterface
     /**
      * Adds the specified foreign key to a database table.
      *
-     * @param \Migrations\Db\Table\Table $table The table to add the foreign key to
+     * @param \Migrations\Db\Table\TableMetadata $table The table to add the foreign key to
      * @param \Migrations\Db\Table\ForeignKey $foreignKey The foreign key to add
      * @return void
      */
-    public function addForeignKey(Table $table, ForeignKey $foreignKey): void;
+    public function addForeignKey(TableMetadata $table, ForeignKey $foreignKey): void;
 
     /**
      * Drops the specified foreign key from a database table.

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -17,7 +17,7 @@ use Migrations\Db\AlterInstructions;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 /**
  * MySQL Adapter.
@@ -132,7 +132,7 @@ class MysqlAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = []): void
+    public function createTable(TableMetadata $table, array $columns = [], array $indexes = []): void
     {
         // This method is based on the MySQL docs here: https://dev.mysql.com/doc/refman/5.1/en/create-index.html
         $defaultOptions = [
@@ -286,7 +286,7 @@ class MysqlAdapter extends AbstractAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getChangePrimaryKeyInstructions(Table $table, $newColumns): AlterInstructions
+    protected function getChangePrimaryKeyInstructions(TableMetadata $table, $newColumns): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -319,7 +319,7 @@ class MysqlAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    protected function getChangeCommentInstructions(Table $table, ?string $newComment): AlterInstructions
+    protected function getChangeCommentInstructions(TableMetadata $table, ?string $newComment): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -444,7 +444,7 @@ class MysqlAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions
+    protected function getAddColumnInstructions(TableMetadata $table, Column $column): AlterInstructions
     {
         $dialect = $this->getSchemaDialect();
         $alter = sprintf(
@@ -566,7 +566,7 @@ class MysqlAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
+    protected function getAddIndexInstructions(TableMetadata $table, Index $index): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -705,7 +705,7 @@ class MysqlAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey): AlterInstructions
+    protected function getAddForeignKeyInstructions(TableMetadata $table, ForeignKey $foreignKey): AlterInstructions
     {
         $alter = sprintf(
             'ADD %s',

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -18,7 +18,7 @@ use Migrations\Db\Literal;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 class PostgresAdapter extends AbstractAdapter
 {
@@ -112,7 +112,7 @@ class PostgresAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = []): void
+    public function createTable(TableMetadata $table, array $columns = [], array $indexes = []): void
     {
         $queries = [];
 
@@ -228,7 +228,7 @@ class PostgresAdapter extends AbstractAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getChangePrimaryKeyInstructions(Table $table, array|string|null $newColumns): AlterInstructions
+    protected function getChangePrimaryKeyInstructions(TableMetadata $table, array|string|null $newColumns): AlterInstructions
     {
         $parts = $this->getSchemaName($table->getName());
         $instructions = new AlterInstructions();
@@ -264,7 +264,7 @@ class PostgresAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    protected function getChangeCommentInstructions(Table $table, ?string $newComment): AlterInstructions
+    protected function getChangeCommentInstructions(TableMetadata $table, ?string $newComment): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -360,7 +360,7 @@ class PostgresAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions
+    protected function getAddColumnInstructions(TableMetadata $table, Column $column): AlterInstructions
     {
         $dialect = $this->getSchemaDialect();
 
@@ -581,7 +581,7 @@ class PostgresAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
+    protected function getAddIndexInstructions(TableMetadata $table, Index $index): AlterInstructions
     {
         $instructions = new AlterInstructions();
         $instructions->addPostStep($this->getIndexSqlDefinition($index, $table->getName()));
@@ -692,7 +692,7 @@ class PostgresAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey): AlterInstructions
+    protected function getAddForeignKeyInstructions(TableMetadata $table, ForeignKey $foreignKey): AlterInstructions
     {
         $alter = sprintf(
             'ADD %s',
@@ -1104,7 +1104,7 @@ class PostgresAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    public function insert(Table $table, array $row): void
+    public function insert(TableMetadata $table, array $row): void
     {
         $sql = sprintf(
             'INSERT INTO %s ',
@@ -1148,7 +1148,7 @@ class PostgresAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    public function bulkinsert(Table $table, array $rows): void
+    public function bulkinsert(TableMetadata $table, array $rows): void
     {
         $sql = sprintf(
             'INSERT INTO %s ',

--- a/src/Db/Adapter/RecordingAdapter.php
+++ b/src/Db/Adapter/RecordingAdapter.php
@@ -20,7 +20,7 @@ use Migrations\Db\Action\RenameColumn;
 use Migrations\Db\Action\RenameTable;
 use Migrations\Db\Plan\Intent;
 use Migrations\Db\Plan\Plan;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 use Migrations\Migration\IrreversibleMigrationException;
 
 /**
@@ -46,7 +46,7 @@ class RecordingAdapter extends AdapterWrapper
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = []): void
+    public function createTable(TableMetadata $table, array $columns = [], array $indexes = []): void
     {
         $this->commands[] = new CreateTable($table);
     }
@@ -54,7 +54,7 @@ class RecordingAdapter extends AdapterWrapper
     /**
      * @inheritDoc
      */
-    public function executeActions(Table $table, array $actions): void
+    public function executeActions(TableMetadata $table, array $actions): void
     {
         $this->commands = array_merge($this->commands, $actions);
     }
@@ -78,7 +78,7 @@ class RecordingAdapter extends AdapterWrapper
 
                 case $command instanceof RenameTable:
                     /** @var \Migrations\Db\Action\RenameTable $command */
-                    $inverted->addAction(new RenameTable(new Table($command->getNewName()), $command->getTable()->getName()));
+                    $inverted->addAction(new RenameTable(new TableMetadata($command->getNewName()), $command->getTable()->getName()));
                     break;
 
                 case $command instanceof AddColumn:

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -17,7 +17,7 @@ use Migrations\Db\Literal;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 use PDOException;
 use RuntimeException;
 use const FILTER_VALIDATE_BOOLEAN;
@@ -232,7 +232,7 @@ class SqliteAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = []): void
+    public function createTable(TableMetadata $table, array $columns = [], array $indexes = []): void
     {
         // Add the default primary key
         $options = $table->getOptions();
@@ -305,7 +305,7 @@ class SqliteAdapter extends AbstractAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getChangePrimaryKeyInstructions(Table $table, $newColumns): AlterInstructions
+    protected function getChangePrimaryKeyInstructions(TableMetadata $table, $newColumns): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -342,7 +342,7 @@ class SqliteAdapter extends AbstractAdapter
      *
      * @throws \BadMethodCallException
      */
-    protected function getChangeCommentInstructions(Table $table, $newComment): AlterInstructions
+    protected function getChangeCommentInstructions(TableMetadata $table, $newComment): AlterInstructions
     {
         throw new BadMethodCallException('SQLite does not have table comments');
     }
@@ -544,7 +544,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions
+    protected function getAddColumnInstructions(TableMetadata $table, Column $column): AlterInstructions
     {
         $tableName = $table->getName();
 
@@ -1197,7 +1197,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
+    protected function getAddIndexInstructions(TableMetadata $table, Index $index): AlterInstructions
     {
         $indexColumnArray = [];
         foreach ((array)$index->getColumns() as $column) {
@@ -1328,11 +1328,11 @@ PCRE_PATTERN;
     }
 
     /**
-     * @param \Migrations\Db\Table\Table $table The Table
+     * @param \Migrations\Db\Table\TableMetadata $table The Table
      * @param string $column Column Name
      * @return \Migrations\Db\AlterInstructions
      */
-    protected function getAddPrimaryKeyInstructions(Table $table, string $column): AlterInstructions
+    protected function getAddPrimaryKeyInstructions(TableMetadata $table, string $column): AlterInstructions
     {
         $instructions = $this->beginAlterByCopyTable($table->getName());
 
@@ -1373,11 +1373,11 @@ PCRE_PATTERN;
     }
 
     /**
-     * @param \Migrations\Db\Table\Table $table Table
+     * @param \Migrations\Db\Table\TableMetadata $table Table
      * @param string $column Column Name
      * @return \Migrations\Db\AlterInstructions
      */
-    protected function getDropPrimaryKeyInstructions(Table $table, string $column): AlterInstructions
+    protected function getDropPrimaryKeyInstructions(TableMetadata $table, string $column): AlterInstructions
     {
         $tableName = $table->getName();
         $instructions = $this->beginAlterByCopyTable($tableName);
@@ -1405,7 +1405,7 @@ PCRE_PATTERN;
     /**
      * @inheritDoc
      */
-    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey): AlterInstructions
+    protected function getAddForeignKeyInstructions(TableMetadata $table, ForeignKey $foreignKey): AlterInstructions
     {
         $instructions = $this->beginAlterByCopyTable($table->getName());
 
@@ -1541,11 +1541,11 @@ PCRE_PATTERN;
     /**
      * Gets the SQLite Index Definition for an Index object.
      *
-     * @param \Migrations\Db\Table\Table $table Table
+     * @param \Migrations\Db\Table\TableMetadata $table Table
      * @param \Migrations\Db\Table\Index $index Index
      * @return string
      */
-    protected function getIndexSqlDefinition(Table $table, Index $index): string
+    protected function getIndexSqlDefinition(TableMetadata $table, Index $index): string
     {
         if ($index->getType() === Index::UNIQUE) {
             $def = 'UNIQUE INDEX';

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -18,8 +18,7 @@ use Migrations\Db\Literal;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
-use Migrations\Db\Table\Table;
-use Migrations\Db\Table\Table as TableMetadata;
+use Migrations\Db\Table\TableMetadata;
 use Migrations\MigrationInterface;
 
 /**
@@ -78,7 +77,7 @@ class SqlserverAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = []): void
+    public function createTable(TableMetadata $table, array $columns = [], array $indexes = []): void
     {
         $options = $table->getOptions();
         $parts = $this->getSchemaName($table->getName());
@@ -155,7 +154,7 @@ class SqlserverAdapter extends AbstractAdapter
      *
      * @throws \InvalidArgumentException
      */
-    protected function getChangePrimaryKeyInstructions(Table $table, $newColumns): AlterInstructions
+    protected function getChangePrimaryKeyInstructions(TableMetadata $table, $newColumns): AlterInstructions
     {
         $instructions = new AlterInstructions();
 
@@ -194,7 +193,7 @@ class SqlserverAdapter extends AbstractAdapter
      * SqlServer does not implement this functionality, and so will always throw an exception if used.
      * @throws \BadMethodCallException
      */
-    protected function getChangeCommentInstructions(Table $table, ?string $newComment): AlterInstructions
+    protected function getChangeCommentInstructions(TableMetadata $table, ?string $newComment): AlterInstructions
     {
         throw new BadMethodCallException('SqlServer does not have table comments');
     }
@@ -345,7 +344,7 @@ class SqlserverAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions
+    protected function getAddColumnInstructions(TableMetadata $table, Column $column): AlterInstructions
     {
         $dialect = $this->getSchemaDialect();
         $alter = sprintf(
@@ -569,7 +568,7 @@ ORDER BY IC.[key_ordinal]';
     /**
      * @inheritDoc
      */
-    protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
+    protected function getAddIndexInstructions(TableMetadata $table, Index $index): AlterInstructions
     {
         $sql = $this->getIndexSqlDefinition($index, $table->getName());
 
@@ -692,7 +691,7 @@ ORDER BY IC.[key_ordinal]';
     /**
      * @inheritDoc
      */
-    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey): AlterInstructions
+    protected function getAddForeignKeyInstructions(TableMetadata $table, ForeignKey $foreignKey): AlterInstructions
     {
         $instructions = new AlterInstructions();
         $instructions->addPostStep(sprintf(

--- a/src/Db/Adapter/TimedOutputAdapter.php
+++ b/src/Db/Adapter/TimedOutputAdapter.php
@@ -13,7 +13,7 @@ use Cake\Console\ConsoleIo;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 /**
  * Wraps any adapter to record the time spend executing its commands
@@ -83,7 +83,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function insert(Table $table, array $row): void
+    public function insert(TableMetadata $table, array $row): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand('insert', [$table->getName()]);
@@ -94,7 +94,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function bulkinsert(Table $table, array $rows): void
+    public function bulkinsert(TableMetadata $table, array $rows): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand('bulkinsert', [$table->getName()]);
@@ -105,7 +105,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function createTable(Table $table, array $columns = [], array $indexes = []): void
+    public function createTable(TableMetadata $table, array $columns = [], array $indexes = []): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand('createTable', [$table->getName()]);
@@ -119,7 +119,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function changePrimaryKey(Table $table, $newColumns): void
+    public function changePrimaryKey(TableMetadata $table, $newColumns): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -137,7 +137,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function changeComment(Table $table, ?string $newComment): void
+    public function changeComment(TableMetadata $table, ?string $newComment): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -202,7 +202,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function addColumn(Table $table, Column $column): void
+    public function addColumn(TableMetadata $table, Column $column): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -281,7 +281,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function addIndex(Table $table, Index $index): void
+    public function addIndex(TableMetadata $table, Index $index): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -335,7 +335,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
      * @throws \BadMethodCallException
      * @return void
      */
-    public function addForeignKey(Table $table, ForeignKey $foreignKey): void
+    public function addForeignKey(TableMetadata $table, ForeignKey $foreignKey): void
     {
         $adapter = $this->getAdapter();
         if (!$adapter instanceof DirectActionInterface) {
@@ -412,7 +412,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function executeActions(Table $table, array $actions): void
+    public function executeActions(TableMetadata $table, array $actions): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand(sprintf('Altering table %s', $table->getName()));

--- a/src/Db/Plan/AlterTable.php
+++ b/src/Db/Plan/AlterTable.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Migrations\Db\Plan;
 
 use Migrations\Db\Action\Action;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 /**
  * A collection of ALTER actions for a single table
@@ -19,9 +19,9 @@ class AlterTable
     /**
      * The table
      *
-     * @var \Migrations\Db\Table\Table
+     * @var \Migrations\Db\Table\TableMetadata
      */
-    protected Table $table;
+    protected TableMetadata $table;
 
     /**
      * The list of actions to execute
@@ -33,9 +33,9 @@ class AlterTable
     /**
      * Constructor
      *
-     * @param \Migrations\Db\Table\Table $table The table to change
+     * @param \Migrations\Db\Table\TableMetadata $table The table to change
      */
-    public function __construct(Table $table)
+    public function __construct(TableMetadata $table)
     {
         $this->table = $table;
     }
@@ -54,9 +54,9 @@ class AlterTable
     /**
      * Returns the table associated to this collection
      *
-     * @return \Migrations\Db\Table\Table
+     * @return \Migrations\Db\Table\TableMetadata
      */
-    public function getTable(): Table
+    public function getTable(): TableMetadata
     {
         return $this->table;
     }

--- a/src/Db/Plan/NewTable.php
+++ b/src/Db/Plan/NewTable.php
@@ -10,7 +10,7 @@ namespace Migrations\Db\Plan;
 
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\Index;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 /**
  * Represents the collection of actions for creating a new table
@@ -20,9 +20,9 @@ class NewTable
     /**
      * The table to create
      *
-     * @var \Migrations\Db\Table\Table
+     * @var \Migrations\Db\Table\TableMetadata
      */
-    protected Table $table;
+    protected TableMetadata $table;
 
     /**
      * The list of columns to add
@@ -41,9 +41,9 @@ class NewTable
     /**
      * Constructor
      *
-     * @param \Migrations\Db\Table\Table $table The table to create
+     * @param \Migrations\Db\Table\TableMetadata $table The table to create
      */
-    public function __construct(Table $table)
+    public function __construct(TableMetadata $table)
     {
         $this->table = $table;
     }
@@ -73,9 +73,9 @@ class NewTable
     /**
      * Returns the table object associated to this collection
      *
-     * @return \Migrations\Db\Table\Table
+     * @return \Migrations\Db\Table\TableMetadata
      */
-    public function getTable(): Table
+    public function getTable(): TableMetadata
     {
         return $this->table;
     }

--- a/src/Db/Plan/Plan.php
+++ b/src/Db/Plan/Plan.php
@@ -24,7 +24,7 @@ use Migrations\Db\Action\RenameColumn;
 use Migrations\Db\Action\RenameTable;
 use Migrations\Db\Adapter\AdapterInterface;
 use Migrations\Db\Plan\Solver\ActionSplitter;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 /**
  * A Plan takes an Intent and transforms int into a sequence of
@@ -235,11 +235,11 @@ class Plan
      * Deletes all actions related to the given table and keeps the
      * rest
      *
-     * @param \Migrations\Db\Table\Table $table The table to find in the list of actions
+     * @param \Migrations\Db\Table\TableMetadata $table The table to find in the list of actions
      * @param \Migrations\Db\Plan\AlterTable[] $actions The actions to transform
      * @return \Migrations\Db\Plan\AlterTable[] The list of actions without actions for the given table
      */
-    protected function forgetTable(Table $table, array $actions): array
+    protected function forgetTable(TableMetadata $table, array $actions): array
     {
         $result = [];
         foreach ($actions as $action) {
@@ -285,13 +285,13 @@ class Plan
     /**
      * Deletes any DropIndex actions for the given table and exact columns
      *
-     * @param \Migrations\Db\Table\Table $table The table to find in the list of actions
+     * @param \Migrations\Db\Table\TableMetadata $table The table to find in the list of actions
      * @param string[] $columns The column names to match
      * @param \Migrations\Db\Plan\AlterTable[] $actions The actions to transform
      * @return array A tuple containing the list of actions without actions for dropping the index
      * and a list of drop index actions that were removed.
      */
-    protected function forgetDropIndex(Table $table, array $columns, array $actions): array
+    protected function forgetDropIndex(TableMetadata $table, array $columns, array $actions): array
     {
         $dropIndexActions = new ArrayObject();
         $indexes = array_map(function ($alter) use ($table, $columns, $dropIndexActions) {
@@ -317,13 +317,13 @@ class Plan
     /**
      * Deletes any RemoveColumn actions for the given table and exact columns
      *
-     * @param \Migrations\Db\Table\Table $table The table to find in the list of actions
+     * @param \Migrations\Db\Table\TableMetadata $table The table to find in the list of actions
      * @param string[] $columns The column names to match
      * @param \Migrations\Db\Plan\AlterTable[] $actions The actions to transform
      * @return array A tuple containing the list of actions without actions for removing the column
      * and a list of remove column actions that were removed.
      */
-    protected function forgetRemoveColumn(Table $table, array $columns, array $actions): array
+    protected function forgetRemoveColumn(TableMetadata $table, array $columns, array $actions): array
     {
         $removeColumnActions = new ArrayObject();
         $indexes = array_map(function ($alter) use ($table, $columns, $removeColumnActions) {

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -31,7 +31,7 @@ use Migrations\Db\Plan\Plan;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
-use Migrations\Db\Table\Table as TableValue;
+use Migrations\Db\Table\TableMetadata;
 use RuntimeException;
 
 /**
@@ -47,9 +47,9 @@ use RuntimeException;
 class Table
 {
     /**
-     * @var \Migrations\Db\Table\Table
+     * @var \Migrations\Db\Table\TableMetadata
      */
-    protected TableValue $table;
+    protected TableMetadata $table;
 
     /**
      * @var \Migrations\Db\Adapter\AdapterInterface|null
@@ -82,7 +82,7 @@ class Table
      */
     public function __construct(string $name, array $options = [], ?AdapterInterface $adapter = null)
     {
-        $this->table = new TableValue($name, $options);
+        $this->table = new TableMetadata($name, $options);
         $this->actions = new Intent();
 
         if ($adapter !== null) {
@@ -113,9 +113,9 @@ class Table
     /**
      * Gets the table name and options as an object
      *
-     * @return \Migrations\Db\Table\Table
+     * @return \Migrations\Db\Table\TableMetadata
      */
-    public function getTable(): TableValue
+    public function getTable(): TableMetadata
     {
         return $this->table;
     }
@@ -489,12 +489,12 @@ class Table
      * on_update, constraint = constraint name.
      *
      * @param string|string[]|\Migrations\Db\Table\ForeignKey $columns Columns
-     * @param string|\Migrations\Db\Table\Table $referencedTable Referenced Table
+     * @param string|\Migrations\Db\Table\TableMetadata $referencedTable Referenced Table
      * @param string|string[] $referencedColumns Referenced Columns
      * @param array<string, mixed> $options Options
      * @return $this
      */
-    public function addForeignKey(string|array|ForeignKey $columns, string|TableValue|null $referencedTable = null, string|array $referencedColumns = ['id'], array $options = [])
+    public function addForeignKey(string|array|ForeignKey $columns, string|TableMetadata|null $referencedTable = null, string|array $referencedColumns = ['id'], array $options = [])
     {
         if ($columns instanceof ForeignKey) {
             $action = new AddForeignKey($this->table, $columns);

--- a/src/Db/Table/ForeignKey.php
+++ b/src/Db/Table/ForeignKey.php
@@ -40,9 +40,9 @@ class ForeignKey
     protected array $columns = [];
 
     /**
-     * @var \Migrations\Db\Table\Table
+     * @var \Migrations\Db\Table\TableMetadata
      */
-    protected Table $referencedTable;
+    protected TableMetadata $referencedTable;
 
     /**
      * @var string[]
@@ -95,13 +95,13 @@ class ForeignKey
     /**
      * Sets the foreign key referenced table.
      *
-     * @param \Migrations\Db\Table\Table|string $table The table this KEY is pointing to
+     * @param \Migrations\Db\Table\TableMetadata|string $table The table this KEY is pointing to
      * @return $this
      */
-    public function setReferencedTable(Table|string $table)
+    public function setReferencedTable(TableMetadata|string $table)
     {
         if (is_string($table)) {
-            $table = new Table($table);
+            $table = new TableMetadata($table);
         }
         $this->referencedTable = $table;
 
@@ -111,9 +111,9 @@ class ForeignKey
     /**
      * Gets the foreign key referenced table.
      *
-     * @return \Migrations\Db\Table\Table
+     * @return \Migrations\Db\Table\TableMetadata
      */
-    public function getReferencedTable(): Table
+    public function getReferencedTable(): TableMetadata
     {
         return $this->referencedTable;
     }

--- a/src/Db/Table/TableMetadata.php
+++ b/src/Db/Table/TableMetadata.php
@@ -12,9 +12,8 @@ use InvalidArgumentException;
 
 /**
  * @internal
- * @TODO rename this to `TableMetadata` having two classes with very similar names is confusing.
  */
-class Table
+class TableMetadata
 {
     /**
      * @var string

--- a/tests/TestCase/Db/Adapter/DefaultAdapterTrait.php
+++ b/tests/TestCase/Db/Adapter/DefaultAdapterTrait.php
@@ -7,7 +7,7 @@ use Migrations\Db\AlterInstructions;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
-use Migrations\Db\Table\Table;
+use Migrations\Db\Table\TableMetadata;
 
 trait DefaultAdapterTrait
 {
@@ -43,7 +43,7 @@ trait DefaultAdapterTrait
         return false;
     }
 
-    public function createTable(Table $table, array $columns = [], array $indexes = []): void
+    public function createTable(TableMetadata $table, array $columns = [], array $indexes = []): void
     {
     }
 
@@ -102,7 +102,7 @@ trait DefaultAdapterTrait
     {
     }
 
-    protected function getAddColumnInstructions(Table $table, Column $column): AlterInstructions
+    protected function getAddColumnInstructions(TableMetadata $table, Column $column): AlterInstructions
     {
         return new AlterInstructions();
     }
@@ -122,7 +122,7 @@ trait DefaultAdapterTrait
         return new AlterInstructions();
     }
 
-    protected function getAddIndexInstructions(Table $table, Index $index): AlterInstructions
+    protected function getAddIndexInstructions(TableMetadata $table, Index $index): AlterInstructions
     {
         return new AlterInstructions();
     }
@@ -137,7 +137,7 @@ trait DefaultAdapterTrait
         return new AlterInstructions();
     }
 
-    protected function getAddForeignKeyInstructions(Table $table, ForeignKey $foreignKey): AlterInstructions
+    protected function getAddForeignKeyInstructions(TableMetadata $table, ForeignKey $foreignKey): AlterInstructions
     {
         return new AlterInstructions();
     }
@@ -162,12 +162,12 @@ trait DefaultAdapterTrait
         return new AlterInstructions();
     }
 
-    protected function getChangePrimaryKeyInstructions(Table $table, array|string|null $newColumns): AlterInstructions
+    protected function getChangePrimaryKeyInstructions(TableMetadata $table, array|string|null $newColumns): AlterInstructions
     {
         return new AlterInstructions();
     }
 
-    protected function getChangeCommentInstructions(Table $table, ?string $newComment): AlterInstructions
+    protected function getChangeCommentInstructions(TableMetadata $table, ?string $newComment): AlterInstructions
     {
         return new AlterInstructions();
     }


### PR DESCRIPTION
Having both `Migrations\Db\Table` and `Migrations\Db\Table\Table` can make reading migrations code confusing to read. Renaming one of the classes to TableMetadata avoids confusion.