### PR TITLE
Fix SQLite defaults for boolean type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,14 @@
     },
     "require": {
         "php": ">=8.1",
-        "cakephp/cache": "^5.2",
-        "cakephp/orm": "^5.2",
+        "cakephp/cache": "^5.2.9",
+        "cakephp/database": "^5.2.9",
+        "cakephp/orm": "^5.2.9",
         "robmorgan/phinx": "^0.16.10"
     },
     "require-dev": {
         "cakephp/bake": "^3.3",
-        "cakephp/cakephp": "^5.2.5",
+        "cakephp/cakephp": "^5.2.9",
         "cakephp/cakephp-codesniffer": "^5.0",
         "phpunit/phpunit": "^10.5.5 || ^11.1.3 || ^12.2.4"
     },

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -466,8 +466,8 @@ class SqliteAdapter extends AbstractAdapter
      */
     protected function parseDefaultValue(mixed $default, string $columnType): mixed
     {
-        if ($default === null) {
-            return null;
+        if (!is_string($default)) {
+            return $default;
         }
 
         // split the input into tokens

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -3147,10 +3147,10 @@ INPUT;
             'Integer 3' => ['create table t(a integer default +1)', 1],
             'Integer 4' => ['create table t(a integer default 2112)', 2112],
             'Integer 5' => ['create table t(a integer default 002112)', 2112],
-            'Integer boolean 1' => ['create table t(a boolean default 1)', true],
-            'Integer boolean 2' => ['create table t(a boolean default 0)', false],
-            'Integer boolean 3' => ['create table t(a boolean default -1)', -1],
-            'Integer boolean 4' => ['create table t(a boolean default 2)', 2],
+            'Integer boolean 1' => ['create table t(a boolean default 1)', 1],
+            'Integer boolean 2' => ['create table t(a boolean default 0)', 0],
+            'Integer boolean 3' => ['create table t(a boolean default -1)', 0],
+            'Integer boolean 4' => ['create table t(a boolean default 2)', 0],
             'Float 1' => ['create table t(a float default 1.0)', 1.0],
             'Float 2' => ['create table t(a float default +1.0)', 1.0],
             'Float 3' => ['create table t(a float default -1.0)', -1.0],
@@ -3184,12 +3184,12 @@ INPUT;
     public static function provideBooleanDefaultValues()
     {
         return [
-            'True LC' => ['create table t(a boolean default true)', true],
-            'True UC' => ['create table t(a boolean default TRUE)', true],
-            'True MC' => ['create table t(a boolean default TRue)', true],
-            'False LC' => ['create table t(a boolean default false)', false],
-            'False UC' => ['create table t(a boolean default FALSE)', false],
-            'False MC' => ['create table t(a boolean default FALse)', false],
+            'True LC' => ['create table t(a boolean default true)', 1],
+            'True UC' => ['create table t(a boolean default TRUE)', 1],
+            'True MC' => ['create table t(a boolean default TRue)', 1],
+            'False LC' => ['create table t(a boolean default false)', 0],
+            'False UC' => ['create table t(a boolean default FALSE)', 0],
+            'False MC' => ['create table t(a boolean default FALse)', 0],
         ];
     }
 


### PR DESCRIPTION
After https://github.com/cakephp/cakephp/pull/18973 the default values of boolean type for SQLite database are always integers `1` or `0`. 

It impacts the value of `$default` attribute passed to `SqliteAdapter::parseDefaultValue()` that is an integer.
As consequence of that a TypeError is thrown calling `preg_match_all($pattern, $default, $matches)` because the second attribute must be a `string`.

This PR fixes the error, returning early the `$default` value if isn't a string.

In addition tests have been fixed to respect the integer default values.