### PR TITLE
Change column storage from associative to indexed array

### DIFF
--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -329,7 +329,7 @@ class SqlserverAdapter extends AbstractAdapter
                 $column->setIdentity($columnInfo['autoIncrement']);
             }
 
-            $columns[$columnInfo['name']] = $column;
+            $columns[] = $column;
         }
 
         return $columns;


### PR DESCRIPTION
SqlServerAdapter::getColumns returns associative array
**Issue:** https://github.com/cakephp/phinx/issues/2386
**Impact:** High - BC breaking bug
**Status in Migrations:** ✅ **CONFIRMED BUG EXISTS**
**Location:** `src/Db/Adapter/SqlserverAdapter.php:316`

```php
// Current (WRONG):
$columns[$columnInfo['name']] = $column;

// Should be:
$columns[] = $column;
```

The `AdapterInterface` specifies `Column[]` (numeric array) but SqlServer returns an associative array keyed by column names. This violates the contract and affects any code iterating over columns.
