### PR TITLE
Fix SQLiteAdapter when changing primary key

### DIFF
--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1354,9 +1354,6 @@ PCRE_PATTERN;
                     if ($matches[2] === 'INTEGER' && $hasAutoIncrement) {
                         // Only add AUTOINCREMENT if the column already had it
                         $replace = '$1 INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT';
-                    } elseif ($matches[2] === 'INTEGER') {
-                        // INTEGER column without AUTOINCREMENT should stay that way
-                        $replace = '$1 INTEGER NOT NULL PRIMARY KEY';
                     } else {
                         $replace = '$1 $2 NOT NULL PRIMARY KEY';
                     }

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1343,14 +1343,21 @@ PCRE_PATTERN;
         $instructions->addPostStep(function ($state) use ($column) {
             $quotedColumn = preg_quote($column);
             $columnPattern = "`{$quotedColumn}`|\"{$quotedColumn}\"|\[{$quotedColumn}\]";
-            $matchPattern = "/($columnPattern)\s+(\w+(\(\d+\))?)(\s+(NOT )?NULL)?/";
+            // Extended pattern to capture AUTOINCREMENT if present
+            $matchPattern = "/($columnPattern)\s+(\w+(\(\d+\))?)(\s+(NOT )?NULL)?(\s+(?:PRIMARY KEY\s+)?AUTOINCREMENT)?/i";
 
             $sql = $state['createSQL'];
 
             if (preg_match($matchPattern, $state['createSQL'], $matches)) {
                 if (isset($matches[2])) {
-                    if ($matches[2] === 'INTEGER') {
+                    $hasAutoIncrement = isset($matches[6]) && stripos($matches[6], 'AUTOINCREMENT') !== false;
+
+                    if ($matches[2] === 'INTEGER' && $hasAutoIncrement) {
+                        // Only add AUTOINCREMENT if the column already had it
                         $replace = '$1 INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT';
+                    } elseif ($matches[2] === 'INTEGER') {
+                        // INTEGER column without AUTOINCREMENT should stay that way
+                        $replace = '$1 INTEGER NOT NULL PRIMARY KEY';
                     } else {
                         $replace = '$1 $2 NOT NULL PRIMARY KEY';
                     }

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1343,7 +1343,6 @@ PCRE_PATTERN;
         $instructions->addPostStep(function ($state) use ($column) {
             $quotedColumn = preg_quote($column);
             $columnPattern = "`{$quotedColumn}`|\"{$quotedColumn}\"|\[{$quotedColumn}\]";
-            // Extended pattern to capture AUTOINCREMENT if present
             $matchPattern = "/($columnPattern)\s+(\w+(\(\d+\))?)(\s+(NOT )?NULL)?(\s+(?:PRIMARY KEY\s+)?AUTOINCREMENT)?/i";
 
             $sql = $state['createSQL'];

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -428,6 +428,51 @@ class SqliteAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasPrimaryKey('table1', ['column2']));
     }
 
+    public function testChangePrimaryKeyWithoutAutoIncrement()
+    {
+        // Create table with id_1 as PK without AUTOINCREMENT keyword
+        $this->adapter->execute('CREATE TABLE table1 (id_1 INTEGER NOT NULL PRIMARY KEY, id_2 INTEGER NOT NULL)');
+
+        // Verify initial SQL does not have AUTOINCREMENT
+        $result = $this->adapter->fetchRow("SELECT sql FROM sqlite_master WHERE type='table' AND name='table1'");
+        $this->assertStringNotContainsString('AUTOINCREMENT', $result['sql']);
+
+        // Change primary key to id_2
+        $table = new Table('table1', [], $this->adapter);
+        $table->changePrimaryKey('id_2')->save();
+
+        // Verify primary key changed
+        $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['id_1']));
+        $this->assertTrue($this->adapter->hasPrimaryKey('table1', ['id_2']));
+
+        // Verify the SQL does NOT have AUTOINCREMENT added to id_2
+        $result = $this->adapter->fetchRow("SELECT sql FROM sqlite_master WHERE type='table' AND name='table1'");
+        $this->assertStringNotContainsString('AUTOINCREMENT', $result['sql'], 'AUTOINCREMENT should not be added when changing PK to a column that did not have it');
+    }
+
+    public function testChangePrimaryKeyFromAutoIncrementColumn()
+    {
+        // Create table with id_1 as PK with AUTOINCREMENT
+        $this->adapter->execute('CREATE TABLE table1 (id_1 INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, id_2 INTEGER NOT NULL)');
+
+        // Verify initial SQL has AUTOINCREMENT
+        $result = $this->adapter->fetchRow("SELECT sql FROM sqlite_master WHERE type='table' AND name='table1'");
+        $this->assertStringContainsString('AUTOINCREMENT', $result['sql']);
+
+        // Change primary key to id_2 (should NOT get AUTOINCREMENT since id_2 doesn't have it)
+        $table = new Table('table1', [], $this->adapter);
+        $table->changePrimaryKey('id_2')->save();
+
+        // Verify primary key changed
+        $this->assertFalse($this->adapter->hasPrimaryKey('table1', ['id_1']));
+        $this->assertTrue($this->adapter->hasPrimaryKey('table1', ['id_2']));
+
+        // Verify the SQL does NOT have AUTOINCREMENT on id_2
+        // (id_1 lost its AUTOINCREMENT when PK was dropped, and id_2 never had it)
+        $result = $this->adapter->fetchRow("SELECT sql FROM sqlite_master WHERE type='table' AND name='table1'");
+        $this->assertStringNotContainsString('AUTOINCREMENT', $result['sql'], 'AUTOINCREMENT should not be added when changing PK to a column that never had it');
+    }
+
     public function testDropPrimaryKey()
     {
         $table = new Table('table1', ['id' => false, 'primary_key' => 'column1'], $this->adapter);


### PR DESCRIPTION
**Issue:** https://github.com/cakephp/phinx/issues/2364

SQLite adapter incorrectly adds `AUTOINCREMENT` keyword to integer columns when changing a table's primary key, even when not explicitly specified.

  Changes Made

  1. Fixed SqliteAdapter::getAddPrimaryKeyInstructions() (src/Db/Adapter/SqliteAdapter.php:1338-1372)
  - Before: Automatically added AUTOINCREMENT to ALL INTEGER columns when making them primary keys
  - After: Only adds AUTOINCREMENT if the column already had it in the original table definition
  - Uses regex to detect the presence of AUTOINCREMENT keyword in the current CREATE TABLE SQL


  The fix was verified to:
  - ✅ No longer add AUTOINCREMENT when changing PK to a column that didn't have it
  - ✅ Maintain backward compatibility with existing tests
  - ✅ Match the behavior of other adapters (MySQL, Postgres, SQL Server)
