### PR TITLE
Use and document short seed name.

### DIFF
--- a/docs/en/seeding.rst
+++ b/docs/en/seeding.rst
@@ -45,6 +45,22 @@ By default, it generates a traditional seed class with a named class:
 
 By default, the table the seed will try to alter is the "tableized" version of the seed filename.
 
+Seed Naming
+-----------
+
+When referencing seeds in your code or via the command line, you can use either:
+
+- The short name without the ``Seed`` suffix (e.g., ``Articles``, ``Users``)
+- The full name with the ``Seed`` suffix (e.g., ``ArticlesSeed``, ``UsersSeed``)
+
+Both forms work identically in:
+
+- Command line: ``--seed Articles`` or ``--seed ArticlesSeed``
+- Dependencies: ``return ['User', 'ShopItem'];`` or ``return ['UserSeed', 'ShopItemSeed'];``
+- Calling seeds: ``$this->call('Articles');`` or ``$this->call('ArticlesSeed');``
+
+Using the short name is recommended for cleaner, more concise code.
+
 Anonymous Seed Classes
 ----------------------
 
@@ -207,17 +223,28 @@ current seed:
         public function getDependencies(): array
         {
             return [
-                'UserSeed',
-                'ShopItemSeed'
+                'User',      // Short name without 'Seed' suffix
+                'ShopItem',  // Short name without 'Seed' suffix
             ];
         }
 
         public function run() : void
         {
-            // Seed the shopping cart  after the `UserSeed` and
+            // Seed the shopping cart after the `UserSeed` and
             // `ShopItemSeed` have been run.
         }
     }
+
+You can also use the full seed name including the ``Seed`` suffix:
+
+.. code-block:: php
+
+    return [
+        'UserSeed',
+        'ShopItemSeed',
+    ];
+
+Both forms are supported and work identically.
 
 .. note::
 
@@ -243,13 +270,23 @@ method to define your own sequence of seeds execution:
     {
         public function run(): void
         {
-            $this->call('AnotherSeed');
-            $this->call('YetAnotherSeed');
+            $this->call('Another');      // Short name without 'Seed' suffix
+            $this->call('YetAnother');   // Short name without 'Seed' suffix
 
             // You can use the plugin dot syntax to call seeds from a plugin
-            $this->call('PluginName.FromPluginSeed');
+            $this->call('PluginName.FromPlugin');
         }
     }
+
+You can also use the full seed name including the ``Seed`` suffix:
+
+.. code-block:: php
+
+    $this->call('AnotherSeed');
+    $this->call('YetAnotherSeed');
+    $this->call('PluginName.FromPluginSeed');
+
+Both forms are supported and work identically.
 
 Inserting Data
 ==============
@@ -341,16 +378,23 @@ This is the easy part. To seed your database, simply use the ``migrations seed``
         $ bin/cake migrations seed
 
 By default, Migrations will execute all available seed classes. If you would like to
-run a specific class, simply pass in the name of it using the ``--seed`` parameter:
+run a specific class, simply pass in the name of it using the ``--seed`` parameter.
+You can use either the short name (without the ``Seed`` suffix) or the full name:
 
 .. code-block:: bash
 
+        $ bin/cake migrations seed --seed User
+        # or
         $ bin/cake migrations seed --seed UserSeed
+
+Both commands work identically.
 
 You can also run multiple seeds:
 
 .. code-block:: bash
 
+        $ bin/cake migrations seed --seed User --seed Permission --seed Log
+        # or with full names
         $ bin/cake migrations seed --seed UserSeed --seed PermissionSeed --seed LogSeed
 
 You can also use the `-v` parameter for more output verbosity:

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -714,7 +714,7 @@ class Manager
             }
         } else {
             // run only one seeder
-            $normalizedName = $this->normalizeSeedName($seed);
+            $normalizedName = $this->normalizeSeedName($seed, $seeds);
             if ($normalizedName !== null) {
                 $this->executeSeed($seeds[$normalizedName]);
             } else {
@@ -940,12 +940,11 @@ class Manager
      * Normalize a seed name by trying with and without the 'Seed' suffix.
      *
      * @param string $name Seed name to normalize
+     * @param array<string, \Migrations\SeedInterface> $seeds Seeds array to search in
      * @return string|null The normalized seed name, or null if not found
      */
-    protected function normalizeSeedName(string $name): ?string
+    protected function normalizeSeedName(string $name, array $seeds): ?string
     {
-        $seeds = $this->getSeeds();
-
         // Try with 'Seed' suffix first
         if (array_key_exists($name . 'Seed', $seeds)) {
             return $name . 'Seed';
@@ -971,7 +970,7 @@ class Manager
         $dependencies = $seed->getDependencies();
         if ($dependencies && $this->seeds) {
             foreach ($dependencies as $dependency) {
-                $normalizedName = $this->normalizeSeedName($dependency);
+                $normalizedName = $this->normalizeSeedName($dependency, $this->seeds);
                 if ($normalizedName !== null) {
                     $dependenciesInstances[$normalizedName] = $this->seeds[$normalizedName];
                 }

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -714,11 +714,9 @@ class Manager
             }
         } else {
             // run only one seeder
-            if (array_key_exists($seed . 'Seed', $seeds)) {
-                $seed = $seed . 'Seed';
-                $this->executeSeed($seeds[$seed]);
-            } elseif (array_key_exists($seed, $seeds)) {
-                $this->executeSeed($seeds[$seed]);
+            $normalizedName = $this->normalizeSeedName($seed);
+            if ($normalizedName !== null) {
+                $this->executeSeed($seeds[$normalizedName]);
             } else {
                 throw new InvalidArgumentException(sprintf('The seed `%s` does not exist', $seed));
             }
@@ -939,6 +937,29 @@ class Manager
     }
 
     /**
+     * Normalize a seed name by trying with and without the 'Seed' suffix.
+     *
+     * @param string $name Seed name to normalize
+     * @return string|null The normalized seed name, or null if not found
+     */
+    protected function normalizeSeedName(string $name): ?string
+    {
+        $seeds = $this->getSeeds();
+
+        // Try with 'Seed' suffix first
+        if (array_key_exists($name . 'Seed', $seeds)) {
+            return $name . 'Seed';
+        }
+
+        // Try exact name
+        if (array_key_exists($name, $seeds)) {
+            return $name;
+        }
+
+        return null;
+    }
+
+    /**
      * Get seed dependencies instances from seed dependency array
      *
      * @param \Migrations\SeedInterface $seed Seed
@@ -950,11 +971,9 @@ class Manager
         $dependencies = $seed->getDependencies();
         if ($dependencies && $this->seeds) {
             foreach ($dependencies as $dependency) {
-                foreach ($this->seeds as $seed) {
-                    $name = $seed->getName();
-                    if ($name === $dependency) {
-                        $dependenciesInstances[$name] = $seed;
-                    }
+                $normalizedName = $this->normalizeSeedName($dependency);
+                if ($normalizedName !== null) {
+                    $dependenciesInstances[$normalizedName] = $this->seeds[$normalizedName];
                 }
             }
         }

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -344,4 +344,53 @@ class SeedCommandTest extends TestCase
         $this->assertEquals('anonymous_store', $result[0]['name']);
         $this->assertEquals('other_store', $result[1]['name']);
     }
+
+    public function testSeederShortName(): void
+    {
+        $this->createTables();
+        $this->exec('migrations seed -c test --seed Numbers');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('All Done');
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $query = $connection->execute('SELECT COUNT(*) FROM numbers');
+        $this->assertEquals(1, $query->fetchColumn(0));
+    }
+
+    public function testSeederShortNameMultiple(): void
+    {
+        $this->createTables();
+        $this->exec('migrations seed -c test --source CallSeeds --seed Letters --seed NumbersCall');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('NumbersCallSeed:</info> <comment>seeding');
+        $this->assertOutputContains('LettersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('All Done');
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $query = $connection->execute('SELECT COUNT(*) FROM numbers');
+        $this->assertEquals(1, $query->fetchColumn(0));
+
+        $query = $connection->execute('SELECT COUNT(*) FROM letters');
+        $this->assertEquals(2, $query->fetchColumn(0));
+    }
+
+    public function testSeederShortNameAnonymous(): void
+    {
+        $this->createTables();
+        $this->exec('migrations seed -c test --seed AnonymousStore');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('AnonymousStoreSeed:</info> <comment>seeding');
+        $this->assertOutputContains('All Done');
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $query = $connection->execute('SELECT COUNT(*) FROM stores');
+        $this->assertEquals(2, $query->fetchColumn(0));
+    }
 }

--- a/tests/test_app/config/CallSeeds/ShortNameCallSeed.php
+++ b/tests/test_app/config/CallSeeds/ShortNameCallSeed.php
@@ -17,7 +17,7 @@ class ShortNameCallSeed extends BaseSeed
      */
     public function run(): void
     {
-        $this->call('NumbersCall');  // Short name without 'Seed' suffix
-        $this->call('Letters');       // Short name without 'Seed' suffix
+        $this->call('NumbersCall');
+        $this->call('Letters');
     }
 }

--- a/tests/test_app/config/CallSeeds/ShortNameCallSeed.php
+++ b/tests/test_app/config/CallSeeds/ShortNameCallSeed.php
@@ -1,0 +1,23 @@
+<?php
+
+use Migrations\BaseSeed;
+
+/**
+ * ShortNameCallSeed seed.
+ */
+class ShortNameCallSeed extends BaseSeed
+{
+    /**
+     * Run Method.
+     *
+     * Write your database seeder using this method.
+     *
+     * More information on writing seeders is available here:
+     * https://book.cakephp.org/migrations/5/en/seeding.html
+     */
+    public function run(): void
+    {
+        $this->call('NumbersCall');  // Short name without 'Seed' suffix
+        $this->call('Letters');       // Short name without 'Seed' suffix
+    }
+}

--- a/tests/test_app/config/ManagerSeeds/ShortNameDependencySeed.php
+++ b/tests/test_app/config/ManagerSeeds/ShortNameDependencySeed.php
@@ -1,0 +1,27 @@
+<?php
+
+use Migrations\BaseSeed;
+
+class ShortNameDependencySeed extends BaseSeed
+{
+    public function run(): void
+    {
+        $data = [
+            [
+                'body' => 'dependency_test',
+                'created' => date('Y-m-d H:i:s'),
+            ],
+        ];
+
+        $posts = $this->table('posts');
+        $posts->insert($data)->save();
+    }
+
+    public function getDependencies(): array
+    {
+        return [
+            'User',  // Short name without 'Seeder' suffix
+            'G',     // Short name without 'Seeder' suffix
+        ];
+    }
+}


### PR DESCRIPTION
Follow https://github.com/cakephp/migrations/pull/920

The full name was a thing from the old phinx days.
Within Cake we usually never reference the suffix, so it would make sense to go into that direction now a bit more officially.

This PR would support both, we could also migrate to only using the short version and requiring valid Seeds to have the Seed suffix.