### PR TITLE
Fix up SQLServer to return numeric array.

### DIFF
--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -313,7 +313,7 @@ class SqlserverAdapter extends AbstractAdapter
                 $column->setIdentity($columnInfo['autoIncrement']);
             }
 
-            $columns[$columnInfo['name']] = $column;
+            $columns[] = $column;
         }
 
         return $columns;

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -435,13 +435,20 @@ SQL;
     protected function getChangeColumnInstructions(string $tableName, string $columnName, Column $newColumn): AlterInstructions
     {
         $columns = $this->getColumns($tableName);
-        if (!isset($columns[$columnName])) {
+        $oldColumn = null;
+        foreach ($columns as $column) {
+            if ($column->getName() === $columnName) {
+                $oldColumn = $column;
+                break;
+            }
+        }
+        if ($oldColumn === null) {
             throw new InvalidArgumentException("Unknown column {$columnName} cannot be changed.");
         }
 
         $changeDefault =
-            $newColumn->getDefault() !== $columns[$columnName]->getDefault() ||
-            $newColumn->getType() !== $columns[$columnName]->getType();
+            $newColumn->getDefault() !== $oldColumn->getDefault() ||
+            $newColumn->getType() !== $oldColumn->getType();
 
         $instructions = new AlterInstructions();
         $dialect = $this->getSchemaDialect();

--- a/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqlserverAdapterTest.php
@@ -474,10 +474,10 @@ class SqlserverAdapterTest extends TestCase
 
         $columns = $this->adapter->getColumns('table1');
         $this->assertCount(2, $columns);
-        $this->assertArrayHasKey('id', $columns);
-        $this->assertArrayHasKey('col', $columns);
-        $this->assertFalse($columns['col']->isNull());
-        $this->assertNull($columns['col']->getDefault());
+        $this->assertEquals('id', $columns[0]->getName());
+        $this->assertEquals('col', $columns[1]->getName());
+        $this->assertFalse($columns[1]->isNull());
+        $this->assertNull($columns[1]->getDefault());
     }
 
     public function testAddColumnWithDefaultBool()
@@ -577,7 +577,7 @@ class SqlserverAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
 
         $columns = $this->adapter->getColumns('t');
-        $this->assertSame('test', $columns['column1']->getDefault());
+        $this->assertSame('test', $columns[1]->getDefault());
 
         $newColumn1 = new Column();
         $newColumn1
@@ -588,7 +588,7 @@ class SqlserverAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasColumn('t', 'column1'));
 
         $columns = $this->adapter->getColumns('t');
-        $this->assertSame('another test', $columns['column1']->getDefault());
+        $this->assertSame('another test', $columns[1]->getDefault());
     }
 
     public function testChangeColumnDefaultToNull()
@@ -603,7 +603,7 @@ class SqlserverAdapterTest extends TestCase
             ->setDefault(null);
         $table->changeColumn('column1', $newColumn1)->save();
         $columns = $this->adapter->getColumns('t');
-        $this->assertNull($columns['column1']->getDefault());
+        $this->assertNull($columns[1]->getDefault());
     }
 
     public function testChangeColumnDefaultToZero()
@@ -618,7 +618,7 @@ class SqlserverAdapterTest extends TestCase
             ->setDefault(0);
         $table->changeColumn('column1', $newColumn1)->save();
         $columns = $this->adapter->getColumns('t');
-        $this->assertSame(0, $columns['column1']->getDefault());
+        $this->assertSame(0, $columns[1]->getDefault());
     }
 
     public function testDropColumn()
@@ -664,11 +664,11 @@ class SqlserverAdapterTest extends TestCase
 
         $columns = $this->adapter->getColumns('t');
         $this->assertCount(2, $columns);
-        $this->assertEquals('id', $columns['id']->getName());
-        $this->assertTrue($columns['id']->getIdentity());
+        $this->assertEquals('id', $columns[0]->getName());
+        $this->assertTrue($columns[0]->getIdentity());
 
-        $this->assertEquals($colName, $columns[$colName]->getName());
-        $this->assertEquals($actualType ?? $type, $columns[$colName]->getType());
+        $this->assertEquals($colName, $columns[1]->getName());
+        $this->assertEquals($actualType ?? $type, $columns[1]->getType());
     }
 
     public function testAddIndex()


### PR DESCRIPTION
Resolves https://github.com/cakephp/migrations/pull/952

**Issue:** https://github.com/cakephp/phinx/issues/2386
**Impact:** High - BC breaking bug
**Status in Migrations:** ✅ **CONFIRMED BUG EXISTS**
**Location:** `src/Db/Adapter/SqlserverAdapter.php:316`

The SqlServerAdapter::getColumns function returns an associative array of columns, where the keys are column names. All other adapters return a numeric array which is also expressed by our AdapterInterface

```php
// Current (WRONG):
$columns[$columnInfo['name']] = $column;

// Should be:
$columns[] = $column;
```

The `AdapterInterface` specifies `Column[]` (numeric array) but SqlServer returns an associative array keyed by column names. This violates the contract and affects any code iterating over columns.