### PR TITLE
Fix up anonymous seed support

### DIFF
--- a/docs/en/seeding.rst
+++ b/docs/en/seeding.rst
@@ -18,11 +18,12 @@ Migrations includes a command to easily generate a new seed class:
 
         $ bin/cake bake seed MyNewSeed
 
-It is based on a skeleton template:
+By default, it generates a traditional seed class with a named class:
 
 .. code-block:: php
 
     <?php
+    declare(strict_types=1);
 
     use Migrations\BaseSeed;
 
@@ -43,6 +44,62 @@ It is based on a skeleton template:
     }
 
 By default, the table the seed will try to alter is the "tableized" version of the seed filename.
+
+Anonymous Seed Classes
+----------------------
+
+Migrations also supports generating anonymous seed classes, which use PHP's
+anonymous class feature instead of named classes. This style is useful for:
+
+- Avoiding namespace declarations
+- Better PHPCS compatibility (no class name to filename matching required)
+- Simpler file structure without named class constraints
+
+To generate an anonymous seed class, use the ``--style anonymous`` option:
+
+.. code-block:: bash
+
+    $ bin/cake bake seed MyNewSeed --style anonymous
+
+This generates a seed file using an anonymous class:
+
+.. code-block:: php
+
+    <?php
+    declare(strict_types=1);
+
+    use Migrations\BaseSeed;
+
+    return new class extends BaseSeed
+    {
+        /**
+         * Run Method.
+         *
+         * Write your database seeder using this method.
+         *
+         * More information on writing seeds is available here:
+         * https://book.cakephp.org/migrations/5/en/seeding.html
+         */
+        public function run(): void
+        {
+
+        }
+    };
+
+Both traditional and anonymous seed classes work identically at runtime and can
+be used interchangeably within the same project.
+
+You can set the default seed style globally in your application configuration:
+
+.. code-block:: php
+
+    // In config/app.php or config/app_local.php
+    'Migrations' => [
+        'style' => 'anonymous',  // or 'traditional'
+    ],
+
+Seed Options
+------------
 
 .. code-block:: bash
     # You specify the name of the table the seed files will alter by using the ``--table`` option
@@ -92,8 +149,10 @@ migrations should be on one of the following paths:
 - ``ROOT/templates/plugin/Migrations/bake/``
 - ``ROOT/templates/bake/``
 
-For example the seed template is ``Seed/seed.twig`` and its full path would be
-**ROOT/templates/plugin/Migrations/bake/Seed/seed.twig**
+For example, the seed templates are:
+
+- Traditional: ``Seed/seed.twig`` at **ROOT/templates/plugin/Migrations/bake/Seed/seed.twig**
+- Anonymous: ``Seed/seed-anonymous.twig`` at **ROOT/templates/plugin/Migrations/bake/Seed/seed-anonymous.twig**
 
 The BaseSeed Class
 ==================

--- a/src/BaseSeed.php
+++ b/src/BaseSeed.php
@@ -129,7 +129,14 @@ class BaseSeed implements SeedInterface
      */
     public function getName(): string
     {
-        return static::class;
+        $name = static::class;
+        if (str_starts_with($name, 'Migrations\BaseSeed@anonymous')) {
+            [, $path] = explode('/', $name, 2);
+            [$path, ] = explode(':', $path, 2);
+            $name = basename($path, '.php');
+        }
+
+        return $name;
     }
 
     /**

--- a/src/BaseSeed.php
+++ b/src/BaseSeed.php
@@ -131,7 +131,7 @@ class BaseSeed implements SeedInterface
     {
         $name = static::class;
         if (str_starts_with($name, 'Migrations\BaseSeed@anonymous')) {
-            [, $path] = explode('/', $name, 2);
+            [, $path] = explode(DIRECTORY_SEPARATOR, $name, 2);
             [$path, ] = explode(':', $path, 2);
             $name = basename($path, '.php');
         }

--- a/src/BaseSeed.php
+++ b/src/BaseSeed.php
@@ -131,10 +131,9 @@ class BaseSeed implements SeedInterface
     {
         $name = static::class;
         if (str_starts_with($name, 'Migrations\BaseSeed@anonymous')) {
-            debug($name);
-            [, $path] = explode(DIRECTORY_SEPARATOR, $name, 2);
-            [$path, ] = explode(':', $path, 2);
-            $name = basename($path, '.php');
+            if (preg_match('#[/\\\\]([a-zA-Z0-9_]+)\.php:#', $name, $matches)) {
+                $name = $matches[1];
+            }
         }
 
         return $name;

--- a/src/BaseSeed.php
+++ b/src/BaseSeed.php
@@ -131,6 +131,7 @@ class BaseSeed implements SeedInterface
     {
         $name = static::class;
         if (str_starts_with($name, 'Migrations\BaseSeed@anonymous')) {
+            debug($name);
             [, $path] = explode(DIRECTORY_SEPARATOR, $name, 2);
             [$path, ] = explode(':', $path, 2);
             $name = basename($path, '.php');

--- a/src/Command/BakeSeedCommand.php
+++ b/src/Command/BakeSeedCommand.php
@@ -43,6 +43,13 @@ class BakeSeedCommand extends SimpleBakeCommand
     protected string $_name;
 
     /**
+     * Arguments
+     *
+     * @var \Cake\Console\Arguments|null
+     */
+    protected ?Arguments $args = null;
+
+    /**
      * @inheritDoc
      */
     public static function defaultName(): string
@@ -84,6 +91,11 @@ class BakeSeedCommand extends SimpleBakeCommand
      */
     public function template(): string
     {
+        $style = $this->args?->getOption('style') ?? Configure::read('Migrations.style', 'traditional');
+        if ($style === 'anonymous') {
+            return 'Migrations.Seed/seed-anonymous';
+        }
+
         return 'Migrations.Seed/seed';
     }
 
@@ -150,6 +162,7 @@ class BakeSeedCommand extends SimpleBakeCommand
      */
     public function bake(string $name, Arguments $args, ConsoleIo $io): void
     {
+        $this->args = $args;
         /** @var array<string, bool|string|null> $options */
         $options = array_merge($args->getOptions(), ['no-test' => true]);
         $newArgs = new Arguments(
@@ -184,6 +197,10 @@ class BakeSeedCommand extends SimpleBakeCommand
         ])->addOption('limit', [
             'short' => 'l',
             'help' => 'If including data, max number of rows to select',
+        ])->addOption('style', [
+            'help' => 'Seed style to use (traditional or anonymous).',
+            'default' => null,
+            'choices' => ['traditional', 'anonymous'],
         ]);
 
         return $parser;

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -1010,22 +1010,37 @@ class Manager
                     $fileNames[$class] = basename($filePath);
 
                     // load the seed file
-                    require_once $filePath;
+                    // For anonymous classes, we need to use require instead of require_once
+                    // to get the returned instance
+                    $seedInstance = null;
                     if (!class_exists($class)) {
+                        $seedInstance = require $filePath;
+                    } else {
+                        require_once $filePath;
+                    }
+
+                    // Check if the file returns an anonymous class instance
+                    if (is_object($seedInstance) && $seedInstance instanceof SeedInterface) {
+                        $io->verbose("Using anonymous class from <info>$filePath</info>.");
+                        $seed = $seedInstance;
+                    } elseif (class_exists($class)) {
+                        // Fall back to traditional class-based seed
+                        $io->verbose("Instantiating <info>$class</info>.");
+                        // instantiate it
+                        /** @var \Migrations\SeedInterface $seed */
+                        if (isset($this->container)) {
+                            $seed = $this->container->get($class);
+                        } else {
+                            $seed = new $class();
+                        }
+                    } else {
                         throw new InvalidArgumentException(sprintf(
-                            'Could not find class `%s` in file `%s`',
+                            'Could not find class `%s` in file `%s` and file did not return a seed instance',
                             $class,
                             $filePath,
                         ));
                     }
 
-                    // instantiate it
-                    /** @var \Migrations\SeedInterface $seed */
-                    if (isset($this->container)) {
-                        $seed = $this->container->get($class);
-                    } else {
-                        $seed = new $class();
-                    }
                     /** @var \Migrations\SeedInterface $seed */
                     $seed->setIo($io);
                     $seed->setConfig($config);

--- a/templates/bake/Seed/seed-anonymous.twig
+++ b/templates/bake/Seed/seed-anonymous.twig
@@ -1,0 +1,44 @@
+{#
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+#}
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseSeed;
+
+return new class extends BaseSeed
+{
+    /**
+     * Run Method.
+     *
+     * Write your database seeder using this method.
+     *
+     * More information on writing seeds is available here:
+     * https://book.cakephp.org/migrations/5/en/seeding.html
+     *
+     * @return void
+     */
+    public function run(): void
+    {
+{% if records %}
+        $data = {{ records | raw }};
+{% else %}
+        $data = [];
+{% endif %}
+
+        $table = $this->table('{{ table }}');
+        $table->insert($data)->save();
+    }
+};

--- a/tests/TestCase/Command/BakeSeedCommandTest.php
+++ b/tests/TestCase/Command/BakeSeedCommandTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Migrations\Test\TestCase\Command;
 
 use Cake\Console\BaseCommand;
+use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\StringCompareTrait;
 use Migrations\Test\TestCase\TestCase;
@@ -159,5 +160,25 @@ class BakeSeedCommandTest extends TestCase
         $this->assertExitCode(BaseCommand::CODE_SUCCESS);
         $result = file_get_contents($this->generatedFile);
         $this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+    }
+
+    /**
+     * Test baking anonymous seed with Configure
+     *
+     * @return void
+     */
+    public function testAnonymousStyleWithConfigure()
+    {
+        Configure::write('Migrations.style', 'anonymous');
+
+        $this->generatedFile = ROOT . DS . 'config/Seeds/ArticlesSeed.php';
+        $this->exec('bake seed Articles --connection test');
+
+        $this->assertExitCode(BaseCommand::CODE_SUCCESS);
+        $result = file_get_contents($this->generatedFile);
+
+        // Check that it returns an anonymous class
+        $this->assertStringContainsString('return new class extends BaseSeed', $result);
+        $this->assertStringNotContainsString('class ArticlesSeed extends', $result);
     }
 }

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -36,7 +36,6 @@ class SeedCommandTest extends TestCase
         $connection->execute('DROP TABLE IF EXISTS numbers');
         $connection->execute('DROP TABLE IF EXISTS letters');
         $connection->execute('DROP TABLE IF EXISTS stores');
-        $connection->execute('DROP TABLE IF EXISTS products');
     }
 
     protected function resetOutput(): void
@@ -330,23 +329,19 @@ class SeedCommandTest extends TestCase
     public function testSeederAnonymousClass(): void
     {
         $this->createTables();
-
-        // Create products table for the test
-        /** @var \Cake\Database\Connection $connection */
-        $connection = ConnectionManager::get('test');
-        $connection->execute('CREATE TABLE products (id INT PRIMARY KEY, name VARCHAR(255))');
-
-        $this->exec('migrations seed -c test --seed ProductsSeed');
+        $this->exec('migrations seed -c test --seed AnonymousStoreSeed');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('ProductsSeed:</info> <comment>seeding');
+        $this->assertOutputContains('AnonymousStoreSeed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
-        $query = $connection->execute('SELECT COUNT(*) FROM products');
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $query = $connection->execute('SELECT COUNT(*) FROM stores');
         $this->assertEquals(2, $query->fetchColumn(0));
 
-        $result = $connection->execute('SELECT * FROM products ORDER BY id')->fetchAll('assoc');
-        $this->assertEquals('Product 1', $result[0]['name']);
-        $this->assertEquals('Product 2', $result[1]['name']);
+        $result = $connection->execute('SELECT * FROM stores ORDER BY id')->fetchAll('assoc');
+        $this->assertEquals('anonymous_store', $result[0]['name']);
+        $this->assertEquals('other_store', $result[1]['name']);
     }
 }

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -36,6 +36,7 @@ class SeedCommandTest extends TestCase
         $connection->execute('DROP TABLE IF EXISTS numbers');
         $connection->execute('DROP TABLE IF EXISTS letters');
         $connection->execute('DROP TABLE IF EXISTS stores');
+        $connection->execute('DROP TABLE IF EXISTS products');
     }
 
     protected function resetOutput(): void
@@ -324,5 +325,28 @@ class SeedCommandTest extends TestCase
 
         $finalCount = $connection->execute('SELECT COUNT(*) FROM stores')->fetchColumn(0);
         $this->assertEquals($initialCount, $finalCount, 'Dry-run mode should not modify stores table');
+    }
+
+    public function testSeederAnonymousClass(): void
+    {
+        $this->createTables();
+
+        // Create products table for the test
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $connection->execute('CREATE TABLE products (id INT PRIMARY KEY, name VARCHAR(255))');
+
+        $this->exec('migrations seed -c test --seed ProductsSeed');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('ProductsSeed:</info> <comment>seeding');
+        $this->assertOutputContains('All Done');
+
+        $query = $connection->execute('SELECT COUNT(*) FROM products');
+        $this->assertEquals(2, $query->fetchColumn(0));
+
+        $result = $connection->execute('SELECT * FROM products ORDER BY id')->fetchAll('assoc');
+        $this->assertEquals('Product 1', $result[0]['name']);
+        $this->assertEquals('Product 2', $result[1]['name']);
     }
 }

--- a/tests/test_app/config/Seeds/AnonymousStoreSeed.php
+++ b/tests/test_app/config/Seeds/AnonymousStoreSeed.php
@@ -19,16 +19,14 @@ return new class extends BaseSeed
     {
         $data = [
             [
-                'id' => '1',
-                'name' => 'Product 1',
+                'name' => 'anonymous_store',
             ],
             [
-                'id' => '2',
-                'name' => 'Product 2',
+                'name' => 'other_store',
             ],
         ];
 
-        $table = $this->table('products');
+        $table = $this->table('stores');
         $table->insert($data)->save();
     }
 };

--- a/tests/test_app/config/Seeds/ProductsSeed.php
+++ b/tests/test_app/config/Seeds/ProductsSeed.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseSeed;
+
+return new class extends BaseSeed
+{
+    /**
+     * Run Method.
+     *
+     * Write your database seeder using this method.
+     *
+     * More information on writing seeds is available here:
+     * https://book.cakephp.org/migrations/5/en/seeding.html
+     *
+     * @return void
+     */
+    public function run(): void
+    {
+        $data = [
+            [
+                'id' => '1',
+                'name' => 'Product 1',
+            ],
+            [
+                'id' => '2',
+                'name' => 'Product 2',
+            ],
+        ];
+
+        $table = $this->table('products');
+        $table->insert($data)->save();
+    }
+};


### PR DESCRIPTION
Follow https://github.com/cakephp/migrations/pull/882

Part of https://github.com/cakephp/migrations/issues/822

With this PHPCS should also not require a namespace for Seed classes.
The file name itself will be clear about the seed, as well. So in sync with Migration files.