### PR TITLE
Make seeds a command argument.

### DIFF
--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -172,15 +172,12 @@ class SeedCommand extends Command
                 return self::CODE_SUCCESS;
             }
 
-            // Display the seeds that will be run and ask for confirmation
-            // Skip confirmation in quiet mode or non-interactive environments
-            $isInteractive = function_exists('posix_isatty') && @posix_isatty(STDIN);
-            if ($io->level() > ConsoleIo::QUIET && $isInteractive) {
+            // Skip confirmation in quiet mode
+            if ($io->level() > ConsoleIo::QUIET) {
                 $io->out('');
                 $io->out('<info>The following seeds will be executed:</info>');
                 foreach ($availableSeeds as $seed) {
                     $seedName = $seed->getName();
-                    // Remove 'Seed' suffix for display
                     if (str_ends_with($seedName, 'Seed')) {
                         $seedName = substr($seedName, 0, -4);
                     }

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -59,10 +59,9 @@ class SeedCommand extends Command
             '<info>migrations seed Users,Posts</info>',
             '<info>migrations seed --plugin Demo</info>',
             '<info>migrations seed --connection secondary</info>',
-            '<info>migrations seed -q</info> (skip confirmation prompt)',
             '',
-            'Runs all seeds if no seed names are specified. When running all seeds,',
-            'a confirmation prompt is shown unless in quiet mode (-q).',
+            'Runs all seeds if no seed names are specified. When running all seeds',
+            'in an interactive terminal, a confirmation prompt is shown.',
         ];
 
         $parser->setDescription($description)
@@ -174,8 +173,9 @@ class SeedCommand extends Command
             }
 
             // Display the seeds that will be run and ask for confirmation
-            // Skip confirmation in quiet mode
-            if ($io->level() > ConsoleIo::QUIET) {
+            // Skip confirmation in quiet mode or non-interactive environments
+            $isInteractive = function_exists('posix_isatty') && @posix_isatty(STDIN);
+            if ($io->level() > ConsoleIo::QUIET && $isInteractive) {
                 $io->out('');
                 $io->out('<info>The following seeds will be executed:</info>');
                 foreach ($availableSeeds as $seed) {

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -17,8 +17,8 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use Cake\Core\Configure;
 use Cake\Event\EventDispatcherTrait;
+use Exception;
 use Migrations\Config\ConfigInterface;
 use Migrations\Migration\ManagerFactory;
 
@@ -50,33 +50,45 @@ class SeedCommand extends Command
      */
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
-        $parser->setDescription([
+        $description = [
             'Seed the database with data',
             '',
-            'Runs a seeder script that can populate the database with data, or run mutations',
+            'Runs a seeder script that can populate the database with data, or run mutations:',
             '',
-            '<info>migrations seed --connection secondary --seed UserSeed</info>',
+            '<info>migrations seed Posts</info>',
+            '<info>migrations seed Users,Posts</info>',
+            '<info>migrations seed --plugin Demo</info>',
+            '<info>migrations seed --connection secondary</info>',
+            '<info>migrations seed -q</info> (skip confirmation prompt)',
             '',
-            'The `--seed` option can be supplied multiple times to run more than one seed',
-        ])->addOption('plugin', [
-            'short' => 'p',
-            'help' => 'The plugin to run seeds in',
-        ])->addOption('connection', [
-            'short' => 'c',
-            'help' => 'The datasource connection to use',
-            'default' => 'default',
-        ])->addOption('dry-run', [
-            'short' => 'x',
-            'help' => 'Dump queries to stdout instead of executing them',
-            'boolean' => true,
-        ])->addOption('source', [
-            'short' => 's',
-            'default' => ConfigInterface::DEFAULT_SEED_FOLDER,
-            'help' => 'The folder where your seeds are.',
-        ])->addOption('seed', [
-            'help' => 'The name of the seed that you want to run.',
-            'multiple' => true,
-        ]);
+            'Runs all seeds if no seed names are specified. When running all seeds,',
+            'a confirmation prompt is shown unless in quiet mode (-q).',
+        ];
+
+        $parser->setDescription($description)
+            ->addArgument('seed', [
+                'help' => 'The name(s) of the seed(s) to run (comma-separated for multiple). Run all seeds if not specified.',
+                'required' => false,
+            ])
+            ->addOption('plugin', [
+                'short' => 'p',
+                'help' => 'The plugin to run seeds in',
+            ])
+            ->addOption('connection', [
+                'short' => 'c',
+                'help' => 'The datasource connection to use',
+                'default' => 'default',
+            ])
+            ->addOption('dry-run', [
+                'short' => 'd',
+                'help' => 'Dump queries to stdout instead of executing them',
+                'boolean' => true,
+            ])
+            ->addOption('source', [
+                'short' => 's',
+                'default' => ConfigInterface::DEFAULT_SEED_FOLDER,
+                'help' => 'The folder where your seeds are.',
+            ]);
 
         return $parser;
     }
@@ -119,10 +131,20 @@ class SeedCommand extends Command
         $manager = $factory->createManager($io);
         $config = $manager->getConfig();
 
-        if (version_compare(Configure::version(), '5.2.0', '>=')) {
-            $seeds = (array)$args->getArrayOption('seed');
-        } else {
-            $seeds = (array)$args->getMultipleOption('seed');
+        // Get seed names from arguments
+        $seeds = [];
+        if ($args->hasArgument('seed')) {
+            $seedArg = $args->getArgument('seed');
+            if ($seedArg !== null) {
+                // Split by comma to support comma-separated list
+                $seedList = explode(',', $seedArg);
+                foreach ($seedList as $seed) {
+                    $trimmed = trim($seed);
+                    if ($trimmed !== '') {
+                        $seeds[] = $trimmed;
+                    }
+                }
+            }
         }
 
         $versionOrder = $config->getVersionOrder();
@@ -136,10 +158,53 @@ class SeedCommand extends Command
 
         $start = microtime(true);
         if (!$seeds) {
+            // Get all available seeds and ask for confirmation
+            try {
+                $availableSeeds = $manager->getSeeds();
+            } catch (Exception $e) {
+                $io->error('Failed to load seeds: ' . $e->getMessage());
+
+                return static::CODE_ERROR;
+            }
+
+            if (!$availableSeeds) {
+                $io->warning('No seeds found.');
+
+                return self::CODE_SUCCESS;
+            }
+
+            // Display the seeds that will be run and ask for confirmation
+            // Skip confirmation in quiet mode
+            if ($io->level() > ConsoleIo::QUIET) {
+                $io->out('');
+                $io->out('<info>The following seeds will be executed:</info>');
+                foreach ($availableSeeds as $seed) {
+                    $seedName = $seed->getName();
+                    // Remove 'Seed' suffix for display
+                    if (str_ends_with($seedName, 'Seed')) {
+                        $seedName = substr($seedName, 0, -4);
+                    }
+                    $io->out('  - ' . $seedName);
+                }
+                $io->out('');
+                $io->out('<warning>Note:</warning> Seeds do not track execution state. They will run');
+                $io->out('regardless of whether they have been executed before. Ensure your');
+                $io->out('seeds are idempotent or manually verify they should be (re)run.');
+                $io->out('');
+
+                // Ask for confirmation
+                $continue = $io->askChoice('Do you want to continue?', ['y', 'n'], 'n');
+                if ($continue !== 'y') {
+                    $io->warning('Seed operation aborted.');
+
+                    return self::CODE_SUCCESS;
+                }
+            }
+
             // run all the seed(ers)
             $manager->seed();
         } else {
-            // run seed(ers) specified in a comma-separated list of classes
+            // run seed(ers) specified as arguments
             foreach ($seeds as $seed) {
                 $manager->seed(trim($seed));
             }

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -58,7 +58,9 @@ class SeedCommandTest extends TestCase
         $this->exec('migrations seed --help');
         $this->assertExitSuccess();
         $this->assertOutputContains('Seed the database with data');
-        $this->assertOutputContains('migrations seed --connection secondary --seed UserSeed');
+        $this->assertOutputContains('migrations seed Posts');
+        $this->assertOutputContains('migrations seed Users,Posts');
+        $this->assertOutputContains('migrations seed -q');
     }
 
     public function testSeederEvents(): void
@@ -73,7 +75,7 @@ class SeedCommandTest extends TestCase
         });
 
         $this->createTables();
-        $this->exec('migrations seed -c test --seed NumbersSeed');
+        $this->exec('migrations seed -c test NumbersSeed');
         $this->assertExitSuccess();
 
         $this->assertSame(['Migration.beforeSeed', 'Migration.afterSeed'], $fired);
@@ -92,7 +94,7 @@ class SeedCommandTest extends TestCase
         });
 
         $this->createTables();
-        $this->exec('migrations seed -c test --seed NumbersSeed');
+        $this->exec('migrations seed -c test NumbersSeed');
         $this->assertExitError();
 
         $this->assertSame(['Migration.beforeSeed'], $fired);
@@ -102,13 +104,13 @@ class SeedCommandTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The seed `NotThere` does not exist');
-        $this->exec('migrations seed -c test --seed NotThere');
+        $this->exec('migrations seed -c test  NotThere');
     }
 
     public function testSeederOne(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --seed NumbersSeed');
+        $this->exec('migrations seed -c test NumbersSeed');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
@@ -123,7 +125,7 @@ class SeedCommandTest extends TestCase
     public function testSeederBaseSeed(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --source BaseSeeds --seed MigrationSeedNumbers');
+        $this->exec('migrations seed -c test --source BaseSeeds  MigrationSeedNumbers');
         $this->assertExitSuccess();
         $this->assertOutputContains('MigrationSeedNumbers:</info> <comment>seeding');
         $this->assertOutputContains('AnotherNumbersSeed:</info> <comment>seeding');
@@ -142,7 +144,7 @@ class SeedCommandTest extends TestCase
     public function testSeederImplicitAll(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test');
+        $this->exec('migrations seed -c test -q');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
@@ -160,13 +162,13 @@ class SeedCommandTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The seed `NotThere` does not exist');
-        $this->exec('migrations seed -c test --seed NumbersSeed --seed NotThere');
+        $this->exec('migrations seed -c test  NumbersSeed  NotThere');
     }
 
     public function testSeederMultiple(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --source CallSeeds --seed LettersSeed --seed NumbersCallSeed');
+        $this->exec('migrations seed -c test --source CallSeeds  LettersSeed  NumbersCallSeed');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('NumbersCallSeed:</info> <comment>seeding');
@@ -188,13 +190,13 @@ class SeedCommandTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The seed `LettersSeed` does not exist');
 
-        $this->exec('migrations seed -c test --source NotThere --seed LettersSeed');
+        $this->exec('migrations seed -c test --source NotThere  LettersSeed');
     }
 
     public function testSeederWithTimestampFields(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --seed StoresSeed');
+        $this->exec('migrations seed -c test  StoresSeed');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('StoresSeed:</info> <comment>seeding');
@@ -219,7 +221,7 @@ class SeedCommandTest extends TestCase
     public function testDryRunModeWarning(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --seed NumbersSeed --dry-run');
+        $this->exec('migrations seed -c test  NumbersSeed --dry-run');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
@@ -230,7 +232,7 @@ class SeedCommandTest extends TestCase
     public function testDryRunModeShortOption(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --seed NumbersSeed -x');
+        $this->exec('migrations seed -c test  NumbersSeed -d');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
@@ -246,7 +248,7 @@ class SeedCommandTest extends TestCase
         $connection = ConnectionManager::get('test');
         $initialCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
 
-        $this->exec('migrations seed -c test --seed NumbersSeed --dry-run');
+        $this->exec('migrations seed -c test  NumbersSeed --dry-run');
         $this->assertExitSuccess();
 
         $finalCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
@@ -256,7 +258,7 @@ class SeedCommandTest extends TestCase
     public function testDryRunModeMultipleSeeds(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --source CallSeeds --seed LettersSeed --seed NumbersCallSeed --dry-run');
+        $this->exec('migrations seed -c test --source CallSeeds  LettersSeed  NumbersCallSeed --dry-run');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
@@ -281,7 +283,7 @@ class SeedCommandTest extends TestCase
         $connection = ConnectionManager::get('test');
         $initialCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
 
-        $this->exec('migrations seed -c test --dry-run');
+        $this->exec('migrations seed -c test --dry-run -q');
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
@@ -302,7 +304,7 @@ class SeedCommandTest extends TestCase
         });
 
         $this->createTables();
-        $this->exec('migrations seed -c test --seed NumbersSeed --dry-run');
+        $this->exec('migrations seed -c test  NumbersSeed --dry-run');
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
 
@@ -317,7 +319,7 @@ class SeedCommandTest extends TestCase
         $connection = ConnectionManager::get('test');
         $initialCount = $connection->execute('SELECT COUNT(*) FROM stores')->fetchColumn(0);
 
-        $this->exec('migrations seed -c test --seed StoresSeed --dry-run');
+        $this->exec('migrations seed -c test  StoresSeed --dry-run');
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
         $this->assertOutputContains('StoresSeed:</info> <comment>seeding');
@@ -329,7 +331,7 @@ class SeedCommandTest extends TestCase
     public function testSeederAnonymousClass(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --seed AnonymousStoreSeed');
+        $this->exec('migrations seed -c test  AnonymousStoreSeed');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('AnonymousStoreSeed:</info> <comment>seeding');
@@ -348,7 +350,7 @@ class SeedCommandTest extends TestCase
     public function testSeederShortName(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --seed Numbers');
+        $this->exec('migrations seed -c test  Numbers');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
@@ -363,7 +365,7 @@ class SeedCommandTest extends TestCase
     public function testSeederShortNameMultiple(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --source CallSeeds --seed Letters --seed NumbersCall');
+        $this->exec('migrations seed -c test --source CallSeeds  Letters  NumbersCall');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('NumbersCallSeed:</info> <comment>seeding');
@@ -382,7 +384,7 @@ class SeedCommandTest extends TestCase
     public function testSeederShortNameAnonymous(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --seed AnonymousStore');
+        $this->exec('migrations seed -c test  AnonymousStore');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('AnonymousStoreSeed:</info> <comment>seeding');
@@ -391,6 +393,92 @@ class SeedCommandTest extends TestCase
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('test');
         $query = $connection->execute('SELECT COUNT(*) FROM stores');
+        $this->assertEquals(2, $query->fetchColumn(0));
+    }
+
+    public function testSeederAllWithConfirmation(): void
+    {
+        $this->createTables();
+        $this->exec('migrations seed -c test', ['y']);
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('The following seeds will be executed:');
+        $this->assertOutputContains('  - Numbers');
+        $this->assertOutputContains('Note:');
+        $this->assertOutputContains('Seeds do not track execution state');
+        $this->assertOutputContains('Do you want to continue?');
+        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('All Done');
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $query = $connection->execute('SELECT COUNT(*) FROM numbers');
+        $this->assertEquals(1, $query->fetchColumn(0));
+    }
+
+    public function testSeederAllWithConfirmationAborted(): void
+    {
+        $this->createTables();
+        $this->exec('migrations seed -c test', ['n']);
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('The following seeds will be executed:');
+        $this->assertOutputContains('  - Numbers');
+        $this->assertOutputContains('Do you want to continue?');
+        $this->assertOutputContains('Seed operation aborted');
+        $this->assertOutputNotContains('NumbersSeed:</info> <comment>seeding');
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $query = $connection->execute('SELECT COUNT(*) FROM numbers');
+        $this->assertEquals(0, $query->fetchColumn(0));
+    }
+
+    public function testSeederAllWithQuietModeSkipsConfirmation(): void
+    {
+        $this->createTables();
+        $this->exec('migrations seed -c test -q');
+
+        $this->assertExitSuccess();
+        $this->assertOutputNotContains('The following seeds will be executed:');
+        $this->assertOutputNotContains('Do you want to continue?');
+        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('All Done');
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $query = $connection->execute('SELECT COUNT(*) FROM numbers');
+        $this->assertEquals(1, $query->fetchColumn(0));
+    }
+
+    public function testSeederSpecificSeedSkipsConfirmation(): void
+    {
+        $this->createTables();
+        $this->exec('migrations seed -c test NumbersSeed');
+
+        $this->assertExitSuccess();
+        $this->assertOutputNotContains('The following seeds will be executed:');
+        $this->assertOutputNotContains('Do you want to continue?');
+        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('All Done');
+    }
+
+    public function testSeederCommaSeparated(): void
+    {
+        $this->createTables();
+        $this->exec('migrations seed -c test --source CallSeeds Letters,NumbersCall');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('NumbersCallSeed:</info> <comment>seeding');
+        $this->assertOutputContains('LettersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('All Done');
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $query = $connection->execute('SELECT COUNT(*) FROM numbers');
+        $this->assertEquals(1, $query->fetchColumn(0));
+
+        $query = $connection->execute('SELECT COUNT(*) FROM letters');
         $this->assertEquals(2, $query->fetchColumn(0));
     }
 }

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -104,7 +104,7 @@ class SeedCommandTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The seed `NotThere` does not exist');
-        $this->exec('migrations seed -c test  NotThere');
+        $this->exec('migrations seed -c test NotThere');
     }
 
     public function testSeederOne(): void
@@ -125,7 +125,7 @@ class SeedCommandTest extends TestCase
     public function testSeederBaseSeed(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --source BaseSeeds  MigrationSeedNumbers');
+        $this->exec('migrations seed -c test --source BaseSeeds MigrationSeedNumbers');
         $this->assertExitSuccess();
         $this->assertOutputContains('MigrationSeedNumbers:</info> <comment>seeding');
         $this->assertOutputContains('AnotherNumbersSeed:</info> <comment>seeding');
@@ -144,7 +144,7 @@ class SeedCommandTest extends TestCase
     public function testSeederImplicitAll(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test -q');
+        $this->exec('migrations seed -c test');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
@@ -162,13 +162,13 @@ class SeedCommandTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The seed `NotThere` does not exist');
-        $this->exec('migrations seed -c test  NumbersSeed  NotThere');
+        $this->exec('migrations seed -c test NumbersSeed,NotThere');
     }
 
     public function testSeederMultiple(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --source CallSeeds  LettersSeed  NumbersCallSeed');
+        $this->exec('migrations seed -c test --source CallSeeds LettersSeed,NumbersCallSeed');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('NumbersCallSeed:</info> <comment>seeding');
@@ -190,13 +190,13 @@ class SeedCommandTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The seed `LettersSeed` does not exist');
 
-        $this->exec('migrations seed -c test --source NotThere  LettersSeed');
+        $this->exec('migrations seed -c test --source NotThere LettersSeed');
     }
 
     public function testSeederWithTimestampFields(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test  StoresSeed');
+        $this->exec('migrations seed -c test StoresSeed');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('StoresSeed:</info> <comment>seeding');
@@ -221,7 +221,7 @@ class SeedCommandTest extends TestCase
     public function testDryRunModeWarning(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test  NumbersSeed --dry-run');
+        $this->exec('migrations seed -c test NumbersSeed --dry-run');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
@@ -232,7 +232,7 @@ class SeedCommandTest extends TestCase
     public function testDryRunModeShortOption(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test  NumbersSeed -d');
+        $this->exec('migrations seed -c test NumbersSeed -d');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
@@ -248,7 +248,7 @@ class SeedCommandTest extends TestCase
         $connection = ConnectionManager::get('test');
         $initialCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
 
-        $this->exec('migrations seed -c test  NumbersSeed --dry-run');
+        $this->exec('migrations seed -c test NumbersSeed --dry-run');
         $this->assertExitSuccess();
 
         $finalCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
@@ -258,7 +258,7 @@ class SeedCommandTest extends TestCase
     public function testDryRunModeMultipleSeeds(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --source CallSeeds  LettersSeed  NumbersCallSeed --dry-run');
+        $this->exec('migrations seed -c test --source CallSeeds LettersSeed,NumbersCallSeed --dry-run');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
@@ -283,7 +283,7 @@ class SeedCommandTest extends TestCase
         $connection = ConnectionManager::get('test');
         $initialCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
 
-        $this->exec('migrations seed -c test --dry-run -q');
+        $this->exec('migrations seed -c test --dry-run');
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
@@ -304,7 +304,7 @@ class SeedCommandTest extends TestCase
         });
 
         $this->createTables();
-        $this->exec('migrations seed -c test  NumbersSeed --dry-run');
+        $this->exec('migrations seed -c test NumbersSeed --dry-run');
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
 
@@ -319,7 +319,7 @@ class SeedCommandTest extends TestCase
         $connection = ConnectionManager::get('test');
         $initialCount = $connection->execute('SELECT COUNT(*) FROM stores')->fetchColumn(0);
 
-        $this->exec('migrations seed -c test  StoresSeed --dry-run');
+        $this->exec('migrations seed -c test StoresSeed --dry-run');
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
         $this->assertOutputContains('StoresSeed:</info> <comment>seeding');
@@ -331,7 +331,7 @@ class SeedCommandTest extends TestCase
     public function testSeederAnonymousClass(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test  AnonymousStoreSeed');
+        $this->exec('migrations seed -c test AnonymousStoreSeed');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('AnonymousStoreSeed:</info> <comment>seeding');
@@ -350,7 +350,7 @@ class SeedCommandTest extends TestCase
     public function testSeederShortName(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test  Numbers');
+        $this->exec('migrations seed -c test Numbers');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
@@ -365,7 +365,7 @@ class SeedCommandTest extends TestCase
     public function testSeederShortNameMultiple(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test --source CallSeeds  Letters  NumbersCall');
+        $this->exec('migrations seed -c test --source CallSeeds Letters,NumbersCall');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('NumbersCallSeed:</info> <comment>seeding');
@@ -384,7 +384,7 @@ class SeedCommandTest extends TestCase
     public function testSeederShortNameAnonymous(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test  AnonymousStore');
+        $this->exec('migrations seed -c test AnonymousStore');
 
         $this->assertExitSuccess();
         $this->assertOutputContains('AnonymousStoreSeed:</info> <comment>seeding');
@@ -396,48 +396,13 @@ class SeedCommandTest extends TestCase
         $this->assertEquals(2, $query->fetchColumn(0));
     }
 
-    public function testSeederAllWithConfirmation(): void
-    {
-        $this->createTables();
-        $this->exec('migrations seed -c test', ['y']);
-
-        $this->assertExitSuccess();
-        $this->assertOutputContains('The following seeds will be executed:');
-        $this->assertOutputContains('  - Numbers');
-        $this->assertOutputContains('Note:');
-        $this->assertOutputContains('Seeds do not track execution state');
-        $this->assertOutputContains('Do you want to continue?');
-        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
-        $this->assertOutputContains('All Done');
-
-        /** @var \Cake\Database\Connection $connection */
-        $connection = ConnectionManager::get('test');
-        $query = $connection->execute('SELECT COUNT(*) FROM numbers');
-        $this->assertEquals(1, $query->fetchColumn(0));
-    }
-
-    public function testSeederAllWithConfirmationAborted(): void
-    {
-        $this->createTables();
-        $this->exec('migrations seed -c test', ['n']);
-
-        $this->assertExitSuccess();
-        $this->assertOutputContains('The following seeds will be executed:');
-        $this->assertOutputContains('  - Numbers');
-        $this->assertOutputContains('Do you want to continue?');
-        $this->assertOutputContains('Seed operation aborted');
-        $this->assertOutputNotContains('NumbersSeed:</info> <comment>seeding');
-
-        /** @var \Cake\Database\Connection $connection */
-        $connection = ConnectionManager::get('test');
-        $query = $connection->execute('SELECT COUNT(*) FROM numbers');
-        $this->assertEquals(0, $query->fetchColumn(0));
-    }
 
     public function testSeederAllWithQuietModeSkipsConfirmation(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test -q');
+        // In test environment (non-TTY), confirmation is automatically skipped
+        // This test verifies that seeds run without prompting
+        $this->exec('migrations seed -c test');
 
         $this->assertExitSuccess();
         $this->assertOutputNotContains('The following seeds will be executed:');

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -143,11 +143,11 @@ class SeedCommandTest extends TestCase
     public function testSeederImplicitAll(): void
     {
         $this->createTables();
-        $this->exec('migrations seed -c test');
+        $this->exec('migrations seed -c test -q');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
-        $this->assertOutputContains('All Done');
+        $this->assertOutputNotContains('The following seeds will be executed:');
+        $this->assertOutputNotContains('Do you want to continue?');
 
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('test');
@@ -282,10 +282,8 @@ class SeedCommandTest extends TestCase
         $connection = ConnectionManager::get('test');
         $initialCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
 
-        $this->exec('migrations seed -c test --dry-run');
+        $this->exec('migrations seed -c test --dry-run -q');
         $this->assertExitSuccess();
-        $this->assertOutputContains('DRY-RUN mode enabled');
-        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
 
         $finalCount = $connection->execute('SELECT COUNT(*) FROM numbers')->fetchColumn(0);
         $this->assertEquals($initialCount, $finalCount, 'Dry-run mode should not modify database when running all seeds');
@@ -398,15 +396,12 @@ class SeedCommandTest extends TestCase
     public function testSeederAllWithQuietModeSkipsConfirmation(): void
     {
         $this->createTables();
-        // In test environment (non-TTY), confirmation is automatically skipped
-        // This test verifies that seeds run without prompting
-        $this->exec('migrations seed -c test');
+        // Quiet mode should skip confirmation prompt
+        $this->exec('migrations seed -c test -q');
 
         $this->assertExitSuccess();
         $this->assertOutputNotContains('The following seeds will be executed:');
         $this->assertOutputNotContains('Do you want to continue?');
-        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
-        $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('test');

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -10,7 +10,6 @@ use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use ReflectionProperty;
 
 class SeedCommandTest extends TestCase
 {

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -60,7 +60,6 @@ class SeedCommandTest extends TestCase
         $this->assertOutputContains('Seed the database with data');
         $this->assertOutputContains('migrations seed Posts');
         $this->assertOutputContains('migrations seed Users,Posts');
-        $this->assertOutputContains('migrations seed -q');
     }
 
     public function testSeederEvents(): void
@@ -395,7 +394,6 @@ class SeedCommandTest extends TestCase
         $query = $connection->execute('SELECT COUNT(*) FROM stores');
         $this->assertEquals(2, $query->fetchColumn(0));
     }
-
 
     public function testSeederAllWithQuietModeSkipsConfirmation(): void
     {

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -38,19 +38,11 @@ class SeedCommandTest extends TestCase
         $connection->execute('DROP TABLE IF EXISTS stores');
     }
 
-    protected function resetOutput(): void
-    {
-        if ($this->_out) {
-            $property = new ReflectionProperty($this->_out, '_out');
-            $property->setValue($this->_out, []);
-        }
-    }
-
     protected function createTables(): void
     {
         $this->exec('migrations migrate -c test -s TestsMigrations --no-lock');
         $this->assertExitSuccess();
-        $this->resetOutput();
+        $this->_in = null;
     }
 
     public function testHelp(): void
@@ -402,6 +394,22 @@ class SeedCommandTest extends TestCase
         $this->assertExitSuccess();
         $this->assertOutputNotContains('The following seeds will be executed:');
         $this->assertOutputNotContains('Do you want to continue?');
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $query = $connection->execute('SELECT COUNT(*) FROM numbers');
+        $this->assertEquals(1, $query->fetchColumn(0));
+    }
+
+    public function testSeederAllHasConfirmation(): void
+    {
+        $this->createTables();
+        // Confirm run all.
+        $this->exec('migrations seed -c test', ['y']);
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('The following seeds will be executed:');
+        $this->assertOutputContains('Do you want to continue?');
 
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('test');


### PR DESCRIPTION
Seeds cleanup

  Modernized the migrations seed command to use a cleaner argument-based syntax instead of options, added safety confirmations, and improved the overall user experience.

  Key Improvements

  1. Simpler Syntax

  - Old: migrations seed --seed Users --seed Posts
  - New: migrations seed Users,Posts

  2. Safety First

  When running all seeds without arguments, users now see:
  - List of seeds that will execute
  - Warning that seeds don't track execution state
  - Confirmation prompt (default: 'n' to prevent accidents)

  3. Automation Support

  - Use -q (quiet mode) to skip confirmation
  - Changed dry-run short option from -x to -d (more intuitive)

  4. Cleaner Display

  - Better help documentation with practical examples
