### PR TITLE
Fix null constraint columns in add-foreign-keys template

### DIFF
--- a/templates/bake/element/add-foreign-keys.twig
+++ b/templates/bake/element/add-foreign-keys.twig
@@ -1,7 +1,7 @@
 {% set statement = Migration.tableStatement(table, true) %}
 {% set hasProcessedConstraint = false %}
 {% for constraintName, constraint in constraints %}
-    {%~ set constraintColumns = constraint['columns']|sort %}
+    {%~ set constraintColumns = constraint['columns']|default([])|sort %}
     {%~ if constraint['type'] == 'foreign' %}
         {%~ set hasProcessedConstraint = true %}
         {%~ set columnsList = '\'' ~ constraint['columns'][0] ~ '\'' %}


### PR DESCRIPTION
## Summary
- Fix Twig runtime error when `constraint['columns']` is null during migration snapshot generation
- Add `default([])` filter before `sort` to handle null values gracefully

Fixes #961

## Test plan
- [ ] Run `bin/cake bake migration_snapshot` on a database that previously triggered the null constraint error
- [ ] Verify existing snapshot generation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)