### PR TITLE
insertOrSkip() for seeds.

### DIFF
--- a/src/BaseSeed.php
+++ b/src/BaseSeed.php
@@ -184,6 +184,16 @@ class BaseSeed implements SeedInterface
     /**
      * {@inheritDoc}
      */
+    public function insertOrSkip(string $tableName, array $data): void
+    {
+        // convert to table object
+        $table = new Table($tableName, [], $this->getAdapter());
+        $table->insertOrSkip($data)->save();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function hasTable(string $tableName): bool
     {
         return $this->getAdapter()->hasTable($tableName);

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -768,9 +768,9 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
      */
     protected function generateBulkInsertSql(TableMetadata $table, array $rows, ?InsertMode $mode = null): string
     {
-        $sql = $this->getInsertPrefix($mode);
-        $sql .= sprintf(
-            ' INTO %s ',
+        $sql = sprintf(
+            '%s INTO %s ',
+            $this->getInsertPrefix($mode),
             $this->quoteTableName($table->getName()),
         );
         $current = current($rows);

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -632,9 +632,9 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
      */
     protected function generateInsertSql(TableMetadata $table, array $row, ?InsertMode $mode = null): string
     {
-        $sql = $this->getInsertPrefix($mode);
-        $sql .= sprintf(
-            ' INTO %s ',
+        $sql = sprintf(
+            '%s INTO %s ',
+            $this->getInsertPrefix($mode),
             $this->quoteTableName($table->getName()),
         );
         $columns = array_keys($row);

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -35,6 +35,7 @@ use Migrations\Db\Action\RemoveColumn;
 use Migrations\Db\Action\RenameColumn;
 use Migrations\Db\Action\RenameTable;
 use Migrations\Db\AlterInstructions;
+use Migrations\Db\InsertMode;
 use Migrations\Db\Literal;
 use Migrations\Db\Table;
 use Migrations\Db\Table\CheckConstraint;
@@ -600,9 +601,9 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     /**
      * @inheritDoc
      */
-    public function insert(TableMetadata $table, array $row): void
+    public function insert(TableMetadata $table, array $row, ?InsertMode $mode = null): void
     {
-        $sql = $this->generateInsertSql($table, $row);
+        $sql = $this->generateInsertSql($table, $row, $mode);
 
         if ($this->isDryRunEnabled()) {
             $this->io->out($sql);
@@ -626,12 +627,14 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
      *
      * @param \Migrations\Db\Table\TableMetadata $table The table to insert into
      * @param array $row The row to insert
+     * @param \Migrations\Db\InsertMode|null $mode Insert mode
      * @return string
      */
-    protected function generateInsertSql(TableMetadata $table, array $row): string
+    protected function generateInsertSql(TableMetadata $table, array $row, ?InsertMode $mode = null): string
     {
-        $sql = sprintf(
-            'INSERT INTO %s ',
+        $sql = $this->getInsertPrefix($mode);
+        $sql .= sprintf(
+            ' INTO %s ',
             $this->quoteTableName($table->getName()),
         );
         $columns = array_keys($row);
@@ -660,6 +663,21 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
 
             return $sql;
         }
+    }
+
+    /**
+     * Get the INSERT prefix based on insert mode and database type.
+     *
+     * @param \Migrations\Db\InsertMode|null $mode Insert mode
+     * @return string
+     */
+    protected function getInsertPrefix(?InsertMode $mode = null): string
+    {
+        if ($mode === InsertMode::IGNORE) {
+            return 'INSERT IGNORE';
+        }
+
+        return 'INSERT';
     }
 
     /**
@@ -709,9 +727,9 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     /**
      * @inheritDoc
      */
-    public function bulkinsert(TableMetadata $table, array $rows): void
+    public function bulkinsert(TableMetadata $table, array $rows, ?InsertMode $mode = null): void
     {
-        $sql = $this->generateBulkInsertSql($table, $rows);
+        $sql = $this->generateBulkInsertSql($table, $rows, $mode);
 
         if ($this->isDryRunEnabled()) {
             $this->io->out($sql);
@@ -745,12 +763,14 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
      *
      * @param \Migrations\Db\Table\TableMetadata $table The table to insert into
      * @param array $rows The rows to insert
+     * @param \Migrations\Db\InsertMode|null $mode Insert mode
      * @return string
      */
-    protected function generateBulkInsertSql(TableMetadata $table, array $rows): string
+    protected function generateBulkInsertSql(TableMetadata $table, array $rows, ?InsertMode $mode = null): string
     {
-        $sql = sprintf(
-            'INSERT INTO %s ',
+        $sql = $this->getInsertPrefix($mode);
+        $sql .= sprintf(
+            ' INTO %s ',
             $this->quoteTableName($table->getName()),
         );
         $current = current($rows);

--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -16,6 +16,7 @@ use Cake\Database\Query\InsertQuery;
 use Cake\Database\Query\SelectQuery;
 use Cake\Database\Query\UpdateQuery;
 use Cake\Database\Schema\TableSchemaInterface;
+use Migrations\Db\InsertMode;
 use Migrations\Db\Table\CheckConstraint;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\TableMetadata;
@@ -313,18 +314,20 @@ interface AdapterInterface
      *
      * @param \Migrations\Db\Table\TableMetadata $table Table where to insert data
      * @param array $row Row
+     * @param \Migrations\Db\InsertMode|null $mode Insert mode
      * @return void
      */
-    public function insert(TableMetadata $table, array $row): void;
+    public function insert(TableMetadata $table, array $row, ?InsertMode $mode = null): void;
 
     /**
      * Inserts data into a table in a bulk.
      *
      * @param \Migrations\Db\Table\TableMetadata $table Table where to insert data
      * @param array $rows Rows
+     * @param \Migrations\Db\InsertMode|null $mode Insert mode
      * @return void
      */
-    public function bulkinsert(TableMetadata $table, array $rows): void;
+    public function bulkinsert(TableMetadata $table, array $rows, ?InsertMode $mode = null): void;
 
     /**
      * Quotes a table name for use in a query.

--- a/src/Db/Adapter/AdapterWrapper.php
+++ b/src/Db/Adapter/AdapterWrapper.php
@@ -15,6 +15,7 @@ use Cake\Database\Query\DeleteQuery;
 use Cake\Database\Query\InsertQuery;
 use Cake\Database\Query\SelectQuery;
 use Cake\Database\Query\UpdateQuery;
+use Migrations\Db\InsertMode;
 use Migrations\Db\Table\CheckConstraint;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\TableMetadata;
@@ -136,17 +137,17 @@ abstract class AdapterWrapper implements WrapperInterface
     /**
      * @inheritDoc
      */
-    public function insert(TableMetadata $table, array $row): void
+    public function insert(TableMetadata $table, array $row, ?InsertMode $mode = null): void
     {
-        $this->getAdapter()->insert($table, $row);
+        $this->getAdapter()->insert($table, $row, $mode);
     }
 
     /**
      * @inheritDoc
      */
-    public function bulkinsert(TableMetadata $table, array $rows): void
+    public function bulkinsert(TableMetadata $table, array $rows, ?InsertMode $mode = null): void
     {
-        $this->getAdapter()->bulkinsert($table, $rows);
+        $this->getAdapter()->bulkinsert($table, $rows, $mode);
     }
 
     /**

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -276,8 +276,8 @@ class MysqlAdapter extends AbstractAdapter
      * Apply MySQL specific translations between the values using migrations constants/types
      * and the cakephp/database constants. Over time, these can be aligned.
      *
-     * @param array $data The raw column data.
-     * @return array Modified column data.
+     * @param array<string, mixed> $data The raw column data.
+     * @return array<string, mixed> Modified column data.
      */
     protected function mapColumnData(array $data): array
     {

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -14,6 +14,7 @@ use Cake\I18n\Date;
 use Cake\I18n\DateTime;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
+use Migrations\Db\InsertMode;
 use Migrations\Db\Literal;
 use Migrations\Db\Table\CheckConstraint;
 use Migrations\Db\Table\Column;
@@ -205,8 +206,8 @@ class PostgresAdapter extends AbstractAdapter
      * Apply postgres specific translations between the values using migrations constants/types
      * and the cakephp/database constants. Over time, these can be aligned.
      *
-     * @param array $data The raw column data.
-     * @return array Modified column data.
+     * @param array<string, mixed> $data The raw column data.
+     * @return array<string, mixed> Modified column data.
      */
     protected function mapColumnData(array $data): array
     {
@@ -1152,7 +1153,7 @@ class PostgresAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    public function insert(TableMetadata $table, array $row): void
+    public function insert(TableMetadata $table, array $row, ?InsertMode $mode = null): void
     {
         $sql = sprintf(
             'INSERT INTO %s ',
@@ -1172,8 +1173,10 @@ class PostgresAdapter extends AbstractAdapter
             $override = self::OVERRIDE_SYSTEM_VALUE . ' ';
         }
 
+        $conflictClause = $this->getConflictClause($mode);
+
         if ($this->isDryRunEnabled()) {
-            $sql .= ' ' . $override . 'VALUES (' . implode(', ', array_map($this->quoteValue(...), $row)) . ');';
+            $sql .= ' ' . $override . 'VALUES (' . implode(', ', array_map($this->quoteValue(...), $row)) . ')' . $conflictClause . ';';
             $this->io->out($sql);
         } else {
             $values = [];
@@ -1188,7 +1191,7 @@ class PostgresAdapter extends AbstractAdapter
                     $vals[] = $value;
                 }
             }
-            $sql .= ' ' . $override . 'VALUES (' . implode(',', $values) . ')';
+            $sql .= ' ' . $override . 'VALUES (' . implode(',', $values) . ')' . $conflictClause;
             $this->getConnection()->execute($sql, $vals);
         }
     }
@@ -1196,7 +1199,7 @@ class PostgresAdapter extends AbstractAdapter
     /**
      * @inheritDoc
      */
-    public function bulkinsert(TableMetadata $table, array $rows): void
+    public function bulkinsert(TableMetadata $table, array $rows, ?InsertMode $mode = null): void
     {
         $sql = sprintf(
             'INSERT INTO %s ',
@@ -1213,11 +1216,13 @@ class PostgresAdapter extends AbstractAdapter
 
         $sql .= '(' . implode(', ', array_map($this->quoteColumnName(...), $keys)) . ') ' . $override . 'VALUES ';
 
+        $conflictClause = $this->getConflictClause($mode);
+
         if ($this->isDryRunEnabled()) {
             $values = array_map(function ($row) {
                 return '(' . implode(', ', array_map($this->quoteValue(...), $row)) . ')';
             }, $rows);
-            $sql .= implode(', ', $values) . ';';
+            $sql .= implode(', ', $values) . $conflictClause . ';';
             $this->io->out($sql);
         } else {
             $vals = [];
@@ -1245,9 +1250,24 @@ class PostgresAdapter extends AbstractAdapter
                 $query = '(' . implode(', ', $values) . ')';
                 $queries[] = $query;
             }
-            $sql .= implode(',', $queries);
+            $sql .= implode(',', $queries) . $conflictClause;
             $this->getConnection()->execute($sql, $vals);
         }
+    }
+
+    /**
+     * Get the ON CONFLICT clause based on insert mode.
+     *
+     * @param \Migrations\Db\InsertMode|null $mode Insert mode
+     * @return string
+     */
+    protected function getConflictClause(?InsertMode $mode = null): string
+    {
+        if ($mode === InsertMode::IGNORE) {
+            return ' ON CONFLICT DO NOTHING';
+        }
+
+        return '';
     }
 
     /**

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -14,6 +14,7 @@ use Cake\Database\Schema\TableSchemaInterface;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
 use Migrations\Db\Expression;
+use Migrations\Db\InsertMode;
 use Migrations\Db\Literal;
 use Migrations\Db\Table\CheckConstraint;
 use Migrations\Db\Table\Column;
@@ -1685,5 +1686,17 @@ PCRE_PATTERN;
         }
 
         return $def;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getInsertPrefix(?InsertMode $mode = null): string
+    {
+        if ($mode === InsertMode::IGNORE) {
+            return 'INSERT OR IGNORE';
+        }
+
+        return 'INSERT';
     }
 }

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -1113,7 +1113,7 @@ SQL;
     protected function getInsertPrefix(?InsertMode $mode = null): string
     {
         if ($mode === InsertMode::IGNORE) {
-            throw new BadMethodCallException('INSERT IGNORE is not supported for SQL Server. Use a MERGE statement or check for existence before inserting.');
+            throw new BadMethodCallException('INSERT IGNORE is not supported for SQL Server');
         }
 
         return parent::getInsertPrefix($mode);

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -14,6 +14,7 @@ use Cake\I18n\Date;
 use Cake\I18n\DateTime;
 use InvalidArgumentException;
 use Migrations\Db\AlterInstructions;
+use Migrations\Db\InsertMode;
 use Migrations\Db\Literal;
 use Migrations\Db\Table\CheckConstraint;
 use Migrations\Db\Table\Column;
@@ -999,9 +1000,9 @@ SQL;
     /**
      * @inheritDoc
      */
-    public function insert(TableMetadata $table, array $row): void
+    public function insert(TableMetadata $table, array $row, ?InsertMode $mode = null): void
     {
-        $sql = $this->generateInsertSql($table, $row);
+        $sql = $this->generateInsertSql($table, $row, $mode);
 
         $sql = $this->updateSQLForIdentityInsert($table->getName(), $sql);
 
@@ -1025,9 +1026,9 @@ SQL;
     /**
      * @inheritDoc
      */
-    public function bulkinsert(TableMetadata $table, array $rows): void
+    public function bulkinsert(TableMetadata $table, array $rows, ?InsertMode $mode = null): void
     {
-        $sql = $this->generateBulkInsertSql($table, $rows);
+        $sql = $this->generateBulkInsertSql($table, $rows, $mode);
 
         $sql = $this->updateSQLForIdentityInsert($table->getName(), $sql);
 
@@ -1104,5 +1105,17 @@ SQL;
     protected function getDropCheckConstraintInstructions(string $tableName, string $constraintName): AlterInstructions
     {
         throw new BadMethodCallException('Check constraints are not yet implemented for SQL Server adapter');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getInsertPrefix(?InsertMode $mode = null): string
+    {
+        if ($mode === InsertMode::IGNORE) {
+            throw new BadMethodCallException('INSERT IGNORE is not supported for SQL Server. Use a MERGE statement or check for existence before inserting.');
+        }
+
+        return parent::getInsertPrefix($mode);
     }
 }

--- a/src/Db/Adapter/TimedOutputAdapter.php
+++ b/src/Db/Adapter/TimedOutputAdapter.php
@@ -10,6 +10,7 @@ namespace Migrations\Db\Adapter;
 
 use BadMethodCallException;
 use Cake\Console\ConsoleIo;
+use Migrations\Db\InsertMode;
 use Migrations\Db\Table\Column;
 use Migrations\Db\Table\ForeignKey;
 use Migrations\Db\Table\Index;
@@ -83,22 +84,22 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
     /**
      * @inheritDoc
      */
-    public function insert(TableMetadata $table, array $row): void
+    public function insert(TableMetadata $table, array $row, ?InsertMode $mode = null): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand('insert', [$table->getName()]);
-        parent::insert($table, $row);
+        parent::insert($table, $row, $mode);
         $end();
     }
 
     /**
      * @inheritDoc
      */
-    public function bulkinsert(TableMetadata $table, array $rows): void
+    public function bulkinsert(TableMetadata $table, array $rows, ?InsertMode $mode = null): void
     {
         $end = $this->startCommandTimer();
         $this->writeCommand('bulkinsert', [$table->getName()]);
-        parent::bulkinsert($table, $rows);
+        parent::bulkinsert($table, $rows, $mode);
         $end();
     }
 

--- a/src/Db/InsertMode.php
+++ b/src/Db/InsertMode.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Migrations\Db;
+
+/**
+ * Insert mode enumeration
+ *
+ * Defines different insertion strategies for handling duplicate key conflicts.
+ */
+enum InsertMode: string
+{
+    /**
+     * Standard INSERT - fails on duplicate key conflicts
+     */
+    case INSERT = 'insert';
+
+    /**
+     * INSERT IGNORE - skips rows that would cause duplicate key conflicts
+     *
+     * - MySQL: INSERT IGNORE
+     * - PostgreSQL: ON CONFLICT DO NOTHING
+     * - SQLite: INSERT OR IGNORE
+     */
+    case IGNORE = 'ignore';
+}

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -67,6 +67,13 @@ class Table
     protected array $data = [];
 
     /**
+     * Insert mode for data operations
+     *
+     * @var \Migrations\Db\InsertMode|null
+     */
+    protected ?InsertMode $insertMode = null;
+
+    /**
      * Primary key for this table.
      * Can either be a string or an array in case of composite
      * primary key.
@@ -262,7 +269,7 @@ class Table
     /**
      * Sets an array of data to be inserted.
      *
-     * @param array $data Data
+     * @param array<string, mixed> $data Data
      * @return $this
      */
     public function setData(array $data)
@@ -625,6 +632,21 @@ class Table
     }
 
     /**
+     * Insert data into the table, skipping rows that would cause duplicate key conflicts.
+     *
+     * This method is idempotent and safe to run multiple times.
+     *
+     * @param array $data array of data in the same format as insert()
+     * @return $this
+     */
+    public function insertOrSkip(array $data)
+    {
+        $this->insertMode = InsertMode::IGNORE;
+
+        return $this->insert($data);
+    }
+
+    /**
      * Creates a table from the object instance.
      *
      * @return void
@@ -743,10 +765,10 @@ class Table
         }
 
         if ($bulk) {
-            $this->getAdapter()->bulkinsert($this->table, $this->getData());
+            $this->getAdapter()->bulkinsert($this->table, $this->getData(), $this->insertMode);
         } else {
             foreach ($this->getData() as $row) {
-                $this->getAdapter()->insert($this->table, $row);
+                $this->getAdapter()->insert($this->table, $row, $this->insertMode);
             }
         }
 

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -773,6 +773,7 @@ class Table
         }
 
         $this->resetData();
+        $this->insertMode = null;
     }
 
     /**

--- a/src/SeedInterface.php
+++ b/src/SeedInterface.php
@@ -143,6 +143,19 @@ interface SeedInterface
     public function insert(string $tableName, array $data): void;
 
     /**
+     * Insert data into a table, skipping rows that would cause duplicate key conflicts.
+     *
+     * This method is idempotent and safe to run multiple times.
+     * Uses INSERT IGNORE (MySQL), ON CONFLICT DO NOTHING (PostgreSQL),
+     * or INSERT OR IGNORE (SQLite).
+     *
+     * @param string $tableName Table name
+     * @param array $data Data
+     * @return void
+     */
+    public function insertOrSkip(string $tableName, array $data): void;
+
+    /**
      * Checks to see if a table exists.
      *
      * @param string $tableName Table name

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -647,7 +647,7 @@ class MigrationHelper extends Helper
      * Render an element.
      *
      * @param string $name The name of the element to render.
-     * @param array $data Additional data for the element.
+     * @param array<string, mixed> $data Additional data for the element.
      * @return ?string
      */
     public function element(string $name, array $data): ?string

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -2446,4 +2446,70 @@ OUTPUT;
             'CREATE TABLE should contain DECIMAL(65,0) with scale=0 properly defined',
         );
     }
+
+    public function testInsertOrSkipWithDuplicates()
+    {
+        $table = new Table('users', [], $this->adapter);
+        $table->addColumn('email', 'string', ['limit' => 255])
+            ->addColumn('name', 'string')
+            ->addIndex('email', ['unique' => true])
+            ->create();
+
+        // First insert
+        $table->insertOrSkip([
+            ['email' => 'test@example.com', 'name' => 'John'],
+        ])->save();
+
+        // Duplicate - should be skipped
+        $table->insertOrSkip([
+            ['email' => 'test@example.com', 'name' => 'Jane'],
+        ])->save();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM users');
+        $this->assertCount(1, $rows);
+        $this->assertEquals('John', $rows[0]['name']);
+    }
+
+    public function testBulkinsertOrSkipWithDuplicates()
+    {
+        $table = new Table('products', [], $this->adapter);
+        $table->addColumn('sku', 'string', ['limit' => 50])
+            ->addColumn('price', 'decimal', ['precision' => 10, 'scale' => 2])
+            ->addIndex('sku', ['unique' => true])
+            ->create();
+
+        // First bulk insert
+        $table->insertOrSkip([
+            ['sku' => 'ABC123', 'price' => 10.50],
+            ['sku' => 'DEF456', 'price' => 20.00],
+        ])->save();
+
+        // Mix of new and duplicate - duplicates should be skipped
+        $table->insertOrSkip([
+            ['sku' => 'ABC123', 'price' => 99.99], // Duplicate
+            ['sku' => 'GHI789', 'price' => 30.00], // New
+        ])->save();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM products ORDER BY sku');
+        $this->assertCount(3, $rows);
+        $this->assertEquals('10.50', $rows[0]['price']); // Original price preserved
+        $this->assertEquals('20.00', $rows[1]['price']);
+        $this->assertEquals('30.00', $rows[2]['price']);
+    }
+
+    public function testInsertOrSkipWithoutDuplicates()
+    {
+        $table = new Table('categories', [], $this->adapter);
+        $table->addColumn('name', 'string')
+            ->create();
+
+        // Should work like normal insert
+        $table->insertOrSkip([
+            ['name' => 'Category 1'],
+            ['name' => 'Category 2'],
+        ])->save();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM categories');
+        $this->assertCount(2, $rows);
+    }
 }

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -2470,6 +2470,26 @@ OUTPUT;
         $this->assertEquals('John', $rows[0]['name']);
     }
 
+    public function testInsertModeResetsAfterInsertOrSkip()
+    {
+        $table = new Table('users', [], $this->adapter);
+        $table->addColumn('email', 'string', ['limit' => 255])
+            ->addColumn('name', 'string')
+            ->addIndex('email', ['unique' => true])
+            ->create();
+
+        // First insert with insertOrSkip
+        $table->insertOrSkip([
+            ['email' => 'test@example.com', 'name' => 'John'],
+        ])->save();
+
+        // Now use regular insert with duplicate - should throw exception
+        $this->expectException(PDOException::class);
+        $table->insert([
+            ['email' => 'test@example.com', 'name' => 'Jane'],
+        ])->save();
+    }
+
     public function testBulkinsertOrSkipWithDuplicates()
     {
         $table = new Table('products', [], $this->adapter);

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -2819,4 +2819,70 @@ OUTPUT;
         $this->expectException(PDOException::class);
         $this->adapter->execute("INSERT INTO {$quotedTableName} (email, status) VALUES ('test@example.com', 'invalid')");
     }
+
+    public function testInsertOrSkipWithDuplicates()
+    {
+        $table = new Table('users', [], $this->adapter);
+        $table->addColumn('email', 'string', ['limit' => 255])
+            ->addColumn('name', 'string')
+            ->addIndex('email', ['unique' => true])
+            ->create();
+
+        // First insert
+        $table->insertOrSkip([
+            ['email' => 'test@example.com', 'name' => 'John'],
+        ])->save();
+
+        // Duplicate - should be skipped
+        $table->insertOrSkip([
+            ['email' => 'test@example.com', 'name' => 'Jane'],
+        ])->save();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM users');
+        $this->assertCount(1, $rows);
+        $this->assertEquals('John', $rows[0]['name']);
+    }
+
+    public function testBulkinsertOrSkipWithDuplicates()
+    {
+        $table = new Table('products', [], $this->adapter);
+        $table->addColumn('sku', 'string', ['limit' => 50])
+            ->addColumn('price', 'decimal', ['precision' => 10, 'scale' => 2])
+            ->addIndex('sku', ['unique' => true])
+            ->create();
+
+        // First bulk insert
+        $table->insertOrSkip([
+            ['sku' => 'ABC123', 'price' => 10.50],
+            ['sku' => 'DEF456', 'price' => 20.00],
+        ])->save();
+
+        // Mix of new and duplicate - duplicates should be skipped
+        $table->insertOrSkip([
+            ['sku' => 'ABC123', 'price' => 99.99], // Duplicate
+            ['sku' => 'GHI789', 'price' => 30.00], // New
+        ])->save();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM products ORDER BY sku');
+        $this->assertCount(3, $rows);
+        $this->assertEquals('10.50', $rows[0]['price']); // Original price preserved
+        $this->assertEquals('20.00', $rows[1]['price']);
+        $this->assertEquals('30.00', $rows[2]['price']);
+    }
+
+    public function testInsertOrSkipWithoutDuplicates()
+    {
+        $table = new Table('categories', [], $this->adapter);
+        $table->addColumn('name', 'string')
+            ->create();
+
+        // Should work like normal insert
+        $table->insertOrSkip([
+            ['name' => 'Category 1'],
+            ['name' => 'Category 2'],
+        ])->save();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM categories');
+        $this->assertCount(2, $rows);
+    }
 }

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -2843,6 +2843,26 @@ OUTPUT;
         $this->assertEquals('John', $rows[0]['name']);
     }
 
+    public function testInsertModeResetsAfterInsertOrSkip()
+    {
+        $table = new Table('users', [], $this->adapter);
+        $table->addColumn('email', 'string', ['limit' => 255])
+            ->addColumn('name', 'string')
+            ->addIndex('email', ['unique' => true])
+            ->create();
+
+        // First insert with insertOrSkip
+        $table->insertOrSkip([
+            ['email' => 'test@example.com', 'name' => 'John'],
+        ])->save();
+
+        // Now use regular insert with duplicate - should throw exception
+        $this->expectException(\PDOException::class);
+        $table->insert([
+            ['email' => 'test@example.com', 'name' => 'Jane'],
+        ])->save();
+    }
+
     public function testBulkinsertOrSkipWithDuplicates()
     {
         $table = new Table('products', [], $this->adapter);

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -2857,7 +2857,7 @@ OUTPUT;
         ])->save();
 
         // Now use regular insert with duplicate - should throw exception
-        $this->expectException(\PDOException::class);
+        $this->expectException(PDOException::class);
         $table->insert([
             ['email' => 'test@example.com', 'name' => 'Jane'],
         ])->save();

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -3148,4 +3148,70 @@ INPUT;
         $this->expectException(PDOException::class);
         $this->adapter->execute("INSERT INTO {$quotedTableName} (email, status) VALUES ('test@example.com', 'invalid')");
     }
+
+    public function testInsertOrSkipWithDuplicates()
+    {
+        $table = new Table('users', [], $this->adapter);
+        $table->addColumn('email', 'string', ['limit' => 255])
+            ->addColumn('name', 'string')
+            ->addIndex('email', ['unique' => true])
+            ->create();
+
+        // First insert
+        $table->insertOrSkip([
+            ['email' => 'test@example.com', 'name' => 'John'],
+        ])->save();
+
+        // Duplicate - should be skipped
+        $table->insertOrSkip([
+            ['email' => 'test@example.com', 'name' => 'Jane'],
+        ])->save();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM users');
+        $this->assertCount(1, $rows);
+        $this->assertEquals('John', $rows[0]['name']);
+    }
+
+    public function testBulkinsertOrSkipWithDuplicates()
+    {
+        $table = new Table('products', [], $this->adapter);
+        $table->addColumn('sku', 'string', ['limit' => 50])
+            ->addColumn('price', 'decimal', ['precision' => 10, 'scale' => 2])
+            ->addIndex('sku', ['unique' => true])
+            ->create();
+
+        // First bulk insert
+        $table->insertOrSkip([
+            ['sku' => 'ABC123', 'price' => 10.50],
+            ['sku' => 'DEF456', 'price' => 20.00],
+        ])->save();
+
+        // Mix of new and duplicate - duplicates should be skipped
+        $table->insertOrSkip([
+            ['sku' => 'ABC123', 'price' => 99.99], // Duplicate
+            ['sku' => 'GHI789', 'price' => 30.00], // New
+        ])->save();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM products ORDER BY sku');
+        $this->assertCount(3, $rows);
+        $this->assertEquals('10.50', $rows[0]['price']); // Original price preserved
+        $this->assertEquals('20.00', $rows[1]['price']);
+        $this->assertEquals('30.00', $rows[2]['price']);
+    }
+
+    public function testInsertOrSkipWithoutDuplicates()
+    {
+        $table = new Table('categories', [], $this->adapter);
+        $table->addColumn('name', 'string')
+            ->create();
+
+        // Should work like normal insert
+        $table->insertOrSkip([
+            ['name' => 'Category 1'],
+            ['name' => 'Category 2'],
+        ])->save();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM categories');
+        $this->assertCount(2, $rows);
+    }
 }

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -3172,6 +3172,26 @@ INPUT;
         $this->assertEquals('John', $rows[0]['name']);
     }
 
+    public function testInsertModeResetsAfterInsertOrSkip()
+    {
+        $table = new Table('users', [], $this->adapter);
+        $table->addColumn('email', 'string', ['limit' => 255])
+            ->addColumn('name', 'string')
+            ->addIndex('email', ['unique' => true])
+            ->create();
+
+        // First insert with insertOrSkip
+        $table->insertOrSkip([
+            ['email' => 'test@example.com', 'name' => 'John'],
+        ])->save();
+
+        // Now use regular insert with duplicate - should throw exception
+        $this->expectException(\PDOException::class);
+        $table->insert([
+            ['email' => 'test@example.com', 'name' => 'Jane'],
+        ])->save();
+    }
+
     public function testBulkinsertOrSkipWithDuplicates()
     {
         $table = new Table('products', [], $this->adapter);

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -3186,7 +3186,7 @@ INPUT;
         ])->save();
 
         // Now use regular insert with duplicate - should throw exception
-        $this->expectException(\PDOException::class);
+        $this->expectException(PDOException::class);
         $table->insert([
             ['email' => 'test@example.com', 'name' => 'Jane'],
         ])->save();

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -1499,4 +1499,19 @@ OUTPUT;
         $this->assertEquals(20, $res[0]['id']);
         $this->assertEquals(50, $res[1]['id']);
     }
+
+    public function testInsertOrSkipThrowsException()
+    {
+        $table = new Table('users', [], $this->adapter);
+        $table->addColumn('email', 'string', ['limit' => 255])
+            ->addColumn('name', 'string')
+            ->create();
+
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('INSERT IGNORE is not supported for SQL Server');
+
+        $table->insertOrSkip([
+            ['email' => 'test@example.com', 'name' => 'John'],
+        ])->save();
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/cakephp/phinx/issues/2205

Follows https://github.com/cakephp/migrations/pull/939 and in general helps to implement safer idempotent seeding.

```php
  // Current way
  $this->insert('users', [['email' => 'test@example.com']]);

  // New idempotent seeding
  $this->insertOrSkip('users', [['email' => 'test@example.com']]);
  // Safe to re-run - duplicates skipped!
```

  Database Support:
  - ✅ MySQL: INSERT IGNORE
  - ✅ PostgreSQL: ON CONFLICT DO NOTHING
  - ✅ SQLite: INSERT OR IGNORE
  - ⚠️ SQL Server: Throws helpful BadMethodCallException
 
 The current implementation also allows other modes internally in the future, including update (upsert)

**Out of scope**: insertOrUpdate()

  INSERT ... ON DUPLICATE UPDATE - Complex

  - ✅ MySQL: Native support
  - ⚠️ PostgreSQL: Need to specify which column(s) cause the conflict
  - ⚠️ SQLite: Need to specify conflict column(s), requires 3.24.0+
  - ⚠️ SQL Server: Very complex MERGE syntax

  Database Support Matrix

  | Feature                            | MySQL/MariaDB | PostgreSQL                      | SQLite                 | SQL Server          |
  |------------------------------------|---------------|---------------------------------|------------------------|---------------------|
  | INSERT IGNORE                      | ✅ Native      | ✅ Via ON CONFLICT DO NOTHING    | ✅ Via INSERT OR IGNORE | ❌ No native support |
  | INSERT ... ON DUPLICATE KEY UPDATE | ✅ Native      | ✅ Via ON CONFLICT ... DO UPDATE | ❌ Limited              | ⚠️ Via MERGE        |
  
  We can still add insertOrUpdate() later if needed
  - Start with single-row upserts
  - Require explicit conflict columns for now (avoid auto-detection complexity)
  - Consider it a "power user" feature for data sync scenarios

  Example future use:
  ```php
  // Seed with updates - sync from external API
  $this->insertOrUpdate('currencies', [
      ['code' => 'USD', 'rate' => 1.0000, 'updated' => '2025-11-04'],
      ['code' => 'EUR', 'rate' => 0.9234, 'updated' => '2025-11-04'],
  ], ['rate', 'updated'], ['code']);  // Update rate+updated if code exists
  ```