### PR TITLE
Merge 4.next into 5.x

### DIFF
--- a/docs/en/contents.rst
+++ b/docs/en/contents.rst
@@ -4,5 +4,7 @@
 
     /index
     /writing-migrations
+    /using-the-query-builder
+    /executing-queries
     /seeding
     /upgrading-to-builtin-backend

--- a/docs/en/executing-queries.rst
+++ b/docs/en/executing-queries.rst
@@ -1,0 +1,134 @@
+Executing Queries
+#################
+
+Queries can be executed with the ``execute()`` and ``query()`` methods. The
+``execute()`` method returns the number of affected rows whereas the
+``query()`` method returns the result as a
+`CakePHP Statement <https://book.cakephp.org/5/en/orm/database-basics.html#interacting-with-statements>`_. Both methods
+accept an optional second parameter ``$params`` which is an array of elements,
+and if used will cause the underlying connection to use a prepared statement::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
+        {
+            // execute()
+            $count = $this->execute('DELETE FROM users'); // returns the number of affected rows
+
+            // query()
+            $stmt = $this->query('SELECT * FROM users'); // returns PDOStatement
+            $rows = $stmt->fetchAll(); // returns the result as an array
+
+            // using prepared queries
+            $count = $this->execute('DELETE FROM users WHERE id = ?', [5]);
+            $stmt = $this->query('SELECT * FROM users WHERE id > ?', [5]); // returns PDOStatement
+            $rows = $stmt->fetchAll();
+        }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+
+        }
+    }
+
+Fetching Rows
+=============
+
+There are two methods available to fetch rows. The ``fetchRow()`` method will
+fetch a single row, whilst the ``fetchAll()`` method will return multiple rows.
+Both methods accept raw SQL as their only parameter::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
+        {
+            // fetch a user
+            $row = $this->fetchRow('SELECT * FROM users');
+
+            // fetch an array of messages
+            $rows = $this->fetchAll('SELECT * FROM messages');
+        }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+
+        }
+    }
+
+Inserting Data
+==============
+
+Migrations makes it easy to insert data into your tables. Whilst this feature is
+intended for the :doc:`seed feature <seeding>`, you are also free to use the
+insert methods in your migrations::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class NewStatus extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
+        {
+            $table = $this->table('status');
+
+            // inserting only one row
+            $singleRow = [
+                'id'    => 1,
+                'name'  => 'In Progress'
+            ];
+
+            $table->insert($singleRow)->saveData();
+
+            // inserting multiple rows
+            $rows = [
+                [
+                  'id'    => 2,
+                  'name'  => 'Stopped'
+                ],
+                [
+                  'id'    => 3,
+                  'name'  => 'Queued'
+                ]
+            ];
+
+            $table->insert($rows)->saveData();
+        }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+            $this->execute('DELETE FROM status');
+        }
+    }
+
+.. note::
+
+    You cannot use the insert methods inside a `change()` method. Please use the
+    `up()` and `down()` methods.
+

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -1,20 +1,20 @@
 Migrations
 ##########
 
-Migrations is a plugin supported by the core team that helps you do schema
-changes in your database by writing PHP files that can be tracked using your
-version control system.
+Migrations is a plugin that lets you track changes to your database schema over
+time as PHP code that accompanies your application. This lets you ensure each
+environment your application runs in can has the appropriate schema by applying
+migrations.
 
-It allows you to evolve your database tables over time. Instead of writing
-schema modifications in SQL, this plugin allows you to use an intuitive set of
-methods to implement your database changes.
+Instead of writing schema modifications in SQL, this plugin allows you to
+define schema changes with a high-level database portable API.
 
 Installation
 ============
 
-By default Migrations is installed with the default application skeleton. If
+By default Migrations is installed with the application skeleton. If
 you've removed it and want to re-install it, you can do so by running the
-following from your application's ROOT directory (where composer.json file is
+following from your application's ROOT directory (where **composer.json** file is
 located):
 
 .. code-block:: bash
@@ -26,7 +26,7 @@ located):
 
 To use the plugin you'll need to load it in your application's
 **config/bootstrap.php** file. You can use `CakePHP's Plugin shell
-<https://book.cakephp.org/3.0/en/console-and-shells/plugin-shell.html>`__ to
+<https://book.cakephp.org/5/en/console-and-shells/plugin-shell.html>`__ to
 load and unload plugins from your **config/bootstrap.php**:
 
 .. code-block:: bash
@@ -38,34 +38,24 @@ adding the following statement::
 
     $this->addPlugin('Migrations');
 
-    // Prior to 3.6.0 you need to use Plugin::load()
-
 Additionally, you will need to configure the default database configuration for
 your application in your **config/app.php** file as explained in the `Database
 Configuration section
-<https://book.cakephp.org/3.0/en/orm/database-basics.html#database-configuration>`__.
+<https://book.cakephp.org/5/en/orm/database-basics.html#database-configuration>`__.
 
 Overview
 ========
 
-A migration is basically a single PHP file that describes the changes to operate
-to the database. A migration file can create or drop tables, add or remove
-columns, create indexes and even insert data into your database.
+A migration is a PHP file that describes the changes to apply to your database.
+A migration file can add, change or remove tables, columns, indexes and foreign keys.
 
-Here's an example of a migration::
+If we wanted to create a table, we could use a migration similar to this::
 
     <?php
     use Migrations\BaseMigration;
 
     class CreateProducts extends BaseMigration
     {
-        /**
-         * Change Method.
-         *
-         * More information on this method is available here:
-         * https://book.cakephp.org/migrations/3/en/writing-migrations.html#the-change-method
-         * @return void
-         */
         public function change(): void
         {
             $table = $this->table('products');
@@ -90,41 +80,27 @@ Here's an example of a migration::
         }
     }
 
-This migration will add a table to your database named ``products`` with the
-following column definitions:
+When applied, this migration will add a table to your database named
+``products`` with the following column definitions:
 
-- ``id`` column of type ``integer`` as primary key
+- ``id`` column of type ``integer`` as primary key. This column is added
+  implicitly, but you can customize the name and type if necessary.
 - ``name`` column of type ``string``
 - ``description`` column of type ``text``
 - ``created`` column of type ``datetime``
 - ``modified`` column of type ``datetime``
 
-.. tip::
-
-    The primary key column named ``id`` will be added **implicitly**.
-
 .. note::
 
-    Note that this file describes how the database will look **after**
-    applying the migration. At this point no ``products`` table exists in
-    your database, we have merely created a file that is able to both create
-    the ``products`` table with the specified columns as well as drop it
-    when a ``rollback`` operation of the migration is performed.
+    Migrations are not automatically applied, you can apply and rollback
+    migrations with CLI commands.
 
-Once the file has been created in the **config/Migrations** folder, you will be
-able to execute the following ``migrations`` command to create the table in
-your database:
+Once the file has been created in the **config/Migrations** folder, you can
+apply it:
 
 .. code-block:: bash
 
     bin/cake migrations migrate
-
-The following ``migrations`` command will perform a ``rollback`` and drop the
-table from your database:
-
-.. code-block:: bash
-
-    bin/cake migrations rollback
 
 Creating Migrations
 ===================
@@ -134,134 +110,56 @@ application. The name of the migration files are prefixed with the date in
 which they were created, in the format **YYYYMMDDHHMMSS_MigrationName.php**.
 Here are examples of migration filenames:
 
-* 20160121163850_CreateProducts.php
-* 20160210133047_AddRatingToProducts.php
+* **20160121163850_CreateProducts.php**
+* **20160210133047_AddRatingToProducts.php**
 
 The easiest way to create a migrations file is by using ``bin/cake bake
-migration`` CLI command.
+migration`` CLI command:
 
-See the :ref:`creating-a-table` section to learn more about using migrations to
-define tables.
+.. code-block:: bash
+
+   bin/cake bake migration CreateProducts
+
+This will create an empty migration that you can edit to add any columns,
+indexes and foreign keys you need. See the :ref:`creating-a-table` section to
+learn more about using migrations to define tables.
 
 .. note::
 
-    When using the ``bake`` option, you can still modify the migration before
-    running them if so desired.
+    Migrations need to be applied using ``bin/cake migrations migrate`` after
+    they have been created.
 
-Syntax
-------
+Migration file names
+--------------------
 
-The ``bake`` command syntax follows the form below:
+When generating a migration, you can follow one of the following patterns
+to have additional skeleton code generated:
 
-.. code-block:: bash
-
-    bin/cake bake migration CreateProducts name:string description:text created modified
-
-When using ``bake`` to create tables, add columns and so on, to your
-database, you will usually provide two things:
-
-* the name of the migration you will generate (``CreateProducts`` in our
-  example)
-* the columns of the table that will be added or removed in the migration
-  (``name:string description:text created modified`` in our example)
-
-Due to the conventions, not all schema changes can be performed via these shell
-commands.
-
-Additionally you can create an empty migrations file if you want full control
-over what needs to be executed, by omitting to specify a columns definition:
-
-.. code-block:: bash
-
-    bin/cake migrations create MyCustomMigration
-
-Migrations file name
-~~~~~~~~~~~~~~~~~~~~
-
-Migration names can follow any of the following patterns:
-
-* (``/^(Create)(.*)/``) Creates the specified table.
-* (``/^(Drop)(.*)/``) Drops the specified table.
+* ``/^(Create)(.*)/`` Creates the specified table.
+* ``/^(Drop)(.*)/`` Drops the specified table.
   Ignores specified field arguments
-* (``/^(Add).*(?:To)(.*)/``) Adds fields to the specified
+* ``/^(Add).*(?:To)(.*)/`` Adds fields to the specified
   table
-* (``/^(Remove).*(?:From)(.*)/``) Removes fields from the
+* ``/^(Remove).*(?:From)(.*)/`` Removes fields from the
   specified table
-* (``/^(Alter)(.*)/``) Alters the specified table. An alias
+* ``/^(Alter)(.*)/`` Alters the specified table. An alias
   for CreateTable and AddField.
-* (``/^(Alter).*(?:On)(.*)/``) Alters fields from the specified table.
+* ``/^(Alter).*(?:On)(.*)/`` Alters fields from the specified table.
 
 You can also use the ``underscore_form`` as the name for your migrations i.e.
 ``create_products``.
 
 .. warning::
 
-    Migration names are used as migration class names, and thus may collide with
+    Migration names are used as class names, and thus may collide with
     other migrations if the class names are not unique. In this case, it may be
     necessary to manually override the name at a later date, or simply change
     the name you are specifying.
 
-Columns definition
-~~~~~~~~~~~~~~~~~~
-
-When using columns in the command line, it may be handy to remember that they
-follow the following pattern::
-
-    fieldName:fieldType?[length]:indexType:indexName
-
-For instance, the following are all valid ways of specifying an email field:
-
-* ``email:string?``
-* ``email:string:unique``
-* ``email:string?[50]``
-* ``email:string:unique:EMAIL_INDEX``
-* ``email:string[120]:unique:EMAIL_INDEX``
-
-While defining decimal, the ``length`` can be defined to have precision and scale, separated by a comma.
-
-* ``amount:decimal[5,2]``
-* ``amount:decimal?[5,2]``
-
-The question mark following the fieldType will make the column nullable.
-
-The ``length`` parameter for the ``fieldType`` is optional and should always be
-written between bracket.
-
-Fields named ``created`` and ``modified``, as well as any field with a ``_at``
-suffix, will automatically be set to the type ``datetime``.
-
-Field types are those generically made available by CakePHP. Those
-can be:
-
-* string
-* text
-* integer
-* biginteger
-* float
-* decimal
-* datetime
-* timestamp
-* time
-* date
-* binary
-* boolean
-* uuid
-* geometry
-* point
-* linestring
-* polygon
-
-There are some heuristics to choosing fieldtypes when left unspecified or set to
-an invalid value. Default field type is ``string``:
-
-* id: integer
-* created, modified, updated: datetime
-* latitude, longitude (or short forms lat, lng): decimal
-
 Creating a table
 ----------------
 
-You can use ``bake`` to create a table:
+You can use ``bake migration`` to create a table:
 
 .. code-block:: bash
 
@@ -305,6 +203,62 @@ The command line above will generate a migration file that resembles::
         }
     }
 
+Column syntax
+-------------
+
+The ``bake migration`` command provides a compact syntax to define columns when
+generating a migration:
+
+.. code-block:: bash
+
+    bin/cake bake migration CreateProducts name:string description:text created modified
+
+You can use the column syntax when creating tables and adding columns. You can
+also edit the migration after generation to add or customize the columns
+
+Columns on the command line follow the following pattern::
+
+    fieldName:fieldType?[length]:indexType:indexName
+
+For instance, the following are all valid ways of specifying an email field:
+
+* ``email:string?``
+* ``email:string:unique``
+* ``email:string?[50]``
+* ``email:string:unique:EMAIL_INDEX``
+* ``email:string[120]:unique:EMAIL_INDEX``
+
+While defining decimal columns, the ``length`` can be defined to have precision
+and scale, separated by a comma.
+
+* ``amount:decimal[5,2]``
+* ``amount:decimal?[5,2]``
+
+Columns with a question mark after the fieldType will make the column nullable.
+
+The ``length`` part is optional and should always be written between bracket.
+
+Fields named ``created`` and ``modified``, as well as any field with a ``_at``
+suffix, will automatically be set to the type ``datetime``.
+
+There are some heuristics to choosing fieldtypes when left unspecified or set to
+an invalid value. Default field type is ``string``:
+
+* id: integer
+* created, modified, updated: datetime
+* latitude, longitude (or short forms lat, lng): decimal
+
+Additionally you can create an empty migrations file if you want full control
+over what needs to be executed, by omitting to specify a columns definition:
+
+.. code-block:: bash
+
+    bin/cake migrations create MyCustomMigration
+
+
+See :doc:`writing-migrations` for more information on how to use ``Table``
+objects to interact with tables and define schema changes.
+
 Adding columns to an existing table
 -----------------------------------
 
@@ -336,8 +290,8 @@ Executing the command line above will generate::
         }
     }
 
-Adding a column as index to a table
------------------------------------
+Adding a column with an index
+-----------------------------
 
 It is also possible to add indexes to columns:
 
@@ -364,45 +318,8 @@ will generate::
         }
     }
 
-Specifying field length
------------------------
-
-.. versionadded:: cakephp/migrations 1.4
-
-If you need to specify a field length, you can do it within brackets in the
-field type, ie:
-
-.. code-block:: bash
-
-    bin/cake bake migration AddFullDescriptionToProducts full_description:string[60]
-
-Executing the command line above will generate::
-
-    <?php
-    use Migrations\BaseMigration;
-
-    class AddFullDescriptionToProducts extends BaseMigration
-    {
-        public function change(): void
-        {
-            $table = $this->table('products');
-            $table->addColumn('full_description', 'string', [
-                'default' => null,
-                'limit' => 60,
-                'null' => false,
-            ])
-            ->update();
-        }
-    }
-
-If no length is specified, lengths for certain type of columns are defaulted:
-
-* string: 255
-* integer: 11
-* biginteger: 20
-
-Alter a column from a table
------------------------------------
+Altering a column
+-----------------
 
 In the same way, you can generate a migration to alter a column by using the
 command line, if the migration name is of the form "AlterXXXOnYYY":
@@ -426,8 +343,14 @@ will generate::
         }
     }
 
-Removing a column from a table
-------------------------------
+.. warning::
+
+    Changing the type of a column can result in data loss if the
+    current and target column type are not compatible. For example converting
+    a varchar to float.
+
+Removing a column
+-----------------
 
 In the same way, you can generate a migration to remove a column by using the
 command line, if the migration name is of the form "RemoveXXXFromYYY":
@@ -457,12 +380,12 @@ creates the file::
     `up` method. A corresponding `addColumn` call should be added to the
     `down` method.
 
-Generating migrations from an existing database
-===============================================
+Generating migration snapshots from an existing database
+========================================================
 
-If you are dealing with a pre-existing database and want to start using
+If you have a pre-existing database and want to start using
 migrations, or to version control the initial schema of your application's
-database, you can run the ``migration_snapshot`` command:
+database, you can run the ``bake migration_snapshot`` command:
 
 .. code-block:: bash
 
@@ -472,9 +395,8 @@ It will generate a migration file called **YYYYMMDDHHMMSS_Initial.php**
 containing all the create statements for all tables in your database.
 
 By default, the snapshot will be created by connecting to the database defined
-in the ``default`` connection configuration.
-If you need to bake a snapshot from a different datasource, you can use the
-``--connection`` option:
+in the ``default`` connection configuration. If you need to bake a snapshot from
+a different datasource, you can use the ``--connection`` option:
 
 .. code-block:: bash
 
@@ -488,8 +410,7 @@ defined the corresponding model classes by using the ``--require-table`` flag:
     bin/cake bake migration_snapshot Initial --require-table
 
 When using the ``--require-table`` flag, the shell will look through your
-application ``Table`` classes and will only add the model tables in the snapshot
-.
+application ``Table`` classes and will only add the model tables in the snapshot.
 
 If you want to generate a snapshot without marking it as migrated (for example,
 for use in unit tests), you can use the ``--generate-only`` flag:
@@ -520,27 +441,18 @@ to the snapshot of your plugin.
 Be aware that when you bake a snapshot, it is automatically added to the
 migrations log table as migrated.
 
-Generating a diff between two database states
-=============================================
+Generating a diff
+=================
 
-.. versionadded:: cakephp/migrations 1.6.0
-
-You can generate a migrations file that will group all the differences between
-two database states using the ``migration_diff`` bake template. To do so, you
-can use the following command:
+As migrations are applied and rolled back, the migrations plugin will generate
+a 'dump' file of your schema. If you make manual changes to your database schema
+outside of migrations, you can use ``bake migration_diff`` to generate
+a migration file that captures the difference between the current schema dump
+file and database schema. To do so, you can use the following command:
 
 .. code-block:: bash
 
     bin/cake bake migration_diff NameOfTheMigrations
-
-In order to have a point of comparison from your current database state, the
-migrations shell will generate a "dump" file after each ``migrate`` or
-``rollback`` call. The dump file is a file containing the full schema state of
-your database at a given point in time.
-
-Once a dump file is generated, every modifications you do directly in your
-database management system will be added to the migration file generated when
-you call the ``bake migration_diff`` command.
 
 By default, the diff will be created by connecting to the database defined
 in the ``default`` connection configuration.
@@ -566,13 +478,10 @@ and use the ``bake migration_diff`` command whenever you see fit.
 
 .. note::
 
-    The migrations shell can not detect column renamings.
+    Migration diff generation can not detect column renamings.
 
-The commands
-============
-
-``migrate`` : Applying Migrations
----------------------------------
+Applying Migrations
+===================
 
 Once you have generated or written your migration file, you need to execute the
 following command to apply the changes to your database:
@@ -602,10 +511,10 @@ following command to apply the changes to your database:
     # or ``-p`` for short
     bin/cake migrations migrate -p MyAwesomePlugin
 
-``rollback`` : Reverting Migrations
------------------------------------
+Reverting Migrations
+====================
 
-The Rollback command is used to undo previous migrations executed by this
+The rollback command is used to undo previous migrations executed by this
 plugin. It is the reverse action of the ``migrate`` command:
 
 .. code-block:: bash
@@ -621,8 +530,8 @@ plugin. It is the reverse action of the ``migrate`` command:
 You can also use the ``--source``, ``--connection`` and ``--plugin`` options
 just like for the ``migrate`` command.
 
-``status`` : Migrations Status
-------------------------------
+View Migrations Status
+======================
 
 The Status command prints a list of all migrations, along with their current
 status. You can use this command to determine which migrations have been run:
@@ -641,15 +550,12 @@ You can also output the results as a JSON formatted string using the
 You can also use the ``--source``, ``--connection`` and ``--plugin`` options
 just like for the ``migrate`` command.
 
-``mark_migrated`` : Marking a migration as migrated
----------------------------------------------------
-
-.. versionadded:: 1.4.0
+Marking a migration as migrated
+===============================
 
 It can sometimes be useful to mark a set of migrations as migrated without
-actually running them.
-In order to do this, you can use the ``mark_migrated`` command.
-The command works seamlessly as the other commands.
+actually running them. In order to do this, you can use the ``mark_migrated``
+command. The command works seamlessly as the other commands.
 
 You can mark all migrations as migrated using this command:
 
@@ -701,8 +607,8 @@ value. If you use it, it will mark all found migrations as migrated:
 
     bin/cake migrations mark_migrated all
 
-``seed`` : Seeding your database
---------------------------------
+Seeding your database
+=====================
 
 Seed classes are a good way to populate your database with default or starter
 data. They are also a great way to generate data for development environments.
@@ -710,11 +616,11 @@ data. They are also a great way to generate data for development environments.
 By default, seeds will be looked for in the ``config/Seeds/`` directory of
 your application. See the :doc:`seeding` for how to build and use seed classes.
 
-``dump`` : Generating a dump file for the diff baking feature
--------------------------------------------------------------
+Generating a dump file
+======================
 
-The Dump command creates a file to be used with the ``migration_diff`` bake
-template:
+The dump command creates a file to be used with the ``bake migration_diff``
+command:
 
 .. code-block:: bash
 
@@ -780,9 +686,6 @@ from drop & truncate operations.
 If you need to see additional debugging output from migrations are being run,
 you can enable a ``debug`` level logger.
 
-.. versionadded: 3.2.0
-    Migrator was added to complement the new fixtures in CakePHP 4.3.0.
-
 Using Migrations In Plugins
 ===========================
 
@@ -800,14 +703,11 @@ execution to the migrations relative to that plugin:
 Running Migrations in a non-shell environment
 =============================================
 
-.. versionadded:: cakephp/migrations 1.2.0
-
-Since the release of version 1.2 of the migrations plugin, you can run
-migrations from a non-shell environment, directly from an app, by using the new
-``Migrations`` class. This can be handy in case you are developing a plugin
-installer for a CMS for instance.
-The ``Migrations`` class allows you to run the following commands from the
-migrations shell:
+While typical usage of migrations is from the command line, you can also run
+migrations from a non-shell environment, by using
+``Migrations\Migrations`` class. This can be handy in case you are developing a plugin
+installer for a CMS for instance. The ``Migrations`` class allows you to run the
+following commands from the migrations shell:
 
 * migrate
 * rollback
@@ -894,167 +794,8 @@ Set them via Configure to enable (e.g. in ``config/app.php``)::
         'column_null_default' => true,
     ],
 
-Tips and tricks
-===============
-
-Creating Custom Primary Keys
-----------------------------
-
-If you need to avoid the automatic creation of the ``id`` primary key when
-adding new tables to the database, you can use the second argument of the
-``table()`` method::
-
-    <?php
-    use Migrations\BaseMigration;
-
-    class CreateProductsTable extends BaseMigration
-    {
-        public function change(): void
-        {
-            $table = $this->table('products', ['id' => false, 'primary_key' => ['id']]);
-            $table
-                  ->addColumn('id', 'uuid')
-                  ->addColumn('name', 'string')
-                  ->addColumn('description', 'text')
-                  ->create();
-        }
-    }
-
-The above will create a ``CHAR(36)`` ``id`` column that is also the primary key.
-
-.. note::
-
-    When specifying a custom primary key on the command line, you must note
-    it as the primary key in the id field, otherwise you may get an error
-    regarding duplicate id fields, i.e.:
-
-    .. code-block:: bash
-
-        bin/cake bake migration CreateProducts id:uuid:primary name:string description:text created modified
-
-Additionally, since Migrations 1.3, a new way to deal with primary key was
-introduced. To do so, your migration class should extend the new
-``Migrations\BaseMigration`` class.
-You can specify a ``autoId`` property in the Migration class and set it to
-``false``, which will turn off the automatic ``id`` column creation. You will
-need to manually create the column that will be used as a primary key and add
-it to the table declaration::
-
-    <?php
-    use Migrations\BaseMigration;
-
-    class CreateProductsTable extends BaseMigration
-    {
-
-        public bool $autoId = false;
-
-        public function up(): void
-        {
-            $table = $this->table('products');
-            $table
-                ->addColumn('id', 'integer', [
-                    'autoIncrement' => true,
-                    'limit' => 11
-                ])
-                ->addPrimaryKey('id')
-                ->addColumn('name', 'string')
-                ->addColumn('description', 'text')
-                ->create();
-        }
-    }
-
-Compared to the previous way of dealing with primary key, this method gives you
-the ability to have more control over the primary key column definition:
-unsigned or not, limit, comment, etc.
-
-All baked migrations and snapshot will use this new way when necessary.
-
-.. warning::
-
-    Dealing with primary key can only be done on table creation operations.
-    This is due to limitations for some database servers the plugin supports.
-
-Collations
-----------
-
-If you need to create a table with a different collation than the database
-default one, you can define it with the ``table()`` method, as an option::
-
-    <?php
-    use Migrations\BaseMigration;
-
-    class CreateCategoriesTable extends BaseMigration
-    {
-        public function change(): void
-        {
-            $table = $this
-                ->table('categories', [
-                    'collation' => 'latin1_german1_ci'
-                ])
-                ->addColumn('title', 'string', [
-                    'default' => null,
-                    'limit' => 255,
-                    'null' => false,
-                ])
-                ->create();
-        }
-    }
-
-Note however this can only be done on table creation : there is currently
-no way of adding a column to an existing table with a different collation than
-the table or the database.
-Only ``MySQL`` and ``SqlServer`` supports this configuration key for the time
-being.
-
-Updating columns name and using Table objects
----------------------------------------------
-
-If you use a CakePHP ORM Table object to manipulate values from your database
-along with renaming or removing a column, make sure you create a new instance of
-your Table object after the ``update()`` call. The Table object registry is
-cleared after an ``update()`` call in order to refresh the schema that is
-reflected and stored in the Table object upon instantiation.
-
-Migrations and Deployment
--------------------------
-
-If you use the plugin when deploying your application, be sure to clear the ORM
-cache so it renews the column metadata of your tables.  Otherwise, you might end
-up having errors about columns not existing when performing operations on those
-new columns.  The CakePHP Core includes a `Schema Cache Shell
-<https://book.cakephp.org/3.0/en/console-and-shells/schema-cache.html>`__ that
-you can use to perform this operation:
-
-.. code-block:: bash
-
-    // Prior to 3.6 use orm_cache
-    bin/cake schema_cache clear
-
-Renaming a table
-----------------
-
-The plugin gives you the ability to rename a table, using the ``rename()``
-method. In your migration file, you can do the following::
-
-    public function up(): void
-    {
-        $this->table('old_table_name')
-            ->rename('new_table_name')
-            ->update();
-    }
-
-    public function down(): void
-    {
-        $this->table('new_table_name')
-            ->rename('old_table_name')
-            ->update();
-    }
-
-
 Skipping the ``schema.lock`` file generation
---------------------------------------------
-
-.. versionadded:: cakephp/migrations 1.6.5
+============================================
 
 In order for the diff feature to work, a **.lock** file is generated everytime
 you migrate, rollback or bake a snapshot, to keep track of the state of your
@@ -1070,8 +811,27 @@ for instance when deploying on your production environment, by using the
 
     bin/cake bake migration_snapshot MyMigration --no-lock
 
+Deployment
+==========
+
+You should update your deployment scripts to run migrations when new code is
+deployed. Ideally you want to run migrations after the code is on your servers,
+but before the application code becomes active.
+
+After running migrations remember to clear the ORM cache so it renews the column
+metadata of your tables. Otherwise, you might end up having errors about
+columns not existing when performing operations on those new columns. The
+CakePHP Core includes a `Schema Cache Shell
+<https://book.cakephp.org/5/en/console-and-shells/schema-cache.html>`__ that you
+can use to perform this operation:
+
+.. code-block:: bash
+
+    bin/cake migration migrate
+    bin/cake schema_cache clear
+
 Alert of missing migrations
----------------------------
+===========================
 
 You can use the ``Migrations.PendingMigrations`` middleware in local development
 to alert developers about new migrations that have not been applied::
@@ -1096,7 +856,7 @@ You can temporarily disable the migration check by adding
 ``skip-migration-check=1`` to the URL query string
 
 IDE autocomplete support
-------------------------
+========================
 
 The `IdeHelper plugin
 <https://github.com/dereuromark/cakephp-ide-helper>`__ can help

--- a/docs/en/using-the-query-builder.rst
+++ b/docs/en/using-the-query-builder.rst
@@ -1,0 +1,272 @@
+Using the Query Builder
+#######################
+
+It is not uncommon to pair database structure changes with data changes. For example, you may want to
+migrate the data in a couple columns from the users to a newly created table. For this type of scenarios,
+Migrations provides access to a Query builder object, that you may use to execute complex ``SELECT``, ``UPDATE``,
+``INSERT`` or ``DELETE`` statements.
+
+The Query builder is provided by the `cakephp/database <https://github.com/cakephp/database>`_ project, and should
+be easy to work with as it resembles very closely plain SQL. Accesing the query builder is done by calling the
+``getQueryBuilder(string $type)`` function. The ``string $type`` options are `'select'`, `'insert'`, `'update'` and `'delete'`::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
+        {
+            $builder = $this->getQueryBuilder('select');
+            $statement = $builder->select('*')->from('users')->execute();
+            var_dump($statement->fetchAll());
+        }
+    }
+
+Selecting Fields
+----------------
+
+Adding fields to the SELECT clause::
+
+    <?php
+    $builder->select(['id', 'title', 'body']);
+
+    // Results in SELECT id AS pk, title AS aliased_title, body ...
+    $builder->select(['pk' => 'id', 'aliased_title' => 'title', 'body']);
+
+    // Use a closure
+    $builder->select(function ($builder) {
+        return ['id', 'title', 'body'];
+    });
+
+
+Where Conditions
+----------------
+
+Generating conditions::
+
+    // WHERE id = 1
+    $builder->where(['id' => 1]);
+
+    // WHERE id > 1
+    $builder->where(['id >' => 1]);
+
+
+As you can see you can use any operator by placing it with a space after the field name. Adding multiple conditions is easy as well::
+
+    <?php
+    $builder->where(['id >' => 1])->andWhere(['title' => 'My Title']);
+
+    // Equivalent to
+    $builder->where(['id >' => 1, 'title' => 'My title']);
+
+    // WHERE id > 1 OR title = 'My title'
+    $builder->where(['OR' => ['id >' => 1, 'title' => 'My title']]);
+
+
+For even more complex conditions you can use closures and expression objects::
+
+    <?php
+    // Coditions are tied together with AND by default
+    $builder
+        ->select('*')
+        ->from('articles')
+        ->where(function ($exp) {
+            return $exp
+                ->eq('author_id', 2)
+                ->eq('published', true)
+                ->notEq('spam', true)
+                ->gt('view_count', 10);
+        });
+
+
+Which results in:
+
+.. code-block:: sql
+
+    SELECT * FROM articles
+    WHERE
+        author_id = 2
+        AND published = 1
+        AND spam != 1
+        AND view_count > 10
+
+
+Combining expressions is also possible::
+
+    <?php
+    $builder
+        ->select('*')
+        ->from('articles')
+        ->where(function ($exp) {
+            $orConditions = $exp->or_(['author_id' => 2])
+                ->eq('author_id', 5);
+            return $exp
+                ->not($orConditions)
+                ->lte('view_count', 10);
+        });
+
+It generates:
+
+.. code-block:: sql
+
+    SELECT *
+    FROM articles
+    WHERE
+        NOT (author_id = 2 OR author_id = 5)
+        AND view_count <= 10
+
+
+When using the expression objects you can use the following methods to create conditions:
+
+* ``eq()`` Creates an equality condition.
+* ``notEq()`` Create an inequality condition
+* ``like()`` Create a condition using the ``LIKE`` operator.
+* ``notLike()`` Create a negated ``LIKE`` condition.
+* ``in()`` Create a condition using ``IN``.
+* ``notIn()`` Create a negated condition using ``IN``.
+* ``gt()`` Create a ``>`` condition.
+* ``gte()`` Create a ``>=`` condition.
+* ``lt()`` Create a ``<`` condition.
+* ``lte()`` Create a ``<=`` condition.
+* ``isNull()`` Create an ``IS NULL`` condition.
+* ``isNotNull()`` Create a negated ``IS NULL`` condition.
+
+
+Aggregates and SQL Functions
+----------------------------
+
+.. code-block:: php
+
+    <?php
+    // Results in SELECT COUNT(*) count FROM ...
+    $builder->select(['count' => $builder->func()->count('*')]);
+
+A number of commonly used functions can be created with the func() method:
+
+* ``sum()`` Calculate a sum. The arguments will be treated as literal values.
+* ``avg()`` Calculate an average. The arguments will be treated as literal values.
+* ``min()`` Calculate the min of a column. The arguments will be treated as literal values.
+* ``max()`` Calculate the max of a column. The arguments will be treated as literal values.
+* ``count()`` Calculate the count. The arguments will be treated as literal values.
+* ``concat()`` Concatenate two values together. The arguments are treated as bound parameters unless marked as literal.
+* ``coalesce()`` Coalesce values. The arguments are treated as bound parameters unless marked as literal.
+* ``dateDiff()`` Get the difference between two dates/times. The arguments are treated as bound parameters unless marked as literal.
+* ``now()`` Take either 'time' or 'date' as an argument allowing you to get either the current time, or current date.
+
+When providing arguments for SQL functions, there are two kinds of parameters you can use,
+literal arguments and bound parameters. Literal parameters allow you to reference columns or
+other SQL literals. Bound parameters can be used to safely add user data to SQL functions. For example:
+
+
+.. code-block:: php
+
+    <?php
+    // Generates:
+    // SELECT CONCAT(title, ' NEW') ...;
+    $concat = $builder->func()->concat([
+        'title' => 'literal',
+        ' NEW'
+    ]);
+    $query->select(['title' => $concat]);
+
+
+Getting Results out of a Query
+------------------------------
+
+Once you’ve made your query, you’ll want to retrieve rows from it. There are a few ways of doing this:
+
+
+.. code-block:: php
+
+    <?php
+    // Iterate the query
+    foreach ($builder as $row) {
+        echo $row['title'];
+    }
+
+    // Get the statement and fetch all results
+    $results = $builder->execute()->fetchAll('assoc');
+
+
+Creating an Insert Query
+------------------------
+
+Creating insert queries is also possible:
+
+
+.. code-block:: php
+
+    <?php
+    $builder = $this->getQueryBuilder('insert');
+    $builder
+        ->insert(['first_name', 'last_name'])
+        ->into('users')
+        ->values(['first_name' => 'Steve', 'last_name' => 'Jobs'])
+        ->values(['first_name' => 'Jon', 'last_name' => 'Snow'])
+        ->execute();
+
+
+For increased performance, you can use another builder object as the values for an insert query:
+
+.. code-block:: php
+
+    <?php
+
+    $namesQuery = $this->getQueryBuilder('select');
+    $namesQuery
+        ->select(['fname', 'lname'])
+        ->from('users')
+        ->where(['is_active' => true]);
+
+    $builder = $this->getQueryBuilder('insert');
+    $st = $builder
+        ->insert(['first_name', 'last_name'])
+        ->into('names')
+        ->values($namesQuery)
+        ->execute();
+
+    var_dump($st->lastInsertId('names', 'id'));
+
+
+The above code will generate:
+
+.. code-block:: sql
+
+    INSERT INTO names (first_name, last_name)
+        (SELECT fname, lname FROM USERS where is_active = 1)
+
+
+Creating an update Query
+------------------------
+
+Creating update queries is similar to both inserting and selecting:
+
+.. code-block:: php
+
+    <?php
+    $builder = $this->getQueryBuilder('update');
+    $builder
+        ->update('users')
+        ->set('fname', 'Snow')
+        ->where(['fname' => 'Jon'])
+        ->execute();
+
+
+Creating a Delete Query
+-----------------------
+
+Finally, delete queries:
+
+.. code-block:: php
+
+    <?php
+    $builder = $this->getQueryBuilder('delete');
+    $builder
+        ->delete('users')
+        ->where(['accepted_gdpr' => false])
+        ->execute();

--- a/docs/en/writing-migrations.rst
+++ b/docs/en/writing-migrations.rst
@@ -21,45 +21,32 @@ replaced with the current timestamp down to the second.
 If you have specified multiple migration paths, you will be asked to select
 which path to create the new migration in.
 
-Bake will automatically creates a skeleton migration file with a single method:
+Bake will automatically creates a skeleton migration file with a single method::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Change Method.
+         *
+         * Write your reversible migrations in this method.
+         */
+        public function change(): void
         {
-            /**
-             * Change Method.
-             *
-             * Write your reversible migrations using this method.
-             *
-             * More information on writing migrations is available here:
-             * https://book.cakephp.org/migrations/5/en/migrations.html#the-change-method
-             *
-             * Remember to call "create()" or "update()" and NOT "save()" when working
-             * with the Table class.
-             *
-             */
-            public function change(): void
-            {
-
-            }
         }
 
-All migrations extend from the ``BaseMigration`` or ``BaseMigration``. These
-classes provides the necessary support to create your database migrations.
-Database migrations can transform your database in many ways, such as creating
-new tables, inserting rows, adding indexes and modifying columns.
+    }
+
 
 The Change Method
 =================
 
 Migrations supports 'reversible migrations'. In many scenarios, you
-only need to define the ``up`` logic, and Migrations can figure out how to migrate
-down automatically for you. For example:
+only need to define the ``up`` logic, and Migrations can figure out how to
+generate the rollback operations for you. For example:
 
 .. code-block:: php
 
@@ -81,7 +68,7 @@ down automatically for you. For example:
 
 When executing this migration, Migrations will create the ``user_logins`` table on
 the way up and automatically figure out how to drop the table on the way down.
-Please be aware that when a ``change`` method exists, Migrations will automatically
+Please be aware that when a ``change`` method exists, Migrations will
 ignore the ``up`` and ``down`` methods. If you need to use these methods it is
 recommended to create a separate migration file.
 
@@ -106,29 +93,28 @@ If a command cannot be reversed then Migrations will throw an
 ``IrreversibleMigrationException`` when it's migrating down. If you wish to
 use a command that cannot be reversed in the change function, you can use an
 if statement with  ``$this->isMigratingUp()`` to only run things in the
-up or down direction. For example:
+up or down direction. For example::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class CreateUserLoginsTable extends BaseMigration
+    class CreateUserLoginsTable extends BaseMigration
+    {
+        public function change(): void
         {
-            public function change(): void
-            {
-                // create the table
-                $table = $this->table('user_logins');
-                $table->addColumn('user_id', 'integer')
-                      ->addColumn('created', 'datetime')
-                      ->create();
-                if ($this->isMigratingUp()) {
-                    $table->insert([['user_id' => 1, 'created' => '2020-01-19 03:14:07']])
-                          ->save();
-                }
+            // create the table
+            $table = $this->table('user_logins');
+            $table->addColumn('user_id', 'integer')
+                  ->addColumn('created', 'datetime')
+                  ->create();
+            if ($this->isMigratingUp()) {
+                $table->insert([['user_id' => 1, 'created' => '2020-01-19 03:14:07']])
+                      ->save();
             }
         }
+    }
+
 
 The Up Method
 =============
@@ -159,574 +145,43 @@ This can be used to prevent the migration from being executed at this time. It a
 returns true by default. You can override it in your custom ``BaseMigration``
 implementation.
 
-Executing Queries
-=================
-
-Queries can be executed with the ``execute()`` and ``query()`` methods. The
-``execute()`` method returns the number of affected rows whereas the
-``query()`` method returns the result as a
-`CakePHP Statement <https://book.cakephp.org/5/en/orm/database-basics.html#interacting-with-statements>`_. Both methods
-accept an optional second parameter ``$params`` which is an array of elements,
-and if used will cause the underlying connection to use a prepared statement.
-
-.. code-block:: php
-
-        <?php
-
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
-        {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                // execute()
-                $count = $this->execute('DELETE FROM users'); // returns the number of affected rows
-
-                // query()
-                $stmt = $this->query('SELECT * FROM users'); // returns PDOStatement
-                $rows = $stmt->fetchAll(); // returns the result as an array
-
-                // using prepared queries
-                $count = $this->execute('DELETE FROM users WHERE id = ?', [5]);
-                $stmt = $this->query('SELECT * FROM users WHERE id > ?', [5]); // returns PDOStatement
-                $rows = $stmt->fetchAll();
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-
-            }
-        }
-
-.. note::
-
-    These commands run using the PHP Data Objects (PDO) extension which
-    defines a lightweight, consistent interface for accessing databases
-    in PHP. Always make sure your queries abide with PDOs before using
-    the ``execute()`` command. This is especially important when using
-    DELIMITERs during insertion of stored procedures or triggers which
-    don't support DELIMITERs.
-
-.. note::
-
-    If you wish to execute multiple queries at once, you may not also use the prepared
-    variant of these functions. When using prepared queries, PDO can only execute
-    them one at a time.
-
-.. warning::
-
-    When using ``execute()`` or ``query()`` with a batch of queries, PDO doesn't
-    throw an exception if there is an issue with one or more of the queries
-    in the batch.
-
-    As such, the entire batch is assumed to have passed without issue.
-
-    If Migrations was to iterate any potential result sets, looking to see if one
-    had an error, then Migrations would be denying access to all the results as there
-    is no facility in PDO to get a previous result set
-    `nextRowset() <https://php.net/manual/en/pdostatement.nextrowset.php>`_ -
-    but no ``previousSet()``).
-
-    So, as a consequence, due to the design decision in PDO to not throw
-    an exception for batched queries, Migrations is unable to provide the fullest
-    support for error handling when batches of queries are supplied.
-
-    Fortunately though, all the features of PDO are available, so multiple batches
-    can be controlled within the migration by calling upon
-    `nextRowset() <https://php.net/manual/en/pdostatement.nextrowset.php>`_
-    and examining `errorInfo <https://php.net/manual/en/pdostatement.errorinfo.php>`_.
-
-Fetching Rows
-=============
-
-There are two methods available to fetch rows. The ``fetchRow()`` method will
-fetch a single row, whilst the ``fetchAll()`` method will return multiple rows.
-Both methods accept raw SQL as their only parameter.
-
-.. code-block:: php
-
-        <?php
-
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
-        {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                // fetch a user
-                $row = $this->fetchRow('SELECT * FROM users');
-
-                // fetch an array of messages
-                $rows = $this->fetchAll('SELECT * FROM messages');
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-
-            }
-        }
-
-Inserting Data
-==============
-
-Migrations makes it easy to insert data into your tables. Whilst this feature is
-intended for the :doc:`seed feature <seeding>`, you are also free to use the
-insert methods in your migrations.
-
-.. code-block:: php
-
-        <?php
-
-        use Migrations\BaseMigration;
-
-        class NewStatus extends BaseMigration
-        {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $table = $this->table('status');
-
-                // inserting only one row
-                $singleRow = [
-                    'id'    => 1,
-                    'name'  => 'In Progress'
-                ];
-
-                $table->insert($singleRow)->saveData();
-
-                // inserting multiple rows
-                $rows = [
-                    [
-                      'id'    => 2,
-                      'name'  => 'Stopped'
-                    ],
-                    [
-                      'id'    => 3,
-                      'name'  => 'Queued'
-                    ]
-                ];
-
-                $table->insert($rows)->saveData();
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-                $this->execute('DELETE FROM status');
-            }
-        }
-
-.. note::
-
-    You cannot use the insert methods inside a `change()` method. Please use the
-    `up()` and `down()` methods.
-
 Working With Tables
 ===================
 
-The Table object is one of the most useful APIs provided by Migrations. It allows
-you to easily manipulate database tables using PHP code. You can retrieve an
-instance of the Table object by calling the ``table()`` method from within
-your database migration.
+The Table object enables you to easily manipulate database tables using PHP
+code. You can retrieve an instance of the Table object by calling the
+``table()`` method from within your database migration::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
         {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $table = $this->table('tableName');
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-
-            }
+            $table = $this->table('tableName');
         }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+
+        }
+    }
 
 You can then manipulate this table using the methods provided by the Table
 object.
 
-Saving Changes
---------------
+.. _adding-columns:
 
-When working with the Table object, Migrations stores certain operations in a
-pending changes cache. Once you have made the changes you want to the table,
-you must save them. To perform this operation, Migrations provides three methods,
-``create()``, ``update()``, and ``save()``. ``create()`` will first create
-the table and then run the pending changes. ``update()`` will just run the
-pending changes, and should be used when the table already exists. ``save()``
-is a helper function that checks first if the table exists and if it does not
-will run ``create()``, else it will run ``update()``.
-
-As stated above, when using the ``change()`` migration method, you should always
-use ``create()`` or ``update()``, and never ``save()`` as otherwise migrating
-and rolling back may result in different states, due to ``save()`` calling
-``create()`` when running migrate and then ``update()`` on rollback. When
-using the ``up()``/``down()`` methods, it is safe to use either ``save()`` or
-the more explicit methods.
-
-When in doubt with working with tables, it is always recommended to call
-the appropriate function and commit any pending changes to the database.
-
-.. _creating-a-table::
-
-Creating a Table
-----------------
-
-Creating a table is really easy using the Table object. Let's create a table to
-store a collection of users.
-
-.. code-block:: php
-
-        <?php
-
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
-        {
-            public function change(): void
-            {
-                $users = $this->table('users');
-                $users->addColumn('username', 'string', ['limit' => 20])
-                      ->addColumn('password', 'string', ['limit' => 40])
-                      ->addColumn('password_salt', 'string', ['limit' => 40])
-                      ->addColumn('email', 'string', ['limit' => 100])
-                      ->addColumn('first_name', 'string', ['limit' => 30])
-                      ->addColumn('last_name', 'string', ['limit' => 30])
-                      ->addColumn('created', 'datetime')
-                      ->addColumn('updated', 'datetime', ['null' => true])
-                      ->addIndex(['username', 'email'], ['unique' => true])
-                      ->create();
-            }
-        }
-
-Columns are added using the ``addColumn()`` method. We create a unique index
-for both the username and email columns using the ``addIndex()`` method.
-Finally calling ``create()`` commits the changes to the database.
-
-.. note::
-
-    Migrations automatically creates an auto-incrementing primary key column called ``id`` for every
-    table.
-
-The ``id`` option sets the name of the automatically created identity field, while the ``primary_key``
-option selects the field or fields used for primary key. ``id`` will always override the ``primary_key``
-option unless it's set to false. If you don't need a primary key set ``id`` to false without
-specifying a ``primary_key``, and no primary key will be created.
-
-To specify an alternate primary key, you can specify the ``primary_key`` option
-when accessing the Table object. Let's disable the automatic ``id`` column and
-create a primary key using two columns instead:
-
-.. code-block:: php
-
-        <?php
-
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
-        {
-            public function change(): void
-            {
-                $table = $this->table('followers', ['id' => false, 'primary_key' => ['user_id', 'follower_id']]);
-                $table->addColumn('user_id', 'integer')
-                      ->addColumn('follower_id', 'integer')
-                      ->addColumn('created', 'datetime')
-                      ->create();
-            }
-        }
-
-Setting a single ``primary_key`` doesn't enable the ``AUTO_INCREMENT`` option.
-To simply change the name of the primary key, we need to override the default ``id`` field name:
-
-.. code-block:: php
-
-        <?php
-
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
-        {
-            public function up(): void
-            {
-                $table = $this->table('followers', ['id' => 'user_id']);
-                $table->addColumn('follower_id', 'integer')
-                      ->addColumn('created', 'timestamp', ['default' => 'CURRENT_TIMESTAMP'])
-                      ->create();
-            }
-        }
-
-In addition, the MySQL adapter supports following options:
-
-========== ===========
-Option     Description
-========== ===========
-comment    set a text comment on the table
-row_format set the table row format
-engine     define table engine *(defaults to ``InnoDB``)*
-collation  define table collation *(defaults to ``utf8mb4_unicode_ci``)*
-signed     whether the primary key is ``signed``  *(defaults to ``false``)*
-limit      set the maximum length for the primary key
-========== ===========
-
-By default, the primary key is ``unsigned``.
-To simply set it to be signed just pass ``signed`` option with a ``true`` value:
-
-.. code-block:: php
-
-        <?php
-
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
-        {
-            public function change(): void
-            {
-                $table = $this->table('followers', ['signed' => false]);
-                $table->addColumn('follower_id', 'integer')
-                      ->addColumn('created', 'timestamp', ['default' => 'CURRENT_TIMESTAMP'])
-                      ->create();
-            }
-        }
-
-
-The PostgreSQL adapter supports the following options:
-
-========= ===========
-Option    Description
-========= ===========
-comment   set a text comment on the table
-========= ===========
-
-To view available column types and options, see `Valid Column Types`_ for details.
-
-Determining Whether a Table Exists
-----------------------------------
-
-You can determine whether or not a table exists by using the ``hasTable()``
-method.
-
-.. code-block:: php
-
-        <?php
-
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
-        {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $exists = $this->hasTable('users');
-                if ($exists) {
-                    // do something
-                }
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-
-            }
-        }
-
-Dropping a Table
-----------------
-
-Tables can be dropped quite easily using the ``drop()`` method. It is a
-good idea to recreate the table again in the ``down()`` method.
-
-Note that like other methods in the ``Table`` class, ``drop`` also needs ``save()``
-to be called at the end in order to be executed. This allows Migrations to intelligently
-plan migrations when more than one table is involved.
-
-.. code-block:: php
-
-        <?php
-
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
-        {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $this->table('users')->drop()->save();
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-                $users = $this->table('users');
-                $users->addColumn('username', 'string', ['limit' => 20])
-                      ->addColumn('password', 'string', ['limit' => 40])
-                      ->addColumn('password_salt', 'string', ['limit' => 40])
-                      ->addColumn('email', 'string', ['limit' => 100])
-                      ->addColumn('first_name', 'string', ['limit' => 30])
-                      ->addColumn('last_name', 'string', ['limit' => 30])
-                      ->addColumn('created', 'datetime')
-                      ->addColumn('updated', 'datetime', ['null' => true])
-                      ->addIndex(['username', 'email'], ['unique' => true])
-                      ->save();
-            }
-        }
-
-Renaming a Table
-----------------
-
-To rename a table access an instance of the Table object then call the
-``rename()`` method.
-
-.. code-block:: php
-
-        <?php
-
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
-        {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $table = $this->table('users');
-                $table
-                    ->rename('legacy_users')
-                    ->update();
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-                $table = $this->table('legacy_users');
-                $table
-                    ->rename('users')
-                    ->update();
-            }
-        }
-
-Changing the Primary Key
-------------------------
-
-To change the primary key on an existing table, use the ``changePrimaryKey()`` method.
-Pass in a column name or array of columns names to include in the primary key, or ``null`` to drop the primary key.
-Note that the mentioned columns must be added to the table, they will not be added implicitly.
-
-.. code-block:: php
-
-        <?php
-
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
-        {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $users = $this->table('users');
-                $users
-                    ->addColumn('username', 'string', ['limit' => 20, 'null' => false])
-                    ->addColumn('password', 'string', ['limit' => 40])
-                    ->save();
-
-                $users
-                    ->addColumn('new_id', 'integer', ['null' => false])
-                    ->changePrimaryKey(['new_id', 'username'])
-                    ->save();
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-
-            }
-        }
-
-Changing the Table Comment
---------------------------
-
-To change the comment on an existing table, use the ``changeComment()`` method.
-Pass in a string to set as the new table comment, or ``null`` to drop the existing comment.
-
-.. code-block:: php
-
-        <?php
-
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
-        {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $users = $this->table('users');
-                $users
-                    ->addColumn('username', 'string', ['limit' => 20])
-                    ->addColumn('password', 'string', ['limit' => 40])
-                    ->save();
-
-                $users
-                    ->changeComment('This is the table with users auth information, password should be encrypted')
-                    ->save();
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-
-            }
-        }
-
-.. _valid-column-types:
-
-Working With Columns
-====================
+Adding Columns
+==============
 
 Column types are specified as strings and can be one of:
 
@@ -781,15 +236,33 @@ after   specify the column that a new column should be placed after, or use ``\M
 comment set a text comment on the column
 ======= ===========
 
-For ``decimal`` columns:
+For ``decimal`` and ``float`` columns:
 
 ========= ===========
 Option    Description
 ========= ===========
-precision combine with ``scale`` set to set decimal accuracy
-scale     combine with ``precision`` to set decimal accuracy
+precision total number of digits (e.g., 10 in ``DECIMAL(10,2)``)
+scale     number of digits after the decimal point (e.g., 2 in ``DECIMAL(10,2)``)
 signed    enable or disable the ``unsigned`` option *(only applies to MySQL)*
 ========= ===========
+
+.. note::
+
+    **Precision and Scale Terminology**
+
+    Migrations follows the SQL standard where ``precision`` represents the total number of digits,
+    and ``scale`` represents digits after the decimal point. For example, to create ``DECIMAL(10,2)``
+    (10 total digits with 2 decimal places):
+
+    .. code-block:: php
+
+        $table->addColumn('price', 'decimal', [
+            'precision' => 10,  // Total digits
+            'scale' => 2,       // Decimal places
+        ]);
+
+    This differs from CakePHP's TableSchema which uses ``length`` for total digits and
+    ``precision`` for decimal places. The migration adapter handles this conversion automatically.
 
 For ``enum`` and ``set`` columns:
 
@@ -806,10 +279,12 @@ Option   Description
 ======== ===========
 identity enable or disable automatic incrementing (if enabled, will set ``null: false`` if ``null`` option is not set)
 signed   enable or disable the ``unsigned`` option *(only applies to MySQL)*
-======== ===========
+========
 
-For Postgres, when using ``identity``, it will utilize the ``serial`` type appropriate for the integer size, so that
-``smallinteger`` will give you ``smallserial``, ``integer`` gives ``serial``, and ``biginteger`` gives ``bigserial``.
+For Postgres, when using ``identity``, it will utilize the ``serial`` type
+appropriate for the integer size, so that ``smallinteger`` will give you
+``smallserial``, ``integer`` gives ``serial``, and ``biginteger`` gives
+``bigserial``.
 
 For ``timestamp`` columns:
 
@@ -821,49 +296,52 @@ update   set an action to be triggered when the row is updated (use with ``CURRE
 timezone enable or disable the ``with time zone`` option for ``time`` and ``timestamp`` columns *(only applies to Postgres)*
 ======== ===========
 
-You can add ``created`` and ``updated`` timestamps to a table using the ``addTimestamps()`` method. This method accepts
-three arguments, where the first two allow setting alternative names for the columns while the third argument allows you to
-enable the ``timezone`` option for the columns. The defaults for these arguments are ``created``, ``updated``, and ``false``
-respectively. For the first and second argument, if you provide ``null``, then the default name will be used, and if you provide
-``false``, then that column will not be created. Please note that attempting to set both to ``false`` will throw a
-``\RuntimeException``. Additionally, you can use the ``addTimestampsWithTimezone()`` method, which is an alias to
-``addTimestamps()`` that will always set the third argument to ``true`` (see examples below). The ``created`` column will
-have a default set to ``CURRENT_TIMESTAMP``. For MySQL only, ``updated`` column will have update set to
-``CURRENT_TIMESTAMP``.
+You can add ``created`` and ``updated`` timestamps to a table using the
+``addTimestamps()`` method. This method accepts three arguments, where the first
+two allow setting alternative names for the columns while the third argument
+allows you to enable the ``timezone`` option for the columns. The defaults for
+these arguments are ``created``, ``updated``, and ``false`` respectively. For
+the first and second argument, if you provide ``null``, then the default name
+will be used, and if you provide ``false``, then that column will not be
+created. Please note that attempting to set both to ``false`` will throw
+a ``\RuntimeException``. Additionally, you can use the
+``addTimestampsWithTimezone()`` method, which is an alias to ``addTimestamps()``
+that will always set the third argument to ``true`` (see examples below). The
+``created`` column will have a default set to ``CURRENT_TIMESTAMP``. For MySQL
+only, ``updated`` column will have update set to
+``CURRENT_TIMESTAMP``::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Change.
+         */
+        public function change(): void
         {
-            /**
-             * Migrate Change.
-             */
-            public function change(): void
-            {
-                // Use defaults (without timezones)
-                $table = $this->table('users')->addTimestamps()->create();
-                // Use defaults (with timezones)
-                $table = $this->table('users')->addTimestampsWithTimezone()->create();
+            // Use defaults (without timezones)
+            $table = $this->table('users')->addTimestamps()->create();
+            // Use defaults (with timezones)
+            $table = $this->table('users')->addTimestampsWithTimezone()->create();
 
-                // Override the 'created' column name with 'recorded_at'.
-                $table = $this->table('books')->addTimestamps('recorded_at')->create();
+            // Override the 'created' column name with 'recorded_at'.
+            $table = $this->table('books')->addTimestamps('recorded_at')->create();
 
-                // Override the 'updated' column name with 'amended_at', preserving timezones.
-                // The two lines below do the same, the second one is simply cleaner.
-                $table = $this->table('books')->addTimestamps(null, 'amended_at', true)->create();
-                $table = $this->table('users')->addTimestampsWithTimezone(null, 'amended_at')->create();
+            // Override the 'updated' column name with 'amended_at', preserving timezones.
+            // The two lines below do the same, the second one is simply cleaner.
+            $table = $this->table('books')->addTimestamps(null, 'amended_at', true)->create();
+            $table = $this->table('users')->addTimestampsWithTimezone(null, 'amended_at')->create();
 
-                // Only add the created column to the table
-                $table = $this->table('books')->addTimestamps(null, false);
-                // Only add the updated column to the table
-                $table = $this->table('users')->addTimestamps(false);
-                // Note, setting both false will throw a \RuntimeError
-            }
+            // Only add the created column to the table
+            $table = $this->table('books')->addTimestamps(null, false);
+            // Only add the updated column to the table
+            $table = $this->table('users')->addTimestamps(false);
+            // Note, setting both false will throw a \RuntimeError
         }
+    }
 
 For ``boolean`` columns:
 
@@ -882,27 +360,18 @@ collation set collation that differs from table defaults *(only applies to MySQL
 encoding  set character set that differs from table defaults *(only applies to MySQL)*
 ========= ===========
 
-For foreign key definitions:
-
-========== ===========
-Option     Description
-========== ===========
-update     set an action to be triggered when the row is updated
-delete     set an action to be triggered when the row is deleted
-constraint set a name to be used by foreign key constraint
-deferrable define deferred constraint application (postgres only)
-========== ===========
-
-You can pass one or more of these options to any column with the optional
-third argument array.
-
 Limit Option and MySQL
 ----------------------
 
 When using the MySQL adapter, there are a couple things to consider when working with limits:
 
-- When using a ``string`` primary key or index on MySQL 5.7 or below, or the MyISAM storage engine, and the default charset of ``utf8mb4_unicode_ci``, you must specify a limit less than or equal to 191, or use a different charset.
-- Additional hinting of database column type can be made for ``integer``, ``text``, ``blob``, ``tinyblob``, ``mediumblob``, ``longblob`` columns. Using ``limit`` with one the following options will modify the column type accordingly:
+- When using a ``string`` primary key or index on MySQL 5.7 or below, or the
+  MyISAM storage engine, and the default charset of ``utf8mb4_unicode_ci``, you
+  must specify a limit less than or equal to 191, or use a different charset.
+- Additional hinting of database column type can be made for ``integer``,
+  ``text``, ``blob``, ``tinyblob``, ``mediumblob``, ``longblob`` columns. Using
+  ``limit`` with one the following options will modify the column type
+  accordingly:
 
 ============ ==============
 Limit        Column Type
@@ -922,332 +391,379 @@ INT_REGULAR  INT
 INT_BIG      BIGINT
 ============ ==============
 
-For ``binary`` or ``varbinary`` types, if limit is set greater than allowed 255 bytes, the type will be changed to the best matching blob type given the length.
+For ``binary`` or ``varbinary`` types, if limit is set greater than allowed 255
+bytes, the type will be changed to the best matching blob type given the
+length::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\Db\Adapter\MysqlAdapter;
 
-        use Migrations\Db\Adapter\MysqlAdapter;
+    //...
 
-        //...
+    $table = $this->table('cart_items');
+    $table->addColumn('user_id', 'integer')
+          ->addColumn('product_id', 'integer', ['limit' => MysqlAdapter::INT_BIG])
+          ->addColumn('subtype_id', 'integer', ['limit' => MysqlAdapter::INT_SMALL])
+          ->addColumn('quantity', 'integer', ['limit' => MysqlAdapter::INT_TINY])
+          ->create();
 
-        $table = $this->table('cart_items');
-        $table->addColumn('user_id', 'integer')
-              ->addColumn('product_id', 'integer', ['limit' => MysqlAdapter::INT_BIG])
-              ->addColumn('subtype_id', 'integer', ['limit' => MysqlAdapter::INT_SMALL])
-              ->addColumn('quantity', 'integer', ['limit' => MysqlAdapter::INT_TINY])
-              ->create();
+Default values with expressions
+-------------------------------
 
-Custom Column Types & Default Values
-------------------------------------
+If you need to set a default to an expression, you can use a ``Literal`` to have
+the column's default value used without any quoting or escaping. This is helpful
+when you want to use a function as a default value::
 
-Some DBMS systems provide additional column types and default values that are specific to them.
-If you don't want to keep your migrations DBMS-agnostic you can use those custom types in your migrations
-through the ``\Migrations\Db\Literal::from`` method, which takes a string as its only argument, and returns an
-instance of ``\Migrations\Db\Literal``. When Migrations encounters this value as a column's type it knows not to
-run any validation on it and to use it exactly as supplied without escaping. This also works for ``default``
-values.
+    use Migrations\BaseMigration;
+    use Migrations\Db\Literal;
 
-You can see an example below showing how to add a ``citext`` column as well as a column whose default value
-is a function, in PostgreSQL. This method of preventing the built-in escaping is supported in all adapters.
-
-.. code-block:: php
-
-        <?php
-
-        use Migrations\BaseMigration;
-        use Migrations\Db\Literal;
-
-        class AddSomeColumns extends BaseMigration
+    class AddSomeColumns extends BaseMigration
+    {
+        public function change(): void
         {
-            public function change(): void
-            {
-                $this->table('users')
-                      ->addColumn('username', Literal::from('citext'))
-                      ->addColumn('uniqid', 'uuid', [
-                          'default' => Literal::from('uuid_generate_v4()')
-                      ])
-                      ->addColumn('creation', 'timestamp', [
-                          'timezone' => true,
-                          'default' => Literal::from('now()')
-                      ])
-                      ->create();
-            }
+            $this->table('users')
+                  ->addColumn('uniqid', 'uuid', [
+                      'default' => Literal::from('uuid_generate_v4()')
+                  ])
+                  ->create();
         }
+    }
 
-Get a column list
------------------
+.. _creating-a-table::
 
-To retrieve all table columns, simply create a ``table`` object and call ``getColumns()``
-method. This method will return an array of Column classes with basic info. Example below:
+Creating a Table
+----------------
 
-.. code-block:: php
+Creating a table is really easy using the Table object. Let's create a table to
+store a collection of users::
 
-        <?php
+    <?php
 
-        use Migrations\BaseMigration;
+    use Migrations\BaseMigration;
 
-        class ColumnListMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        public function change(): void
         {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $columns = $this->table('users')->getColumns();
-                ...
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-                ...
-            }
+            $users = $this->table('users');
+            $users->addColumn('username', 'string', ['limit' => 20])
+                  ->addColumn('password', 'string', ['limit' => 40])
+                  ->addColumn('password_salt', 'string', ['limit' => 40])
+                  ->addColumn('email', 'string', ['limit' => 100])
+                  ->addColumn('first_name', 'string', ['limit' => 30])
+                  ->addColumn('last_name', 'string', ['limit' => 30])
+                  ->addColumn('created', 'datetime')
+                  ->addColumn('updated', 'datetime', ['null' => true])
+                  ->addIndex(['username', 'email'], ['unique' => true])
+                  ->create();
         }
+    }
 
-Get a column by name
---------------------
+Columns are added using the ``addColumn()`` method. We create a unique index
+for both the username and email columns using the ``addIndex()`` method.
+Finally calling ``create()`` commits the changes to the database.
 
-To retrieve one table column, simply create a ``table`` object and call the ``getColumn()``
-method. This method will return a Column class with basic info or NULL when the column doesn't exist. Example below:
+.. note::
 
-.. code-block:: php
+    Migrations automatically creates an auto-incrementing primary key column called ``id`` for every
+    table.
 
-        <?php
+The ``id`` option sets the name of the automatically created identity field,
+while the ``primary_key`` option selects the field or fields used for primary
+key. ``id`` will always override the ``primary_key`` option unless it's set to
+false. If you don't need a primary key set ``id`` to false without specifying
+a ``primary_key``, and no primary key will be created.
 
-        use Migrations\BaseMigration;
+To specify an alternate primary key, you can specify the ``primary_key`` option
+when accessing the Table object. Let's disable the automatic ``id`` column and
+create a primary key using two columns instead::
 
-        class ColumnListMigration extends BaseMigration
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class MyNewMigration extends BaseMigration
+    {
+        public function change(): void
         {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $column = $this->table('users')->getColumn('email');
-                ...
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-                ...
-            }
+            $table = $this->table('followers', ['id' => false, 'primary_key' => ['user_id', 'follower_id']]);
+            $table->addColumn('user_id', 'integer')
+                  ->addColumn('follower_id', 'integer')
+                  ->addColumn('created', 'datetime')
+                  ->create();
         }
+    }
 
-Checking whether a column exists
---------------------------------
+Setting a single ``primary_key`` doesn't enable the ``AUTO_INCREMENT`` option.
+To simply change the name of the primary key, we need to override the default ``id`` field name::
 
-You can check if a table already has a certain column by using the
-``hasColumn()`` method.
+    <?php
 
-.. code-block:: php
+    use Migrations\BaseMigration;
 
-        <?php
-
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        public function up(): void
         {
-            /**
-             * Change Method.
-             */
-            public function change(): void
-            {
-                $table = $this->table('user');
-                $column = $table->hasColumn('username');
-
-                if ($column) {
-                    // do something
-                }
-
-            }
+            $table = $this->table('followers', ['id' => 'user_id']);
+            $table->addColumn('follower_id', 'integer')
+                  ->addColumn('created', 'timestamp', ['default' => 'CURRENT_TIMESTAMP'])
+                  ->create();
         }
+    }
+
+In addition, the MySQL adapter supports following options:
+
+========== ================ ===========
+Option     Platform         Description
+========== ================ ===========
+comment    MySQL, Postgres  set a text comment on the table
+collation  MySQL, SqlServer the default collation for a table if different than the database.
+row_format MySQL            set the table row format
+engine     MySQL            define table engine *(defaults to ``InnoDB``)*
+collation  MySQL            define table collation *(defaults to ``utf8mb4_unicode_ci``)*
+signed     MySQL            whether the primary key is ``signed``  *(defaults to ``false``)*
+limit      MySQL            set the maximum length for the primary key
+========== ================ ===========
+
+By default, the primary key is ``unsigned``.
+To simply set it to be signed just pass ``signed`` option with a ``true``
+value::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class MyNewMigration extends BaseMigration
+    {
+        public function change(): void
+        {
+            $table = $this->table('followers', ['signed' => false]);
+            $table->addColumn('follower_id', 'integer')
+                  ->addColumn('created', 'timestamp', ['default' => 'CURRENT_TIMESTAMP'])
+                  ->create();
+        }
+    }
+
+If you need to create a table with a different collation than the database,
+use::
+
+    <?php
+    use Migrations\BaseMigration;
+
+    class CreateCategoriesTable extends BaseMigration
+    {
+        public function change(): void
+        {
+            $table = $this
+                ->table('categories', [
+                    'collation' => 'latin1_german1_ci'
+                ])
+                ->addColumn('title', 'string')
+                ->create();
+        }
+    }
+
+Note however this can only be done on table creation : there is currently no way
+of adding a column to an existing table with a different collation than the
+table or the database. Only ``MySQL`` and ``SqlServer`` supports this
+configuration key for the time being.
+
+To view available column types and options, see :ref:`adding-columns` for details.
+
+Saving Changes
+--------------
+
+When working with the Table object, Migrations stores certain operations in a
+pending changes cache. Once you have made the changes you want to the table,
+you must save them. To perform this operation, Migrations provides three methods,
+``create()``, ``update()``, and ``save()``. ``create()`` will first create
+the table and then run the pending changes. ``update()`` will just run the
+pending changes, and should be used when the table already exists. ``save()``
+is a helper function that checks first if the table exists and if it does not
+will run ``create()``, else it will run ``update()``.
+
+As stated above, when using the ``change()`` migration method, you should always
+use ``create()`` or ``update()``, and never ``save()`` as otherwise migrating
+and rolling back may result in different states, due to ``save()`` calling
+``create()`` when running migrate and then ``update()`` on rollback. When
+using the ``up()``/``down()`` methods, it is safe to use either ``save()`` or
+the more explicit methods.
+
+When in doubt with working with tables, it is always recommended to call
+the appropriate function and commit any pending changes to the database.
+
 
 Renaming a Column
 -----------------
 
 To rename a column, access an instance of the Table object then call the
-``renameColumn()`` method.
+``renameColumn()`` method::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
         {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $table = $this->table('users');
-                $table->renameColumn('bio', 'biography')
-                      ->save();
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-                $table = $this->table('users');
-                $table->renameColumn('biography', 'bio')
-                       ->save();
-            }
+            $table = $this->table('users');
+            $table->renameColumn('bio', 'biography')
+                  ->save();
         }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+            $table = $this->table('users');
+            $table->renameColumn('biography', 'bio')
+                   ->save();
+        }
+    }
 
 Adding a Column After Another Column
 ------------------------------------
 
-When adding a column with the MySQL adapter, you can dictate its position using the ``after`` option,
-where its value is the name of the column to position it after.
+When adding a column with the MySQL adapter, you can dictate its position using
+the ``after`` option, where its value is the name of the column to position it
+after::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Change Method.
+         */
+        public function change(): void
         {
-            /**
-             * Change Method.
-             */
-            public function change(): void
-            {
-                $table = $this->table('users');
-                $table->addColumn('city', 'string', ['after' => 'email'])
-                      ->update();
-            }
+            $table = $this->table('users');
+            $table->addColumn('city', 'string', ['after' => 'email'])
+                  ->update();
         }
+    }
 
-This would create the new column ``city`` and position it after the ``email`` column. The
-``\Migrations\Db\Adapter\MysqlAdapter::FIRST`` constant can be used to specify that the new column should be
-created as the first column in that table.
+This would create the new column ``city`` and position it after the ``email``
+column. The ``\Migrations\Db\Adapter\MysqlAdapter::FIRST`` constant can be used
+to specify that the new column should be created as the first column in that
+table.
 
 Dropping a Column
 -----------------
 
-To drop a column, use the ``removeColumn()`` method.
+To drop a column, use the ``removeColumn()`` method::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate up.
+         */
+        public function up(): void
         {
-            /**
-             * Migrate up.
-             */
-            public function up(): void
-            {
-                $table = $this->table('users');
-                $table->removeColumn('short_name')
-                      ->save();
-            }
+            $table = $this->table('users');
+            $table->removeColumn('short_name')
+                  ->save();
         }
+    }
 
 
 Specifying a Column Limit
 -------------------------
 
-You can limit the maximum length of a column by using the ``limit`` option.
+You can limit the maximum length of a column by using the ``limit`` option::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Change Method.
+         */
+        public function change(): void
         {
-            /**
-             * Change Method.
-             */
-            public function change(): void
-            {
-                $table = $this->table('tags');
-                $table->addColumn('short_name', 'string', ['limit' => 30])
-                      ->update();
-            }
+            $table = $this->table('tags');
+            $table->addColumn('short_name', 'string', ['limit' => 30])
+                  ->update();
         }
+    }
 
 Changing Column Attributes
 --------------------------
 
 To change column type or options on an existing column, use the ``changeColumn()`` method.
-See :ref:`valid-column-types` and `Valid Column Options`_ for allowed values.
+See :ref:`valid-column-types` and `Valid Column Options`_ for allowed values::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
         {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $users = $this->table('users');
-                $users->changeColumn('email', 'string', ['limit' => 255])
-                      ->save();
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-
-            }
+            $users = $this->table('users');
+            $users->changeColumn('email', 'string', ['limit' => 255])
+                  ->save();
         }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+
+        }
+    }
 
 Working With Indexes
 --------------------
 
 To add an index to a table you can simply call the ``addIndex()`` method on the
-table object.
+table object::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
         {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $table = $this->table('users');
-                $table->addColumn('city', 'string')
-                      ->addIndex(['city'])
-                      ->save();
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-
-            }
+            $table = $this->table('users');
+            $table->addColumn('city', 'string')
+                  ->addIndex(['city'])
+                  ->save();
         }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+
+        }
+    }
 
 By default Migrations instructs the database adapter to create a simple index. We
 can pass an additional parameter ``unique`` to the ``addIndex()`` method to
@@ -1307,24 +823,22 @@ define indexes::
 
 
 The MySQL adapter also supports ``fulltext`` indexes. If you are using a version before 5.6 you must
-ensure the table uses the ``MyISAM`` engine.
+ensure the table uses the ``MyISAM`` engine::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        public function change(): void
         {
-            public function change(): void
-            {
-                $table = $this->table('users', ['engine' => 'MyISAM']);
-                $table->addColumn('email', 'string')
-                      ->addIndex('email', ['type' => 'fulltext'])
-                      ->create();
-            }
+            $table = $this->table('users', ['engine' => 'MyISAM']);
+            $table->addColumn('email', 'string')
+                  ->addIndex('email', ['type' => 'fulltext'])
+                  ->create();
         }
+    }
 
 MySQL adapter supports setting the index length defined by limit option.
 When you are using a multi-column index, you are able to define each column index length.
@@ -1471,42 +985,48 @@ Working With Foreign Keys
 -------------------------
 
 Migrations has support for creating foreign key constraints on your database tables.
-Let's add a foreign key to an example table:
+Let's add a foreign key to an example table::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
         {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $table = $this->table('tags');
-                $table->addColumn('tag_name', 'string')
-                      ->save();
+            $table = $this->table('tags');
+            $table->addColumn('tag_name', 'string')
+                  ->save();
 
-                $refTable = $this->table('tag_relationships');
-                $refTable->addColumn('tag_id', 'integer', ['null' => true])
-                         ->addForeignKey('tag_id', 'tags', 'id', ['delete'=> 'SET_NULL', 'update'=> 'NO_ACTION'])
-                         ->save();
+            $refTable = $this->table('tag_relationships');
+            $refTable->addColumn('tag_id', 'integer', ['null' => true])
+                    ->addForeignKey(
+                        'tag_id',
+                        'tags',
+                        'id',
+                        ['delete'=> 'SET_NULL', 'update'=> 'NO_ACTION'],
+                    )
+                    ->save();
 
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-
-            }
         }
 
-"On delete" and "On update" actions are defined with a 'delete' and 'update' options array. Possibles values are 'SET_NULL', 'NO_ACTION', 'CASCADE' and 'RESTRICT'.  If 'SET_NULL' is used then the column must be created as nullable with the option ``['null' => true]``.
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+
+        }
+    }
+
+The 'delete' and 'update' options allow you to define the ``ON UPDATE`` and ``ON
+DELETE`` behavior. Possibles values are 'SET_NULL', 'NO_ACTION', 'CASCADE' and
+'RESTRICT'.  If 'SET_NULL' is used then the column must be created as nullable
+with the option ``['null' => true]``.
 
 Foreign keys can be defined with arrays of columns to build constraints between
 tables with composite keys::
@@ -1530,12 +1050,23 @@ tables with composite keys::
                     [
                         'delete'=> 'NO_ACTION',
                         'update'=> 'NO_ACTION',
-                        'constraint' => 'user_follower_id'
+                        'constraint' => 'user_follower_id',
                     ]
                 )
                 ->save();
         }
     }
+
+The options parameter of ``addForeignKey()`` supports the following options:
+
+========== ===========
+Option     Description
+========== ===========
+update     set an action to be triggered when the row is updated
+delete     set an action to be triggered when the row is deleted
+constraint set a name to be used by foreign key constraint
+deferrable define deferred constraint application (postgres only)
+========== ===========
 
 Using the ``foreignKey()`` method provides a fluent builder to define a foreign
 key::
@@ -1568,361 +1099,398 @@ key::
 .. versionadded:: 4.6.0
    The ``foreignKey`` method was added.
 
-We can also easily check if a foreign key exists:
+We can also easily check if a foreign key exists::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
         {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $table = $this->table('tag_relationships');
-                $exists = $table->hasForeignKey('tag_id');
-                if ($exists) {
-                    // do something
-                }
-            }
-
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
-
+            $table = $this->table('tag_relationships');
+            $exists = $table->hasForeignKey('tag_id');
+            if ($exists) {
+                // do something
             }
         }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+
+        }
+    }
 
 Finally, to delete a foreign key, use the ``dropForeignKey`` method.
 
-Note that like other methods in the ``Table`` class, ``dropForeignKey`` also needs ``save()``
-to be called at the end in order to be executed. This allows Migrations to intelligently
-plan migrations when more than one table is involved.
+Note that like other methods in the ``Table`` class, ``dropForeignKey`` also
+needs ``save()`` to be called at the end in order to be executed. This allows
+Migrations to intelligently plan migrations when more than one table is
+involved::
 
-.. code-block:: php
+    <?php
 
-        <?php
+    use Migrations\BaseMigration;
 
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
         {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $table = $this->table('tag_relationships');
-                $table->dropForeignKey('tag_id')->save();
-            }
+            $table = $this->table('tag_relationships');
+            $table->dropForeignKey('tag_id')->save();
+        }
 
-            /**
-             * Migrate Down.
-             */
-            public function down(): void
-            {
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
 
+        }
+    }
+
+Determining Whether a Table Exists
+----------------------------------
+
+You can determine whether or not a table exists by using the ``hasTable()``
+method::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
+        {
+            $exists = $this->hasTable('users');
+            if ($exists) {
+                // do something
             }
         }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+
+        }
+    }
+
+Dropping a Table
+----------------
+
+Tables can be dropped quite easily using the ``drop()`` method. It is a
+good idea to recreate the table again in the ``down()`` method.
+
+Note that like other methods in the ``Table`` class, ``drop`` also needs ``save()``
+to be called at the end in order to be executed. This allows Migrations to intelligently
+plan migrations when more than one table is involved::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
+        {
+            $this->table('users')->drop()->save();
+        }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+            $users = $this->table('users');
+            $users->addColumn('username', 'string', ['limit' => 20])
+                  ->addColumn('password', 'string', ['limit' => 40])
+                  ->addColumn('password_salt', 'string', ['limit' => 40])
+                  ->addColumn('email', 'string', ['limit' => 100])
+                  ->addColumn('first_name', 'string', ['limit' => 30])
+                  ->addColumn('last_name', 'string', ['limit' => 30])
+                  ->addColumn('created', 'datetime')
+                  ->addColumn('updated', 'datetime', ['null' => true])
+                  ->addIndex(['username', 'email'], ['unique' => true])
+                  ->save();
+        }
+    }
+
+Renaming a Table
+----------------
+
+To rename a table access an instance of the Table object then call the
+``rename()`` method::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
+        {
+            $table = $this->table('users');
+            $table
+                ->rename('legacy_users')
+                ->update();
+        }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+            $table = $this->table('legacy_users');
+            $table
+                ->rename('users')
+                ->update();
+        }
+    }
+
+Changing the Primary Key
+------------------------
+
+To change the primary key on an existing table, use the ``changePrimaryKey()``
+method. Pass in a column name or array of columns names to include in the
+primary key, or ``null`` to drop the primary key. Note that the mentioned
+columns must be added to the table, they will not be added implicitly::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
+        {
+            $users = $this->table('users');
+            $users
+                ->addColumn('username', 'string', ['limit' => 20, 'null' => false])
+                ->addColumn('password', 'string', ['limit' => 40])
+                ->save();
+
+            $users
+                ->addColumn('new_id', 'integer', ['null' => false])
+                ->changePrimaryKey(['new_id', 'username'])
+                ->save();
+        }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+
+        }
+    }
+
+Creating Custom Primary Keys
+----------------------------
+
+You can specify a ``autoId`` property in the Migration class and set it to
+``false``, which will turn off the automatic ``id`` column creation. You will
+need to manually create the column that will be used as a primary key and add
+it to the table declaration::
+
+    <?php
+    use Migrations\BaseMigration;
+
+    class CreateProductsTable extends BaseMigration
+    {
+
+        public bool $autoId = false;
+
+        public function up(): void
+        {
+            $table = $this->table('products');
+            $table
+                ->addColumn('id', 'uuid')
+                ->addPrimaryKey('id')
+                ->addColumn('name', 'string')
+                ->addColumn('description', 'text')
+                ->create();
+        }
+    }
+
+The above will create a ``CHAR(36)`` ``id`` column that is also the primary key.
+
+When specifying a custom primary key on the command line, you must note
+it as the primary key in the id field, otherwise you may get an error
+regarding duplicate id fields, i.e.:
+
+.. code-block:: bash
+
+    bin/cake bake migration CreateProducts id:uuid:primary name:string description:text created modified
+
+
+All baked migrations and snapshot will use this new way when necessary.
+
+.. warning::
+
+    Dealing with primary key can only be done on table creation operations.
+    This is due to limitations for some database servers the plugin supports.
+
+Changing the Table Comment
+--------------------------
+
+To change the comment on an existing table, use the ``changeComment()`` method.
+Pass in a string to set as the new table comment, or ``null`` to drop the existing comment::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
+        {
+            $users = $this->table('users');
+            $users
+                ->addColumn('username', 'string', ['limit' => 20])
+                ->addColumn('password', 'string', ['limit' => 40])
+                ->save();
+
+            $users
+                ->changeComment('This is the table with users auth information, password should be encrypted')
+                ->save();
+        }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+
+        }
+    }
+
+Checking Columns
+================
+
+``BaseMigration`` also provides methods for introspecting the current schema,
+allowing you to conditionally make changes to schema, or read data.
+Schema is inspected **when the migration is run**.
+
+Get a column list
+-----------------
+
+To retrieve all table columns, simply create a ``table`` object and call
+``getColumns()`` method. This method will return an array of Column classes with
+basic info. Example below::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class ColumnListMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
+        {
+            $columns = $this->table('users')->getColumns();
+            ...
+        }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+            ...
+        }
+    }
+
+Get a column by name
+--------------------
+
+To retrieve one table column, simply create a ``table`` object and call the
+``getColumn()`` method. This method will return a Column class with basic info
+or NULL when the column doesn't exist. Example below::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class ColumnListMigration extends BaseMigration
+    {
+        /**
+         * Migrate Up.
+         */
+        public function up(): void
+        {
+            $column = $this->table('users')->getColumn('email');
+            ...
+        }
+
+        /**
+         * Migrate Down.
+         */
+        public function down(): void
+        {
+            ...
+        }
+    }
+
+Checking whether a column exists
+--------------------------------
+
+You can check if a table already has a certain column by using the
+``hasColumn()`` method::
+
+    <?php
+
+    use Migrations\BaseMigration;
+
+    class MyNewMigration extends BaseMigration
+    {
+        /**
+         * Change Method.
+         */
+        public function change(): void
+        {
+            $table = $this->table('user');
+            $column = $table->hasColumn('username');
+
+            if ($column) {
+                // do something
+            }
+
+        }
+    }
+
 
 Changing templates
 ------------------
 
 See :ref:`custom-seed-migration-templates` for how to customize the templates
 used to generate migrations.
-
-
-Using the Query Builder
-=======================
-
-It is not uncommon to pair database structure changes with data changes. For example, you may want to
-migrate the data in a couple columns from the users to a newly created table. For this type of scenarios,
-Migrations provides access to a Query builder object, that you may use to execute complex ``SELECT``, ``UPDATE``,
-``INSERT`` or ``DELETE`` statements.
-
-The Query builder is provided by the `cakephp/database <https://github.com/cakephp/database>`_ project, and should
-be easy to work with as it resembles very closely plain SQL. Accesing the query builder is done by calling the
-``getQueryBuilder(string $type)`` function. The ``string $type`` options are `'select'`, `'insert'`, `'update'` and `'delete'`:
-
-
-.. code-block:: php
-
-        <?php
-
-        use Migrations\BaseMigration;
-
-        class MyNewMigration extends BaseMigration
-        {
-            /**
-             * Migrate Up.
-             */
-            public function up(): void
-            {
-                $builder = $this->getQueryBuilder('select');
-                $statement = $builder->select('*')->from('users')->execute();
-                var_dump($statement->fetchAll());
-            }
-        }
-
-Selecting Fields
-----------------
-
-Adding fields to the SELECT clause:
-
-
-.. code-block:: php
-
-        <?php
-        $builder->select(['id', 'title', 'body']);
-
-        // Results in SELECT id AS pk, title AS aliased_title, body ...
-        $builder->select(['pk' => 'id', 'aliased_title' => 'title', 'body']);
-
-        // Use a closure
-        $builder->select(function ($builder) {
-            return ['id', 'title', 'body'];
-        });
-
-
-Where Conditions
-----------------
-
-Generating conditions:
-
-.. code-block:: php
-
-        // WHERE id = 1
-        $builder->where(['id' => 1]);
-
-        // WHERE id > 1
-        $builder->where(['id >' => 1]);
-
-
-As you can see you can use any operator by placing it with a space after the field name. Adding multiple conditions is easy as well:
-
-
-.. code-block:: php
-
-        <?php
-        $builder->where(['id >' => 1])->andWhere(['title' => 'My Title']);
-
-        // Equivalent to
-        $builder->where(['id >' => 1, 'title' => 'My title']);
-
-        // WHERE id > 1 OR title = 'My title'
-        $builder->where(['OR' => ['id >' => 1, 'title' => 'My title']]);
-
-
-For even more complex conditions you can use closures and expression objects:
-
-.. code-block:: php
-
-        <?php
-        // Coditions are tied together with AND by default
-        $builder
-            ->select('*')
-            ->from('articles')
-            ->where(function ($exp) {
-                return $exp
-                    ->eq('author_id', 2)
-                    ->eq('published', true)
-                    ->notEq('spam', true)
-                    ->gt('view_count', 10);
-            });
-
-
-Which results in:
-
-.. code-block:: sql
-
-    SELECT * FROM articles
-    WHERE
-        author_id = 2
-        AND published = 1
-        AND spam != 1
-        AND view_count > 10
-
-
-Combining expressions is also possible:
-
-
-.. code-block:: php
-
-        <?php
-        $builder
-            ->select('*')
-            ->from('articles')
-            ->where(function ($exp) {
-                $orConditions = $exp->or_(['author_id' => 2])
-                    ->eq('author_id', 5);
-                return $exp
-                    ->not($orConditions)
-                    ->lte('view_count', 10);
-            });
-
-It generates:
-
-.. code-block:: sql
-
-    SELECT *
-    FROM articles
-    WHERE
-        NOT (author_id = 2 OR author_id = 5)
-        AND view_count <= 10
-
-
-When using the expression objects you can use the following methods to create conditions:
-
-* ``eq()`` Creates an equality condition.
-* ``notEq()`` Create an inequality condition
-* ``like()`` Create a condition using the ``LIKE`` operator.
-* ``notLike()`` Create a negated ``LIKE`` condition.
-* ``in()`` Create a condition using ``IN``.
-* ``notIn()`` Create a negated condition using ``IN``.
-* ``gt()`` Create a ``>`` condition.
-* ``gte()`` Create a ``>=`` condition.
-* ``lt()`` Create a ``<`` condition.
-* ``lte()`` Create a ``<=`` condition.
-* ``isNull()`` Create an ``IS NULL`` condition.
-* ``isNotNull()`` Create a negated ``IS NULL`` condition.
-
-
-Aggregates and SQL Functions
-----------------------------
-
-.. code-block:: php
-
-    <?php
-    // Results in SELECT COUNT(*) count FROM ...
-    $builder->select(['count' => $builder->func()->count('*')]);
-
-A number of commonly used functions can be created with the func() method:
-
-* ``sum()`` Calculate a sum. The arguments will be treated as literal values.
-* ``avg()`` Calculate an average. The arguments will be treated as literal values.
-* ``min()`` Calculate the min of a column. The arguments will be treated as literal values.
-* ``max()`` Calculate the max of a column. The arguments will be treated as literal values.
-* ``count()`` Calculate the count. The arguments will be treated as literal values.
-* ``concat()`` Concatenate two values together. The arguments are treated as bound parameters unless marked as literal.
-* ``coalesce()`` Coalesce values. The arguments are treated as bound parameters unless marked as literal.
-* ``dateDiff()`` Get the difference between two dates/times. The arguments are treated as bound parameters unless marked as literal.
-* ``now()`` Take either 'time' or 'date' as an argument allowing you to get either the current time, or current date.
-
-When providing arguments for SQL functions, there are two kinds of parameters you can use,
-literal arguments and bound parameters. Literal parameters allow you to reference columns or
-other SQL literals. Bound parameters can be used to safely add user data to SQL functions. For example:
-
-
-.. code-block:: php
-
-    <?php
-    // Generates:
-    // SELECT CONCAT(title, ' NEW') ...;
-    $concat = $builder->func()->concat([
-        'title' => 'literal',
-        ' NEW'
-    ]);
-    $query->select(['title' => $concat]);
-
-
-Getting Results out of a Query
-------------------------------
-
-Once you’ve made your query, you’ll want to retrieve rows from it. There are a few ways of doing this:
-
-
-.. code-block:: php
-
-    <?php
-    // Iterate the query
-    foreach ($builder as $row) {
-        echo $row['title'];
-    }
-
-    // Get the statement and fetch all results
-    $results = $builder->execute()->fetchAll('assoc');
-
-
-Creating an Insert Query
-------------------------
-
-Creating insert queries is also possible:
-
-
-.. code-block:: php
-
-    <?php
-    $builder = $this->getQueryBuilder('insert');
-    $builder
-        ->insert(['first_name', 'last_name'])
-        ->into('users')
-        ->values(['first_name' => 'Steve', 'last_name' => 'Jobs'])
-        ->values(['first_name' => 'Jon', 'last_name' => 'Snow'])
-        ->execute();
-
-
-For increased performance, you can use another builder object as the values for an insert query:
-
-.. code-block:: php
-
-    <?php
-
-    $namesQuery = $this->getQueryBuilder('select');
-    $namesQuery
-        ->select(['fname', 'lname'])
-        ->from('users')
-        ->where(['is_active' => true]);
-
-    $builder = $this->getQueryBuilder('insert');
-    $st = $builder
-        ->insert(['first_name', 'last_name'])
-        ->into('names')
-        ->values($namesQuery)
-        ->execute();
-
-    var_dump($st->lastInsertId('names', 'id'));
-
-
-The above code will generate:
-
-.. code-block:: sql
-
-    INSERT INTO names (first_name, last_name)
-        (SELECT fname, lname FROM USERS where is_active = 1)
-
-
-Creating an update Query
-------------------------
-
-Creating update queries is similar to both inserting and selecting:
-
-.. code-block:: php
-
-    <?php
-    $builder = $this->getQueryBuilder('update');
-    $builder
-        ->update('users')
-        ->set('fname', 'Snow')
-        ->where(['fname' => 'Jon'])
-        ->execute();
-
-
-Creating a Delete Query
------------------------
-
-Finally, delete queries:
-
-.. code-block:: php
-
-    <?php
-    $builder = $this->getQueryBuilder('delete');
-    $builder
-        ->delete('users')
-        ->where(['accepted_gdpr' => false])
-        ->execute();

--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -72,6 +72,15 @@ interface AdapterInterface
     public const PHINX_TYPE_INTERVAL = TableSchemaInterface::TYPE_INTERVAL;
 
     /**
+     * @deprecated 5.0.0 Enum column support will be removed in a future release.
+     */
+    public const PHINX_TYPE_ENUM = 'enum';
+    /**
+     * @deprecated 5.0.0 Set column support will be removed in a future release.
+     */
+    public const PHINX_TYPE_SET = 'set';
+
+    /**
      * Get all migrated version numbers.
      *
      * @return array<int>

--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -72,15 +72,6 @@ interface AdapterInterface
     public const PHINX_TYPE_INTERVAL = TableSchemaInterface::TYPE_INTERVAL;
 
     /**
-     * @deprecated 5.0.0 Enum column support will be removed in a future release.
-     */
-    public const PHINX_TYPE_ENUM = 'enum';
-    /**
-     * @deprecated 5.0.0 Set column support will be removed in a future release.
-     */
-    public const PHINX_TYPE_SET = 'set';
-
-    /**
      * Get all migrated version numbers.
      *
      * @return array<int>

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -32,7 +32,42 @@ class MysqlAdapter extends AbstractAdapter
         self::PHINX_TYPE_YEAR,
         self::PHINX_TYPE_JSON,
         self::PHINX_TYPE_BINARYUUID,
+        self::PHINX_TYPE_ENUM,
+        self::PHINX_TYPE_SET,
+        self::PHINX_TYPE_BLOB,
+        self::PHINX_TYPE_TINYBLOB,
+        self::PHINX_TYPE_MEDIUMBLOB,
+        self::PHINX_TYPE_LONGBLOB,
     ];
+
+    /**
+     * @deprecated 5.0.0 Enum column support will be removed in a future release.
+     */
+    public const PHINX_TYPE_ENUM = 'enum';
+    /**
+     * @deprecated 5.0.0 Set column support will be removed in a future release.
+     */
+    public const PHINX_TYPE_SET = 'set';
+    /**
+     * @deprecated 5.0.0 Use binary type with with no limit instead.
+     */
+    public const PHINX_TYPE_BLOB = 'blob';
+    /**
+     * @deprecated 5.0.0 Use binary type with with limit BLOB_SMALL instead.
+     */
+    public const PHINX_TYPE_TINYBLOB = 'tinyblob';
+    /**
+     * @deprecated 5.0.0 Use binary type with with limit BLOB_MEDIUM instead.
+     */
+    public const PHINX_TYPE_MEDIUMBLOB = 'mediumblob';
+    /**
+     * @deprecated 5.0.0 Use binary type with with limit BLOB_LONG instead.
+     */
+    public const PHINX_TYPE_LONGBLOB = 'longblob';
+    /**
+     * @deprecated 5.0.0 Use binary type instead.
+     */
+    public const PHINX_TYPE_VARBINARY = 'varbinary';
 
     // These constants roughly correspond to the maximum allowed value for each field,
     // except for the `_LONG` and `_BIG` variants, which are maxed at 32-bit
@@ -254,7 +289,15 @@ class MysqlAdapter extends AbstractAdapter
                 default => null,
             };
         }
-        if ($data['type'] === self::PHINX_TYPE_BINARY) {
+        $blobTypes = [
+            self::PHINX_TYPE_BINARY,
+            self::PHINX_TYPE_VARBINARY,
+            self::PHINX_TYPE_BLOB,
+            self::PHINX_TYPE_TINYBLOB,
+            self::PHINX_TYPE_MEDIUMBLOB,
+            self::PHINX_TYPE_LONGBLOB,
+        ];
+        if (in_array($data['type'], $blobTypes, true)) {
             if ($data['length'] === self::BLOB_REGULAR) {
                 $data['type'] = TableSchema::TYPE_BINARY;
                 $data['length'] = null;
@@ -268,6 +311,14 @@ class MysqlAdapter extends AbstractAdapter
                     $data['length'] = $bucket;
                     break;
                 }
+            }
+            if ($data['length'] === null) {
+                $data['length'] = match ($data['type']) {
+                    self::PHINX_TYPE_TINYBLOB => TableSchema::LENGTH_TINY,
+                    self::PHINX_TYPE_MEDIUMBLOB => TableSchema::LENGTH_MEDIUM,
+                    self::PHINX_TYPE_LONGBLOB => TableSchema::LENGTH_LONG,
+                    default => null,
+                };
             }
             $data['type'] = 'binary';
         } elseif ($data['type'] === self::PHINX_TYPE_INTEGER) {

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -480,6 +480,7 @@ class MysqlAdapter extends AbstractAdapter
             $type = 'timestamp';
             $length = $columnData['precision'] ?? $length;
         } elseif ($type === TableSchema::TYPE_BINARY) {
+            // TODO could rawType be removed? We should be able to use the abstract type and length only.
             // CakePHP returns BLOB columns as 'binary' with specific lengths
             // Check the raw MySQL type to distinguish BLOB from BINARY columns
             $rawType = $columnData['rawType'] ?? '';

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -11,6 +11,7 @@ namespace Migrations\Db\Adapter;
 use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Exception\QueryException;
+use Cake\Database\Schema\SchemaDialect;
 use Cake\Database\Schema\TableSchema;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
@@ -202,8 +203,7 @@ class MysqlAdapter extends AbstractAdapter
         $sql = 'CREATE TABLE ';
         $sql .= $this->quoteTableName($table->getName()) . ' (';
         foreach ($columns as $column) {
-            $columnData = $this->mapColumnData($column->toArray());
-            $sql .= $dialect->columnDefinitionSql($columnData) . ', ';
+            $sql .= $this->columnDefinitionSql($dialect, $column) . ', ';
         }
 
         // set the primary key(s)
@@ -279,6 +279,44 @@ class MysqlAdapter extends AbstractAdapter
         }
 
         return $data;
+    }
+
+    /**
+     * Get the SQL fragment for a column definition.
+     *
+     * This method provides backwards compatibility for enum and set types
+     * as userland migrations use those types, but they are not supported
+     * in cakephp/database.
+     *
+     * @param \Cake\Database\Schema\SchemaDialect $dialect The dialect to use.
+     * @param \Migrations\Db\Table\Column $column The column to get the SQL for.
+     * @return string
+     */
+    protected function columnDefinitionSql(SchemaDialect $dialect, Column $column): string
+    {
+        $columnData = $column->toArray();
+        $deprecatedTypes = [self::PHINX_TYPE_ENUM, self::PHINX_TYPE_SET];
+        if (in_array($columnData['type'], $deprecatedTypes, true)) {
+            $sql = $this->quoteColumnName($columnData['name']) . ' ' . $columnData['type'];
+            $values = $column->getValues();
+            if ($values) {
+                $sql .= '(' . implode(', ', array_map(function ($value) {
+                    // Special case NULL to trigger errors as it isn't allowed
+                    // in enum values.
+                    return $value === null ? 'NULL' : $this->quoteString($value);
+                }, $values)) . ')';
+            }
+
+            $sql .= $column->getEncoding() ? ' CHARACTER SET ' . $column->getEncoding() : '';
+            $sql .= $column->getCollation() ? ' COLLATE ' . $column->getCollation() : '';
+            $sql .= $column->isNull() ? ' NULL' : ' NOT NULL';
+            $sql .= $column->getDefault() ? ' DEFAULT ' . $this->quoteString($column->getDefault()) : '';
+            $sql .= $column->getComment() ? ' COMMENT ' . $this->quoteString($column->getComment()) : '';
+
+            return $sql;
+        }
+
+        return $dialect->columnDefinitionSql($this->mapColumnData($columnData));
     }
 
     /**
@@ -374,6 +412,7 @@ class MysqlAdapter extends AbstractAdapter
      * Convert from cakephp/database conventions to migrations\column
      *
      * - converts datetimefractional -> datetime + length
+     * - converts binary types to mysql blob type constants.
      *
      * @param array $columnData The cakephp/database column data to transform
      * @return array The extracted/converted type and length.
@@ -389,6 +428,28 @@ class MysqlAdapter extends AbstractAdapter
         } elseif ($type === TableSchema::TYPE_TIMESTAMP_FRACTIONAL) {
             $type = 'timestamp';
             $length = $columnData['precision'] ?? $length;
+        } elseif ($type === TableSchema::TYPE_BINARY) {
+            // CakePHP returns BLOB columns as 'binary' with specific lengths
+            // Check the raw MySQL type to distinguish BLOB from BINARY columns
+            $rawType = $columnData['rawType'] ?? '';
+            if (str_contains($rawType, 'blob')) {
+                // Map BLOB columns back to the appropriate BLOB types
+                if (str_contains($rawType, 'tinyblob')) {
+                    $type = static::PHINX_TYPE_TINYBLOB;
+                    $length = static::BLOB_TINY;
+                } elseif (str_contains($rawType, 'mediumblob')) {
+                    $type = static::PHINX_TYPE_MEDIUMBLOB;
+                    $length = static::BLOB_MEDIUM;
+                } elseif (str_contains($rawType, 'longblob')) {
+                    $type = static::PHINX_TYPE_LONGBLOB;
+                    $length = static::BLOB_LONG;
+                } else {
+                    // Regular BLOB
+                    $type = static::PHINX_TYPE_BLOB;
+                    $length = static::BLOB_REGULAR;
+                }
+            }
+            // else: keep as binary or varbinary (actual BINARY/VARBINARY column)
         }
 
         return [$type, $length];
@@ -401,8 +462,17 @@ class MysqlAdapter extends AbstractAdapter
     {
         $dialect = $this->getSchemaDialect();
         $columnRecords = $dialect->describeColumns($tableName);
+
+        // Fetch raw column types to distinguish BLOB from BINARY columns
+        $rawTypes = [];
+        $rows = $this->fetchAll(sprintf('SHOW COLUMNS FROM %s', $this->quoteTableName($tableName)));
+        foreach ($rows as $row) {
+            $rawTypes[$row['Field']] = strtolower($row['Type']);
+        }
+
         $columns = [];
         foreach ($columnRecords as $record) {
+            $record['rawType'] = $rawTypes[$record['name']] ?? null;
             [$type, $length] = $this->mapColumnType($record);
 
             $column = (new Column())
@@ -449,7 +519,7 @@ class MysqlAdapter extends AbstractAdapter
         $dialect = $this->getSchemaDialect();
         $alter = sprintf(
             'ADD %s',
-            $dialect->columnDefinitionSql($this->mapColumnData($column->toArray())),
+            $this->columnDefinitionSql($dialect, $column),
         );
 
         $alter .= $this->afterClause($column);
@@ -532,7 +602,7 @@ class MysqlAdapter extends AbstractAdapter
         $alter = sprintf(
             'CHANGE %s %s%s',
             $this->quoteColumnName($columnName),
-            $dialect->columnDefinitionSql($this->mapColumnData($newColumn->toArray())),
+            $this->columnDefinitionSql($dialect, $newColumn),
             $this->afterClause($newColumn),
         );
 

--- a/src/Db/Table/Column.php
+++ b/src/Db/Table/Column.php
@@ -843,6 +843,7 @@ class Column
             'timezone' => $this->getTimezone(),
             'comment' => $this->getComment(),
             'autoIncrement' => $this->getIdentity(),
+            'values' => $this->getValues(),
         ];
     }
 }

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -493,6 +493,18 @@ class MysqlAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasColumn('ntable', 'address'));
     }
 
+    public function testCreateTableWithSetEnumTypes()
+    {
+        $table = new Table('enum_test', [], $this->adapter);
+        $table->addColumn('status', 'enum', ['values' => ['pending', 'active', 'archived']])
+              ->addColumn('kind', 'set', ['values' => ['a', 'b']])
+              ->save();
+
+        $this->assertTrue($this->adapter->hasTable('enum_test'));
+        $this->assertTrue($this->adapter->hasColumn('enum_test', 'status'));
+        $this->assertTrue($this->adapter->hasColumn('enum_test', 'kind'));
+    }
+
     #[RunInSeparateProcess]
     public function testUnsignedPksFeatureFlag()
     {
@@ -933,6 +945,151 @@ class MysqlAdapterTest extends TestCase
         $this->assertNull($rows[1]['Default']);
     }
 
+    public function testChangeColumnEnum()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'string')
+              ->save();
+        $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
+
+        $table->changeColumn('column1', 'enum', ['values' => ['a', 'b']])->save();
+        $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
+
+        $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM t');
+        $this->assertNull($rows[1]['Default']);
+        $this->assertEquals("enum('a','b')", $rows[1]['Type']);
+    }
+
+    public static function binaryToBlobAutomaticConversionData()
+    {
+        return [
+            // When creating binary with limit > 255, MySQL auto-converts to BLOB
+            // input limit, expected SQL type name, expected column limit after round-trip
+            [null, 'blob', MysqlAdapter::BLOB_REGULAR], // binary(null) becomes BLOB
+            [64, 'tinyblob', MysqlAdapter::BLOB_TINY], // binary(64) becomes TINYBLOB
+            [MysqlAdapter::BLOB_REGULAR - 20, 'mediumblob', MysqlAdapter::BLOB_MEDIUM],
+            [MysqlAdapter::BLOB_REGULAR, 'blob', MysqlAdapter::BLOB_REGULAR],
+            [MysqlAdapter::BLOB_REGULAR + 20, 'mediumblob', MysqlAdapter::BLOB_MEDIUM],
+            [MysqlAdapter::BLOB_MEDIUM, 'mediumblob', MysqlAdapter::BLOB_MEDIUM],
+            [MysqlAdapter::BLOB_MEDIUM + 20, 'longblob', MysqlAdapter::BLOB_LONG],
+            [MysqlAdapter::BLOB_LONG, 'longblob', MysqlAdapter::BLOB_LONG],
+        ];
+    }
+
+    #[DataProvider('binaryToBlobAutomaticConversionData')]
+    public function testBinaryToBlobAutomaticConversion(?int $limit, string $expectedType, ?int $expectedLimit)
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'binary', ['limit' => $limit])
+              ->save();
+        $columns = $table->getColumns();
+        $this->assertSame($expectedType, $columns[1]->getType());
+        $this->assertSame($expectedLimit, $columns[1]->getLimit());
+    }
+
+    public static function varbinaryToBlobAutomaticConversionData()
+    {
+        return [
+            // When creating varbinary with limit > 255, MySQL auto-converts to BLOB
+            // input limit, expected SQL type name, expected column limit after round-trip
+            [null, 'blob', MysqlAdapter::BLOB_REGULAR], // varbinary(null) becomes BLOB
+            [64, 'tinyblob', MysqlAdapter::BLOB_TINY], // varbinary(64) becomes TINYBLOB
+            [MysqlAdapter::BLOB_REGULAR - 20, 'mediumblob', MysqlAdapter::BLOB_MEDIUM],
+            [MysqlAdapter::BLOB_REGULAR, 'blob', MysqlAdapter::BLOB_REGULAR],
+            [MysqlAdapter::BLOB_REGULAR + 20, 'mediumblob', MysqlAdapter::BLOB_MEDIUM],
+            [MysqlAdapter::BLOB_MEDIUM, 'mediumblob', MysqlAdapter::BLOB_MEDIUM],
+            [MysqlAdapter::BLOB_MEDIUM + 20, 'longblob', MysqlAdapter::BLOB_LONG],
+            [MysqlAdapter::BLOB_LONG, 'longblob', MysqlAdapter::BLOB_LONG],
+        ];
+    }
+
+    #[DataProvider('varbinaryToBlobAutomaticConversionData')]
+    public function testVarbinaryToBlobAutomaticConversion(?int $limit, string $expectedType, ?int $expectedLimit)
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'varbinary', ['limit' => $limit])
+              ->save();
+        $columns = $table->getColumns();
+        $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
+        $this->assertSame($expectedType, $columns[1]->getType());
+        $this->assertSame($expectedLimit, $columns[1]->getLimit());
+    }
+
+    public static function blobColumnsData()
+    {
+        return [
+          // BLOB columns with various limits - MySQL auto-selects appropriate BLOB subtype
+          // input type, expected SQL type, input limit, expected column limit after round-trip
+          // Tiny blobs
+          ['tinyblob', 'tinyblob', null, MysqlAdapter::BLOB_TINY],
+          ['tinyblob', 'tinyblob', MysqlAdapter::BLOB_TINY, MysqlAdapter::BLOB_TINY],
+          ['tinyblob', 'mediumblob', MysqlAdapter::BLOB_TINY + 20, MysqlAdapter::BLOB_MEDIUM],
+          ['tinyblob', 'mediumblob', MysqlAdapter::BLOB_MEDIUM, MysqlAdapter::BLOB_MEDIUM],
+          ['tinyblob', 'longblob', MysqlAdapter::BLOB_LONG, MysqlAdapter::BLOB_LONG],
+          // Regular blobs
+          ['blob', 'tinyblob', MysqlAdapter::BLOB_TINY, MysqlAdapter::BLOB_TINY],
+          ['blob', 'blob', null, MysqlAdapter::BLOB_REGULAR],
+          ['blob', 'blob', MysqlAdapter::BLOB_REGULAR, MysqlAdapter::BLOB_REGULAR],
+          ['blob', 'mediumblob', MysqlAdapter::BLOB_MEDIUM, MysqlAdapter::BLOB_MEDIUM],
+          ['blob', 'longblob', MysqlAdapter::BLOB_LONG, MysqlAdapter::BLOB_LONG],
+          // Medium blobs
+          ['mediumblob', 'tinyblob', MysqlAdapter::BLOB_TINY, MysqlAdapter::BLOB_TINY],
+          ['mediumblob', 'blob', MysqlAdapter::BLOB_REGULAR, MysqlAdapter::BLOB_REGULAR],
+          ['mediumblob', 'mediumblob', null, MysqlAdapter::BLOB_MEDIUM],
+          ['mediumblob', 'mediumblob', MysqlAdapter::BLOB_MEDIUM, MysqlAdapter::BLOB_MEDIUM],
+          ['mediumblob', 'longblob', MysqlAdapter::BLOB_LONG, MysqlAdapter::BLOB_LONG],
+          // Long blobs
+          ['longblob', 'tinyblob', MysqlAdapter::BLOB_TINY, MysqlAdapter::BLOB_TINY],
+          ['longblob', 'blob', MysqlAdapter::BLOB_REGULAR, MysqlAdapter::BLOB_REGULAR],
+          ['longblob', 'mediumblob', MysqlAdapter::BLOB_MEDIUM, MysqlAdapter::BLOB_MEDIUM],
+          ['longblob', 'longblob', null, MysqlAdapter::BLOB_LONG],
+          ['longblob', 'longblob', MysqlAdapter::BLOB_LONG, MysqlAdapter::BLOB_LONG],
+        ];
+    }
+
+    #[DataProvider('blobColumnsData')]
+    public function testblobColumns(string $type, string $expectedType, ?int $limit, ?int $expectedLimit)
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', $type, ['limit' => $limit])
+              ->save();
+        $columns = $table->getColumns();
+        $this->assertSame($expectedType, $columns[1]->getType());
+        $this->assertSame($expectedLimit, $columns[1]->getLimit());
+    }
+
+    public static function blobRoundTripData()
+    {
+        return [
+            // type, limit, expected type after round-trip, expected limit after round-trip
+            ['blob', null, 'blob', MysqlAdapter::BLOB_REGULAR],
+            ['blob', MysqlAdapter::BLOB_REGULAR, 'blob', MysqlAdapter::BLOB_REGULAR],
+            ['tinyblob', null, 'tinyblob', MysqlAdapter::BLOB_TINY],
+            ['mediumblob', null, 'mediumblob', MysqlAdapter::BLOB_MEDIUM],
+            ['longblob', null, 'longblob', MysqlAdapter::BLOB_LONG],
+        ];
+    }
+
+    #[DataProvider('blobRoundTripData')]
+    public function testBlobRoundTrip(string $type, ?int $limit, string $expectedType, int $expectedLimit)
+    {
+        // Create a table with a BLOB column
+        $table = new Table('blob_round_trip_test', [], $this->adapter);
+        $table->addColumn('blob_col', $type, ['limit' => $limit])
+              ->save();
+
+        // Read the column back from the database
+        $columns = $this->adapter->getColumns('blob_round_trip_test');
+
+        $blobColumn = $columns[1];
+        $this->assertNotNull($blobColumn, 'BLOB column not found');
+        $this->assertSame($expectedType, $blobColumn->getType(), 'Type mismatch after round-trip');
+        $this->assertSame($expectedLimit, $blobColumn->getLimit(), 'Limit mismatch after round-trip');
+
+        // Clean up
+        $this->adapter->dropTable('blob_round_trip_test');
+    }
+
     public function testTimestampInvalidLimit()
     {
         $this->adapter->connect();
@@ -975,7 +1132,7 @@ class MysqlAdapterTest extends TestCase
             ['column9', 'time', []],
             ['column10', 'timestamp', []],
             ['column11', 'date', []],
-            ['column12', 'binary', []],
+            ['column12', 'blob', []], // binary with no limit becomes BLOB in MySQL
             ['column13', 'boolean', ['comment' => 'Lorem ipsum']],
             ['column14', 'string', ['limit' => 10]],
             ['column16', 'geometry', []],
@@ -1625,6 +1782,40 @@ class MysqlAdapterTest extends TestCase
         $columnWithComment = $rows[1];
 
         $this->assertSame('column1', $columnWithComment['COLUMN_NAME'], "Didn't set column name correctly");
+        $this->assertEquals($comment, $columnWithComment['COLUMN_COMMENT'], "Didn't set column comment correctly");
+    }
+
+    public function testAddColumnEnum()
+    {
+        $table = new Table('t', [], $this->adapter);
+        $table->addColumn('column1', 'string')
+              ->save();
+        $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
+
+        $table->addColumn('column2', 'enum', ['values' => ['a', 'b']])->save();
+        $this->assertTrue($this->adapter->hasColumn('t', 'column2'));
+
+        $comment = 'Comments from "column3"';
+        $table->addColumn('column3', 'enum', ['values' => ['c', 'd'], 'null' => false, 'default' => 'd', 'comment' => $comment])->save();
+        $this->assertTrue($this->adapter->hasColumn('t', 'column3'));
+
+        $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM t');
+        $this->assertEquals("enum('a','b')", $rows[2]['Type']);
+        $this->assertEquals('YES', $rows[2]['Null']);
+        $this->assertNull($rows[2]['Default']);
+        $this->assertEquals("enum('c','d')", $rows[3]['Type']);
+        $this->assertEquals('NO', $rows[3]['Null']);
+        $this->assertEquals('d', $rows[3]['Default']);
+
+        $rows = $this->adapter->fetchAll(sprintf(
+            "SELECT COLUMN_NAME, COLUMN_COMMENT
+            FROM information_schema.columns
+            WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='t'
+            ORDER BY ORDINAL_POSITION",
+            $this->config['database'],
+        ));
+        $columnWithComment = $rows[3];
+        $this->assertSame('column3', $columnWithComment['COLUMN_NAME'], "Didn't set column name correctly");
         $this->assertEquals($comment, $columnWithComment['COLUMN_COMMENT'], "Didn't set column comment correctly");
     }
 

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -1010,7 +1010,6 @@ class MysqlAdapterTest extends TestCase
         $table->addColumn('column1', 'varbinary', ['limit' => $limit])
               ->save();
         $columns = $table->getColumns();
-        $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
         $this->assertSame($expectedType, $columns[1]->getType());
         $this->assertSame($expectedLimit, $columns[1]->getLimit());
     }
@@ -1051,7 +1050,7 @@ class MysqlAdapterTest extends TestCase
     public function testblobColumns(string $type, string $expectedType, ?int $limit, ?int $expectedLimit)
     {
         $table = new Table('t', [], $this->adapter);
-        $table->addColumn('column1', $type, ['limit' => $limit])
+        $table->addColumn('blob_col', $type, ['limit' => $limit])
               ->save();
         $columns = $table->getColumns();
         $this->assertSame($expectedType, $columns[1]->getType());


### PR DESCRIPTION
Merge 4.next (and 4.x) into 5.x. I has to implement some more shim logic to preserve compatibility for the binary types that were recently restored in 4.x.