### PR TITLE
Fix snapshots for plugins.

### DIFF
--- a/src/Util/TableFinder.php
+++ b/src/Util/TableFinder.php
@@ -69,7 +69,7 @@ class TableFinder
             return $tables;
         }
 
-        if ($options['require-table'] === true || $options['plugin']) {
+        if ($options['require-table'] === true) {
             $tableNamesInPlugin = $this->getTableNames($options['plugin']);
 
             if (!$tableNamesInPlugin) {

--- a/tests/TestCase/Command/BakeMigrationSnapshotCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationSnapshotCommandTest.php
@@ -217,6 +217,34 @@ class BakeMigrationSnapshotCommandTest extends TestCase
         $this->runSnapshotTest('PluginBlog', '-p TestBlog');
     }
 
+    /**
+     * Test baking a snapshot for a plugin with custom connection (issue #463).
+     * This tests that when using both --plugin and --connection options,
+     * the migration includes all tables from the connection, not just those
+     * with Table classes in the plugin.
+     *
+     * @return void
+     */
+    public function testPluginWithCustomConnection()
+    {
+        $this->loadPlugins(['SimpleSnapshot']);
+        $this->migrationPath = ROOT . DS . 'Plugin' . DS . 'SimpleSnapshot' . DS . 'config' . DS . 'Migrations' . DS;
+
+        $bakeName = $this->getBakeName('TestSnapshotPluginCustomConnection');
+        $this->exec("bake migration_snapshot {$bakeName} -c test -p SimpleSnapshot");
+
+        $generatedMigration = glob($this->migrationPath . "*_TestSnapshotPluginCustomConnection*.php");
+        $this->generatedFiles = $generatedMigration;
+        $this->generatedFiles[] = $this->migrationPath . 'schema-dump-test.lock';
+
+        $this->assertNotEmpty($generatedMigration, 'Migration file should be generated');
+
+        $content = file_get_contents($generatedMigration[0]);
+        $this->assertStringContainsString('function up()', $content);
+        $this->assertStringNotContainsString('public function up(): void {}', $content, 'up() method should not be empty');
+        $this->assertStringContainsString('->create()', $content, 'Migration should contain table creation statements');
+    }
+
     protected function runSnapshotTest(string $scenario, string $arguments = ''): void
     {
         if ($arguments) {

--- a/tests/TestCase/Command/BakeMigrationSnapshotCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationSnapshotCommandTest.php
@@ -233,7 +233,7 @@ class BakeMigrationSnapshotCommandTest extends TestCase
         $bakeName = $this->getBakeName('TestSnapshotPluginCustomConnection');
         $this->exec("bake migration_snapshot {$bakeName} -c test -p SimpleSnapshot");
 
-        $generatedMigration = glob($this->migrationPath . "*_TestSnapshotPluginCustomConnection*.php");
+        $generatedMigration = glob($this->migrationPath . '*_TestSnapshotPluginCustomConnection*.php');
         $this->generatedFiles = $generatedMigration;
         $this->generatedFiles[] = $this->migrationPath . 'schema-dump-test.lock';
 

--- a/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
@@ -104,6 +104,57 @@ class TestSnapshotPluginBlogPgsql extends BaseMigration
             )
             ->create();
 
+        $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']])
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => '',
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->create();
+
+        $this->table('events')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('published', 'string', [
+                'default' => 'N',
+                'limit' => 1,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('orders')
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addIndex(
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
+            )
+            ->create();
+
         $this->table('parts')
             ->addColumn('name', 'string', [
                 'default' => null,
@@ -117,6 +168,143 @@ class TestSnapshotPluginBlogPgsql extends BaseMigration
             ])
             ->create();
 
+        $this->table('products')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'precision' => 6,
+                'scale' => 6,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'precision' => 6,
+                'scale' => 6,
+            ])
+            ->addIndex(
+                $this->index([
+                        'id',
+                        'category_id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('products_title_idx')
+            )
+            ->create();
+
+        $this->table('special_pks', ['id' => false, 'primary_key' => ['id']])
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('special_tags')
+            ->addColumn('article_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addColumn('author_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
+            ->addColumn('tag_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addColumn('highlighted', 'boolean', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('highlighted_time', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'precision' => 6,
+                'scale' => 6,
+            ])
+            ->addIndex(
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('texts', ['id' => false])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('users')
+            ->addColumn('username', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('password', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'precision' => 6,
+                'scale' => 6,
+            ])
+            ->addColumn('updated', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'precision' => 6,
+                'scale' => 6,
+            ])
+            ->create();
+
         $this->table('articles')
             ->addForeignKey(
                 $this->foreignKey('category_id')
@@ -125,6 +313,34 @@ class TestSnapshotPluginBlogPgsql extends BaseMigration
                     ->setOnDelete('NO_ACTION')
                     ->setOnUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
+            )
+            ->update();
+
+        $this->table('orders')
+            ->addForeignKey(
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('orders_product_fk')
+            )
+            ->update();
+
+        $this->table('products')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('products_category_fk')
             )
             ->update();
     }
@@ -144,8 +360,29 @@ class TestSnapshotPluginBlogPgsql extends BaseMigration
                 'category_id'
             )->save();
 
+        $this->table('orders')
+            ->dropForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ]
+            )->save();
+
+        $this->table('products')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
         $this->table('articles')->drop()->save();
         $this->table('categories')->drop()->save();
+        $this->table('composite_pks')->drop()->save();
+        $this->table('events')->drop()->save();
+        $this->table('orders')->drop()->save();
         $this->table('parts')->drop()->save();
+        $this->table('products')->drop()->save();
+        $this->table('special_pks')->drop()->save();
+        $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
+        $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
@@ -95,6 +95,57 @@ class TestSnapshotPluginBlogSqlite extends BaseMigration
             )
             ->create();
 
+        $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']])
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => '',
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->create();
+
+        $this->table('events')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('published', 'string', [
+                'default' => 'N',
+                'limit' => 1,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('orders')
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addIndex(
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
+            )
+            ->create();
+
         $this->table('parts')
             ->addColumn('name', 'string', [
                 'default' => null,
@@ -108,6 +159,133 @@ class TestSnapshotPluginBlogSqlite extends BaseMigration
             ])
             ->create();
 
+        $this->table('products')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('products_title_idx')
+            )
+            ->create();
+
+        $this->table('special_pks', ['id' => false, 'primary_key' => ['id']])
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('special_tags')
+            ->addColumn('article_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addColumn('author_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+            ])
+            ->addColumn('tag_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addColumn('highlighted', 'boolean', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('highlighted_time', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('texts', ['id' => false])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('users')
+            ->addColumn('username', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('password', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('updated', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
         $this->table('articles')
             ->addForeignKey(
                 $this->foreignKey('category_id')
@@ -116,6 +294,34 @@ class TestSnapshotPluginBlogSqlite extends BaseMigration
                     ->setOnDelete('NO_ACTION')
                     ->setOnUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
+            )
+            ->update();
+
+        $this->table('orders')
+            ->addForeignKey(
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('orders_product_fk')
+            )
+            ->update();
+
+        $this->table('products')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('products_category_fk')
             )
             ->update();
     }
@@ -135,8 +341,29 @@ class TestSnapshotPluginBlogSqlite extends BaseMigration
                 'category_id'
             )->save();
 
+        $this->table('orders')
+            ->dropForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ]
+            )->save();
+
+        $this->table('products')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
         $this->table('articles')->drop()->save();
         $this->table('categories')->drop()->save();
+        $this->table('composite_pks')->drop()->save();
+        $this->table('events')->drop()->save();
+        $this->table('orders')->drop()->save();
         $this->table('parts')->drop()->save();
+        $this->table('products')->drop()->save();
+        $this->table('special_pks')->drop()->save();
+        $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
+        $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_plugin_blog_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_plugin_blog_sqlserver.php
@@ -108,6 +108,61 @@ class TestSnapshotPluginBlogSqlserver extends BaseMigration
             )
             ->create();
 
+        $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']])
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'collation' => 'SQL_Latin1_General_CP1_CI_AS',
+                'default' => '',
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->create();
+
+        $this->table('events')
+            ->addColumn('title', 'string', [
+                'collation' => 'SQL_Latin1_General_CP1_CI_AS',
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'collation' => 'SQL_Latin1_General_CP1_CI_AS',
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('published', 'string', [
+                'collation' => 'SQL_Latin1_General_CP1_CI_AS',
+                'default' => 'N',
+                'limit' => 1,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('orders')
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addIndex(
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
+            )
+            ->create();
+
         $this->table('parts')
             ->addColumn('name', 'string', [
                 'collation' => 'SQL_Latin1_General_CP1_CI_AS',
@@ -122,6 +177,150 @@ class TestSnapshotPluginBlogSqlserver extends BaseMigration
             ])
             ->create();
 
+        $this->table('products')
+            ->addColumn('title', 'string', [
+                'collation' => 'SQL_Latin1_General_CP1_CI_AS',
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'collation' => 'SQL_Latin1_General_CP1_CI_AS',
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'precision' => 7,
+                'scale' => 7,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'precision' => 7,
+                'scale' => 7,
+            ])
+            ->addIndex(
+                $this->index([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('products_title_idx')
+            )
+            ->create();
+
+        $this->table('special_pks', ['id' => false, 'primary_key' => ['id']])
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'collation' => 'SQL_Latin1_General_CP1_CI_AS',
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('special_tags')
+            ->addColumn('article_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addColumn('author_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+            ])
+            ->addColumn('tag_id', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addColumn('highlighted', 'boolean', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('highlighted_time', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'precision' => 7,
+                'scale' => 7,
+            ])
+            ->addIndex(
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('texts', ['id' => false])
+            ->addColumn('title', 'string', [
+                'collation' => 'SQL_Latin1_General_CP1_CI_AS',
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'collation' => 'SQL_Latin1_General_CP1_CI_AS',
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('users')
+            ->addColumn('username', 'string', [
+                'collation' => 'SQL_Latin1_General_CP1_CI_AS',
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('password', 'string', [
+                'collation' => 'SQL_Latin1_General_CP1_CI_AS',
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'precision' => 7,
+                'scale' => 7,
+            ])
+            ->addColumn('updated', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'precision' => 7,
+                'scale' => 7,
+            ])
+            ->create();
+
         $this->table('articles')
             ->addForeignKey(
                 $this->foreignKey('category_id')
@@ -130,6 +329,34 @@ class TestSnapshotPluginBlogSqlserver extends BaseMigration
                     ->setOnDelete('NO_ACTION')
                     ->setOnUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
+            )
+            ->update();
+
+        $this->table('orders')
+            ->addForeignKey(
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('orders_product_fk')
+            )
+            ->update();
+
+        $this->table('products')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('products_category_fk')
             )
             ->update();
     }
@@ -149,8 +376,29 @@ class TestSnapshotPluginBlogSqlserver extends BaseMigration
                 'category_id'
             )->save();
 
+        $this->table('orders')
+            ->dropForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ]
+            )->save();
+
+        $this->table('products')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
         $this->table('articles')->drop()->save();
         $this->table('categories')->drop()->save();
+        $this->table('composite_pks')->drop()->save();
+        $this->table('events')->drop()->save();
+        $this->table('orders')->drop()->save();
         $this->table('parts')->drop()->save();
+        $this->table('products')->drop()->save();
+        $this->table('special_pks')->drop()->save();
+        $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
+        $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/test_snapshot_plugin_blog.php
+++ b/tests/comparisons/Migration/test_snapshot_plugin_blog.php
@@ -104,6 +104,59 @@ class TestSnapshotPluginBlog extends BaseMigration
             )
             ->create();
 
+        $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']])
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => '',
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->create();
+
+        $this->table('events')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('published', 'string', [
+                'default' => 'N',
+                'limit' => 1,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('orders')
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addIndex(
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
+            )
+            ->create();
+
         $this->table('parts')
             ->addColumn('name', 'string', [
                 'default' => null,
@@ -118,6 +171,138 @@ class TestSnapshotPluginBlog extends BaseMigration
             ])
             ->create();
 
+        $this->table('products')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('products_title_idx')
+                    ->setType('fulltext')
+            )
+            ->create();
+
+        $this->table('special_pks', ['id' => false, 'primary_key' => ['id']])
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('special_tags')
+            ->addColumn('article_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('author_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('tag_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('highlighted', 'boolean', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('highlighted_time', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('texts', ['id' => false])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('users')
+            ->addColumn('username', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('password', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('updated', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
         $this->table('articles')
             ->addForeignKey(
                 $this->foreignKey('category_id')
@@ -126,6 +311,34 @@ class TestSnapshotPluginBlog extends BaseMigration
                     ->setOnDelete('NO_ACTION')
                     ->setOnUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
+            )
+            ->update();
+
+        $this->table('orders')
+            ->addForeignKey(
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('orders_product_fk')
+            )
+            ->update();
+
+        $this->table('products')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('products_category_fk')
             )
             ->update();
     }
@@ -145,8 +358,29 @@ class TestSnapshotPluginBlog extends BaseMigration
                 'category_id'
             )->save();
 
+        $this->table('orders')
+            ->dropForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ]
+            )->save();
+
+        $this->table('products')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
         $this->table('articles')->drop()->save();
         $this->table('categories')->drop()->save();
+        $this->table('composite_pks')->drop()->save();
+        $this->table('events')->drop()->save();
+        $this->table('orders')->drop()->save();
         $this->table('parts')->drop()->save();
+        $this->table('products')->drop()->save();
+        $this->table('special_pks')->drop()->save();
+        $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
+        $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_compatible_signed_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_compatible_signed_primary_keys.php
@@ -5,6 +5,8 @@ use Migrations\BaseMigration;
 
 class TestSnapshotWithAutoIdCompatibleSignedPrimaryKeys extends BaseMigration
 {
+    public bool $autoId = false;
+
     /**
      * Up Method.
      *
@@ -15,7 +17,134 @@ class TestSnapshotWithAutoIdCompatibleSignedPrimaryKeys extends BaseMigration
      */
     public function up(): void
     {
+        $this->table('articles')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'comment' => 'Article title',
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('category_id')
+                    ->setName('articles_category_fk')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('articles_title_idx')
+            )
+            ->create();
+
+        $this->table('categories')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('parent_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('composite_pks')
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => '',
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id', 'name'])
+            ->create();
+
         $this->table('events')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => true,
+            ])
+            ->addPrimaryKey(['id'])
             ->addColumn('title', 'string', [
                 'default' => null,
                 'limit' => 255,
@@ -32,6 +161,254 @@ class TestSnapshotWithAutoIdCompatibleSignedPrimaryKeys extends BaseMigration
                 'null' => true,
             ])
             ->create();
+
+        $this->table('orders')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addIndex(
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
+            )
+            ->create();
+
+        $this->table('parts')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('number', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->create();
+
+        $this->table('products')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('products_title_idx')
+                    ->setType('fulltext')
+            )
+            ->create();
+
+        $this->table('special_pks')
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('special_tags')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('article_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('author_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('tag_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('highlighted', 'boolean', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('highlighted_time', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('texts')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('users')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('username', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('password', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('updated', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('articles')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
+            )
+            ->update();
+
+        $this->table('orders')
+            ->addForeignKey(
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('orders_product_fk')
+            )
+            ->update();
+
+        $this->table('products')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('products_category_fk')
+            )
+            ->update();
     }
 
     /**
@@ -44,6 +421,34 @@ class TestSnapshotWithAutoIdCompatibleSignedPrimaryKeys extends BaseMigration
      */
     public function down(): void
     {
+        $this->table('articles')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
+        $this->table('orders')
+            ->dropForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ]
+            )->save();
+
+        $this->table('products')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
+        $this->table('articles')->drop()->save();
+        $this->table('categories')->drop()->save();
+        $this->table('composite_pks')->drop()->save();
         $this->table('events')->drop()->save();
+        $this->table('orders')->drop()->save();
+        $this->table('parts')->drop()->save();
+        $this->table('products')->drop()->save();
+        $this->table('special_pks')->drop()->save();
+        $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
+        $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_signed_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_signed_primary_keys.php
@@ -17,6 +17,125 @@ class TestSnapshotWithAutoIdIncompatibleSignedPrimaryKeys extends BaseMigration
      */
     public function up(): void
     {
+        $this->table('articles')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'comment' => 'Article title',
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('category_id')
+                    ->setName('articles_category_fk')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('articles_title_idx')
+            )
+            ->create();
+
+        $this->table('categories')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('parent_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('composite_pks')
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => '',
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id', 'name'])
+            ->create();
+
         $this->table('events')
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
@@ -42,6 +161,254 @@ class TestSnapshotWithAutoIdIncompatibleSignedPrimaryKeys extends BaseMigration
                 'null' => true,
             ])
             ->create();
+
+        $this->table('orders')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addIndex(
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
+            )
+            ->create();
+
+        $this->table('parts')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('number', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->create();
+
+        $this->table('products')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('products_title_idx')
+                    ->setType('fulltext')
+            )
+            ->create();
+
+        $this->table('special_pks')
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('special_tags')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('article_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('author_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('tag_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('highlighted', 'boolean', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('highlighted_time', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('texts')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('users')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('username', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('password', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('updated', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('articles')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
+            )
+            ->update();
+
+        $this->table('orders')
+            ->addForeignKey(
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('orders_product_fk')
+            )
+            ->update();
+
+        $this->table('products')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('products_category_fk')
+            )
+            ->update();
     }
 
     /**
@@ -54,6 +421,34 @@ class TestSnapshotWithAutoIdIncompatibleSignedPrimaryKeys extends BaseMigration
      */
     public function down(): void
     {
+        $this->table('articles')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
+        $this->table('orders')
+            ->dropForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ]
+            )->save();
+
+        $this->table('products')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
+        $this->table('articles')->drop()->save();
+        $this->table('categories')->drop()->save();
+        $this->table('composite_pks')->drop()->save();
         $this->table('events')->drop()->save();
+        $this->table('orders')->drop()->save();
+        $this->table('parts')->drop()->save();
+        $this->table('products')->drop()->save();
+        $this->table('special_pks')->drop()->save();
+        $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
+        $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_unsigned_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_unsigned_primary_keys.php
@@ -17,6 +17,125 @@ class TestSnapshotWithAutoIdIncompatibleUnsignedPrimaryKeys extends BaseMigratio
      */
     public function up(): void
     {
+        $this->table('articles')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'comment' => 'Article title',
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('category_id')
+                    ->setName('articles_category_fk')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('articles_title_idx')
+            )
+            ->create();
+
+        $this->table('categories')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('parent_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('composite_pks')
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => '',
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id', 'name'])
+            ->create();
+
         $this->table('events')
             ->addColumn('id', 'integer', [
                 'autoIncrement' => true,
@@ -42,6 +161,254 @@ class TestSnapshotWithAutoIdIncompatibleUnsignedPrimaryKeys extends BaseMigratio
                 'null' => true,
             ])
             ->create();
+
+        $this->table('orders')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addIndex(
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
+            )
+            ->create();
+
+        $this->table('parts')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('number', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->create();
+
+        $this->table('products')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('products_title_idx')
+                    ->setType('fulltext')
+            )
+            ->create();
+
+        $this->table('special_pks')
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('special_tags')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('article_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('author_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('tag_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('highlighted', 'boolean', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('highlighted_time', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('texts')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('users')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('username', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('password', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('updated', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('articles')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
+            )
+            ->update();
+
+        $this->table('orders')
+            ->addForeignKey(
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('orders_product_fk')
+            )
+            ->update();
+
+        $this->table('products')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('products_category_fk')
+            )
+            ->update();
     }
 
     /**
@@ -54,6 +421,34 @@ class TestSnapshotWithAutoIdIncompatibleUnsignedPrimaryKeys extends BaseMigratio
      */
     public function down(): void
     {
+        $this->table('articles')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
+        $this->table('orders')
+            ->dropForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ]
+            )->save();
+
+        $this->table('products')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
+        $this->table('articles')->drop()->save();
+        $this->table('categories')->drop()->save();
+        $this->table('composite_pks')->drop()->save();
         $this->table('events')->drop()->save();
+        $this->table('orders')->drop()->save();
+        $this->table('parts')->drop()->save();
+        $this->table('products')->drop()->save();
+        $this->table('special_pks')->drop()->save();
+        $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
+        $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/test_snapshot_with_non_default_collation.php
+++ b/tests/comparisons/Migration/test_snapshot_with_non_default_collation.php
@@ -15,9 +15,111 @@ class TestSnapshotWithNonDefaultCollation extends BaseMigration
      */
     public function up(): void
     {
+        $this->table('articles')
+            ->addColumn('title', 'string', [
+                'comment' => 'Article title',
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('category_id')
+                    ->setName('articles_category_fk')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('articles_title_idx')
+            )
+            ->create();
+
+        $this->table('categories')
+            ->addColumn('parent_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']])
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => '',
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->create();
+
         $this->table('events')
             ->addColumn('title', 'string', [
-                'collation' => 'utf8mb3_hungarian_ci',
+                'collation' => 'utf8_hungarian_ci',
                 'default' => null,
                 'limit' => 255,
                 'null' => true,
@@ -33,6 +135,213 @@ class TestSnapshotWithNonDefaultCollation extends BaseMigration
                 'null' => true,
             ])
             ->create();
+
+        $this->table('orders')
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addIndex(
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
+            )
+            ->create();
+
+        $this->table('parts')
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('number', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->create();
+
+        $this->table('products')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('products_title_idx')
+                    ->setType('fulltext')
+            )
+            ->create();
+
+        $this->table('special_pks', ['id' => false, 'primary_key' => ['id']])
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('special_tags')
+            ->addColumn('article_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('author_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('tag_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('highlighted', 'boolean', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('highlighted_time', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('texts', ['id' => false])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('users')
+            ->addColumn('username', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('password', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('updated', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('articles')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('NO_ACTION')
+                    ->setOnUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
+            )
+            ->update();
+
+        $this->table('orders')
+            ->addForeignKey(
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('orders_product_fk')
+            )
+            ->update();
+
+        $this->table('products')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setOnDelete('CASCADE')
+                    ->setOnUpdate('CASCADE')
+                    ->setName('products_category_fk')
+            )
+            ->update();
     }
 
     /**
@@ -45,6 +354,34 @@ class TestSnapshotWithNonDefaultCollation extends BaseMigration
      */
     public function down(): void
     {
+        $this->table('articles')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
+        $this->table('orders')
+            ->dropForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ]
+            )->save();
+
+        $this->table('products')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
+        $this->table('articles')->drop()->save();
+        $this->table('categories')->drop()->save();
+        $this->table('composite_pks')->drop()->save();
         $this->table('events')->drop()->save();
+        $this->table('orders')->drop()->save();
+        $this->table('parts')->drop()->save();
+        $this->table('products')->drop()->save();
+        $this->table('special_pks')->drop()->save();
+        $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
+        $this->table('users')->drop()->save();
     }
 }

--- a/tests/comparisons/Migration/test_snapshot_with_non_default_collation.php
+++ b/tests/comparisons/Migration/test_snapshot_with_non_default_collation.php
@@ -119,7 +119,7 @@ class TestSnapshotWithNonDefaultCollation extends BaseMigration
 
         $this->table('events')
             ->addColumn('title', 'string', [
-                'collation' => 'utf8_hungarian_ci',
+                'collation' => 'utf8mb3_hungarian_ci',
                 'default' => null,
                 'limit' => 255,
                 'null' => true,


### PR DESCRIPTION
Resolves https://github.com/cakephp/migrations/issues/463


  Root Cause

  The bug was in src/Util/TableFinder.php:72. The code incorrectly treated the --plugin option the same as --require-table, filtering tables to only include those with corresponding Table classes in the plugin. When creating
   an initial migration snapshot for a plugin (before Table classes exist), this resulted in an empty migration.

  The Fix

  Changed line 72 in src/Util/TableFinder.php:
  ```
  // Before (buggy)
  if ($options['require-table'] === true || $options['plugin']) {

  // After (fixed)  
  if ($options['require-table'] === true) {
  ```
  Behavior Changes

  Before:
  - --plugin option would filter tables to only include those with Table classes in the plugin
  - Made it impossible to create initial snapshots for plugins with custom connections

  After:
  - --plugin option only determines where the migration file is saved
  - All tables from the specified connection are included (excluding phinxlog tables)
  - Use --require-table if you want to filter by existing Table classes

