### PR TITLE
Order tables in schema dump

### DIFF
--- a/src/Command/Phinx/Dump.php
+++ b/src/Command/Phinx/Dump.php
@@ -96,6 +96,8 @@ class Dump extends AbstractCommand
         ];
         $tables = $this->getTablesToBake($collection, $options);
 
+        sort($tables);
+
         $dump = [];
         if ($tables) {
             foreach ($tables as $table) {


### PR DESCRIPTION
We versioned our schema dumps to keep an eye on changes in the MySQLDB schemas.

But we noticed we get diffs across multiple dev machines from time to time because the order of the desrcibed tables is not aligned. This makes comparing them quite difficult, even in IDEs.

To unify the dumps across developer machines, this simply sorts the table names.