### PR TITLE
Add default value syntax support for bake migration command

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -218,7 +218,7 @@ also edit the migration after generation to add or customize the columns
 
 Columns on the command line follow the following pattern::
 
-    fieldName:fieldType?[length]:indexType:indexName
+    fieldName:fieldType?[length]:default[value]:indexType:indexName
 
 For instance, the following are all valid ways of specifying an email field:
 
@@ -237,6 +237,16 @@ and scale, separated by a comma.
 Columns with a question mark after the fieldType will make the column nullable.
 
 The ``length`` part is optional and should always be written between bracket.
+
+The ``default[value]`` part is optional and sets the default value for the column.
+Supported value types include:
+
+* Booleans: ``true`` or ``false`` - e.g., ``active:boolean:default[true]``
+* Integers: ``0``, ``123``, ``-456`` - e.g., ``count:integer:default[0]``
+* Floats: ``1.5``, ``-2.75`` - e.g., ``rate:decimal:default[1.5]``
+* Strings: ``'hello'`` or ``"world"`` (quoted) - e.g., ``status:string:default['pending']``
+* Null: ``null`` or ``NULL`` - e.g., ``description:text?:default[null]``
+* SQL expressions: ``CURRENT_TIMESTAMP`` - e.g., ``created_at:datetime:default[CURRENT_TIMESTAMP]``
 
 Fields named ``created`` and ``modified``, as well as any field with a ``_at``
 suffix, will automatically be set to the type ``datetime``.
@@ -317,6 +327,39 @@ will generate::
                   ->update();
         }
     }
+
+Adding a column with a default value
+-------------------------------------
+
+You can specify default values for columns using the ``default[value]`` syntax:
+
+.. code-block:: bash
+
+    bin/cake bake migration AddActiveToUsers active:boolean:default[true]
+
+will generate::
+
+    <?php
+    use Migrations\BaseMigration;
+
+    class AddActiveToUsers extends BaseMigration
+    {
+        public function change(): void
+        {
+            $table = $this->table('users');
+            $table->addColumn('active', 'boolean', [
+                'default' => true,
+                'null' => false,
+            ]);
+            $table->update();
+        }
+    }
+
+You can combine default values with other options like nullable and indexes:
+
+.. code-block:: bash
+
+    bin/cake bake migration AddStatusToOrders status:string:default['pending']:unique
 
 Altering a column
 -----------------

--- a/src/Command/BakeMigrationCommand.php
+++ b/src/Command/BakeMigrationCommand.php
@@ -174,7 +174,7 @@ field on the users table.
 
 When describing columns you can use the following syntax:
 
-<warning>{name}:{primary}{type}{nullable}[{length}]:{index}:{indexName}</warning>
+<warning>{name}:{type}{nullable}[{length}]:default[{value}]:{index}:{indexName}</warning>
 
 All sections other than name are optional.
 
@@ -182,6 +182,9 @@ All sections other than name are optional.
 * The <warning>?</warning> value indicates if a column is nullable.
   e.g. <warning>role:string?</warning>.
 * Length option must be enclosed in <warning>[]</warning>, for example: <warning>name:string?[100]</warning>.
+* The <warning>default[value]</warning> option sets a default value for the column.
+  Supports booleans (true/false), integers, floats, strings, and null.
+  e.g. <warning>active:boolean:default[true]</warning>, <warning>count:integer:default[0]</warning>.
 * The <warning>index</warning> attribute can define the column as having a unique
   key with <warning>unique</warning> or a primary key with <warning>primary</warning>.
 * Use <warning>references</warning> type to create a foreign key constraint.
@@ -213,6 +216,12 @@ constraint on <warning>user_id</warning> referencing the <warning>users</warning
 <warning>bin/cake bake migration AddCategoryIdToArticles category_id:references:categories</warning>
 Create a migration that adds a foreign key column (<warning>category_id</warning>) to the <warning>articles</warning>
 table referencing the <warning>categories</warning> table.
+
+<warning>bin/cake bake migration AddActiveToUsers active:boolean:default[true]</warning>
+Create a migration that adds an <warning>active</warning> column with a default value of <warning>true</warning>.
+
+<warning>bin/cake bake migration AddCountToProducts count:integer:default[0]:unique</warning>
+Create a migration that adds a <warning>count</warning> column with default <warning>0</warning> and a unique index.
 
 <info>Migration Styles</info>
 

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -82,7 +82,7 @@ class ColumnParser
                 'columnType' => $type,
                 'options' => [
                     'null' => $nullable,
-                    'default' => $this->parseDefaultValue($defaultValue, $type),
+                    'default' => $this->parseDefaultValue($defaultValue, $type ?? 'string'),
                 ],
             ];
 
@@ -252,17 +252,20 @@ class ColumnParser
      *
      * @param string $field Name of field
      * @param string|null $type User-specified type
-     * @return array<string|int|array|null> First value is the field type, second value is the field length. If no length
+     * @return array{0: string|null, 1: int|array<int>|null} First value is the field type, second value is the field length. If no length
      * can be extracted, null is returned for the second value
      */
     public function getTypeAndLength(string $field, ?string $type): array
     {
         if ($type && preg_match($this->regexpParseField, $type, $matches)) {
-            if (str_contains($matches[2], ',')) {
-                $matches[2] = explode(',', $matches[2]);
+            $length = $matches[2];
+            if (str_contains($length, ',')) {
+                $length = array_map('intval', explode(',', $length));
+            } else {
+                $length = (int)$length;
             }
 
-            return [$matches[1], $matches[2]];
+            return [$matches[1], $length];
         }
 
         /** @var string $fieldType */

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -371,7 +371,7 @@ class ColumnParser
      */
     public function parseDefaultValue(?string $value, string $columnType): string|int|float|bool|null
     {
-        if ($value === null) {
+        if ($value === null || $value === '') {
             return null;
         }
 

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -28,6 +28,7 @@ class ColumnParser
                 (?:,(?:[0-9]|[1-9][0-9]+))?
             \])?
         ))?
+        (?::default\[([^\]]+)\])?
         (?::(\w+))?
         (?::(\w+))?
         $
@@ -54,7 +55,8 @@ class ColumnParser
             preg_match($this->regexpParseColumn, $field, $matches);
             $field = $matches[1];
             $type = Hash::get($matches, 2, '');
-            $indexType = Hash::get($matches, 3);
+            $defaultValue = Hash::get($matches, 3);
+            $indexType = Hash::get($matches, 4);
 
             $typeIsPk = in_array($type, ['primary', 'primary_key'], true);
             $isPrimaryKey = false;
@@ -80,7 +82,7 @@ class ColumnParser
                 'columnType' => $type,
                 'options' => [
                     'null' => $nullable,
-                    'default' => null,
+                    'default' => $this->parseDefaultValue($defaultValue, $type),
                 ],
             ];
 
@@ -114,8 +116,8 @@ class ColumnParser
             preg_match($this->regexpParseColumn, $field, $matches);
             $field = $matches[1];
             $type = Hash::get($matches, 2);
-            $indexType = Hash::get($matches, 3);
-            $indexName = Hash::get($matches, 4);
+            $indexType = Hash::get($matches, 4);
+            $indexName = Hash::get($matches, 5);
 
             // Skip references - they create foreign keys, not indexes
             if ($type && str_starts_with($type, 'references')) {
@@ -168,7 +170,7 @@ class ColumnParser
             preg_match($this->regexpParseColumn, $field, $matches);
             $field = $matches[1];
             $type = Hash::get($matches, 2);
-            $indexType = Hash::get($matches, 3);
+            $indexType = Hash::get($matches, 4);
 
             if (
                 in_array($type, ['primary', 'primary_key'], true)
@@ -196,8 +198,8 @@ class ColumnParser
             preg_match($this->regexpParseColumn, $field, $matches);
             $fieldName = $matches[1];
             $type = Hash::get($matches, 2, '');
-            $indexType = Hash::get($matches, 3);
-            $indexName = Hash::get($matches, 4);
+            $indexType = Hash::get($matches, 4);
+            $indexName = Hash::get($matches, 5);
 
             // Check if type is 'references' or 'references?'
             $isReference = str_starts_with($type, 'references');
@@ -351,5 +353,62 @@ class ColumnParser
         }
 
         return $indexName;
+    }
+
+    /**
+     * Parses a default value string into the appropriate PHP type.
+     *
+     * Supports:
+     * - Booleans: true, false
+     * - Null: null, NULL
+     * - Integers: 123, -123
+     * - Floats: 1.5, -1.5
+     * - Strings: 'hello' (quoted) or unquoted values
+     *
+     * @param string|null $value The raw default value from the command line
+     * @param string $columnType The column type to help with type coercion
+     * @return string|int|float|bool|null The parsed default value
+     */
+    public function parseDefaultValue(?string $value, string $columnType): string|int|float|bool|null
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $lowerValue = strtolower($value);
+
+        // Handle null
+        if ($lowerValue === 'null') {
+            return null;
+        }
+
+        // Handle booleans
+        if ($lowerValue === 'true') {
+            return true;
+        }
+        if ($lowerValue === 'false') {
+            return false;
+        }
+
+        // Handle quoted strings - strip quotes
+        if (
+            (str_starts_with($value, "'") && str_ends_with($value, "'")) ||
+            (str_starts_with($value, '"') && str_ends_with($value, '"'))
+        ) {
+            return substr($value, 1, -1);
+        }
+
+        // Handle integers
+        if (preg_match('/^-?[0-9]+$/', $value)) {
+            return (int)$value;
+        }
+
+        // Handle floats
+        if (preg_match('/^-?[0-9]+\.[0-9]+$/', $value)) {
+            return (float)$value;
+        }
+
+        // Return as-is for SQL expressions like CURRENT_TIMESTAMP
+        return $value;
     }
 }

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -349,16 +349,16 @@ class ColumnParserTest extends TestCase
     public function testGetTypeAndLengthReturnsIntegerTypes()
     {
         // Test that lengths are returned as integers, not strings
-        [$type, $length] = $this->columnParser->getTypeAndLength('name', 'string[128]');
+        [, $length] = $this->columnParser->getTypeAndLength('name', 'string[128]');
         $this->assertIsInt($length);
         $this->assertSame(128, $length);
 
-        [$type, $length] = $this->columnParser->getTypeAndLength('count', 'integer[9]');
+        [, $length] = $this->columnParser->getTypeAndLength('count', 'integer[9]');
         $this->assertIsInt($length);
         $this->assertSame(9, $length);
 
         // Test that precision/scale arrays contain integers
-        [$type, $length] = $this->columnParser->getTypeAndLength('amount', 'decimal[10,6]');
+        [, $length] = $this->columnParser->getTypeAndLength('amount', 'decimal[10,6]');
         $this->assertIsArray($length);
         $this->assertCount(2, $length);
         $this->assertIsInt($length[0]);
@@ -367,11 +367,11 @@ class ColumnParserTest extends TestCase
         $this->assertSame(6, $length[1]);
 
         // Test default lengths are also integers
-        [$type, $length] = $this->columnParser->getTypeAndLength('name', 'string');
+        [, $length] = $this->columnParser->getTypeAndLength('name', 'string');
         $this->assertIsInt($length);
         $this->assertSame(255, $length);
 
-        [$type, $length] = $this->columnParser->getTypeAndLength('id', 'integer');
+        [, $length] = $this->columnParser->getTypeAndLength('id', 'integer');
         $this->assertIsInt($length);
         $this->assertSame(11, $length);
     }

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -346,6 +346,36 @@ class ColumnParserTest extends TestCase
         $this->assertEquals(['decimal', [10, 6]], $this->columnParser->getTypeAndLength('latitude', 'decimal[10,6]'));
     }
 
+    public function testGetTypeAndLengthReturnsIntegerTypes()
+    {
+        // Test that lengths are returned as integers, not strings
+        [$type, $length] = $this->columnParser->getTypeAndLength('name', 'string[128]');
+        $this->assertIsInt($length);
+        $this->assertSame(128, $length);
+
+        [$type, $length] = $this->columnParser->getTypeAndLength('count', 'integer[9]');
+        $this->assertIsInt($length);
+        $this->assertSame(9, $length);
+
+        // Test that precision/scale arrays contain integers
+        [$type, $length] = $this->columnParser->getTypeAndLength('amount', 'decimal[10,6]');
+        $this->assertIsArray($length);
+        $this->assertCount(2, $length);
+        $this->assertIsInt($length[0]);
+        $this->assertIsInt($length[1]);
+        $this->assertSame(10, $length[0]);
+        $this->assertSame(6, $length[1]);
+
+        // Test default lengths are also integers
+        [$type, $length] = $this->columnParser->getTypeAndLength('name', 'string');
+        $this->assertIsInt($length);
+        $this->assertSame(255, $length);
+
+        [$type, $length] = $this->columnParser->getTypeAndLength('id', 'integer');
+        $this->assertIsInt($length);
+        $this->assertSame(11, $length);
+    }
+
     public function testGetLength()
     {
         $this->assertSame(255, $this->columnParser->getLength('string'));

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -413,6 +413,189 @@ class ColumnParserTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testParseFieldsWithDefaultValues()
+    {
+        // Test boolean default true
+        $expected = [
+            'active' => [
+                'columnType' => 'boolean',
+                'options' => [
+                    'null' => false,
+                    'default' => true,
+                ],
+            ],
+        ];
+        $actual = $this->columnParser->parseFields(['active:boolean:default[true]']);
+        $this->assertEquals($expected, $actual);
+
+        // Test boolean default false
+        $expected = [
+            'skip_updates' => [
+                'columnType' => 'boolean',
+                'options' => [
+                    'null' => false,
+                    'default' => false,
+                ],
+            ],
+        ];
+        $actual = $this->columnParser->parseFields(['skip_updates:boolean:default[false]']);
+        $this->assertEquals($expected, $actual);
+
+        // Test integer default
+        $expected = [
+            'count' => [
+                'columnType' => 'integer',
+                'options' => [
+                    'null' => false,
+                    'default' => 0,
+                    'limit' => 11,
+                ],
+            ],
+        ];
+        $actual = $this->columnParser->parseFields(['count:integer:default[0]']);
+        $this->assertEquals($expected, $actual);
+
+        // Test string default with quotes
+        $expected = [
+            'status' => [
+                'columnType' => 'string',
+                'options' => [
+                    'null' => false,
+                    'default' => 'pending',
+                    'limit' => 255,
+                ],
+            ],
+        ];
+        $actual = $this->columnParser->parseFields(["status:string:default['pending']"]);
+        $this->assertEquals($expected, $actual);
+
+        // Test nullable with default
+        $expected = [
+            'role' => [
+                'columnType' => 'string',
+                'options' => [
+                    'null' => true,
+                    'default' => 'user',
+                    'limit' => 255,
+                ],
+            ],
+        ];
+        $actual = $this->columnParser->parseFields(["role:string?:default['user']"]);
+        $this->assertEquals($expected, $actual);
+
+        // Test default with index
+        $expected = [
+            'email' => [
+                'columnType' => 'string',
+                'options' => [
+                    'null' => false,
+                    'default' => null,
+                    'limit' => 255,
+                ],
+            ],
+        ];
+        $actual = $this->columnParser->parseFields(['email:string:default[null]:unique']);
+        $this->assertEquals($expected, $actual);
+
+        // Test float default
+        $expected = [
+            'rate' => [
+                'columnType' => 'decimal',
+                'options' => [
+                    'null' => false,
+                    'default' => 1.5,
+                    'precision' => 10,
+                    'scale' => 6,
+                ],
+            ],
+        ];
+        $actual = $this->columnParser->parseFields(['rate:decimal:default[1.5]']);
+        $this->assertEquals($expected, $actual);
+
+        // Test length with default
+        $expected = [
+            'code' => [
+                'columnType' => 'string',
+                'options' => [
+                    'null' => false,
+                    'default' => 'ABC',
+                    'limit' => 10,
+                ],
+            ],
+        ];
+        $actual = $this->columnParser->parseFields(["code:string[10]:default['ABC']"]);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testParseDefaultValue()
+    {
+        // Test null values
+        $this->assertNull($this->columnParser->parseDefaultValue(null, 'string'));
+        $this->assertNull($this->columnParser->parseDefaultValue('null', 'string'));
+        $this->assertNull($this->columnParser->parseDefaultValue('NULL', 'string'));
+
+        // Test boolean values
+        $this->assertTrue($this->columnParser->parseDefaultValue('true', 'boolean'));
+        $this->assertTrue($this->columnParser->parseDefaultValue('TRUE', 'boolean'));
+        $this->assertFalse($this->columnParser->parseDefaultValue('false', 'boolean'));
+        $this->assertFalse($this->columnParser->parseDefaultValue('FALSE', 'boolean'));
+
+        // Test integer values
+        $this->assertSame(0, $this->columnParser->parseDefaultValue('0', 'integer'));
+        $this->assertSame(123, $this->columnParser->parseDefaultValue('123', 'integer'));
+        $this->assertSame(-456, $this->columnParser->parseDefaultValue('-456', 'integer'));
+
+        // Test float values
+        $this->assertSame(1.5, $this->columnParser->parseDefaultValue('1.5', 'decimal'));
+        $this->assertSame(-2.75, $this->columnParser->parseDefaultValue('-2.75', 'decimal'));
+
+        // Test quoted strings
+        $this->assertSame('hello', $this->columnParser->parseDefaultValue("'hello'", 'string'));
+        $this->assertSame('world', $this->columnParser->parseDefaultValue('"world"', 'string'));
+
+        // Test SQL expressions (returned as-is)
+        $this->assertSame('CURRENT_TIMESTAMP', $this->columnParser->parseDefaultValue('CURRENT_TIMESTAMP', 'datetime'));
+    }
+
+    public function testParseIndexesWithDefaultValues()
+    {
+        // Ensure indexes still work with default values in the definition
+        $expected = [
+            'UNIQUE_EMAIL' => [
+                'columns' => ['email'],
+                'options' => ['unique' => true, 'name' => 'UNIQUE_EMAIL'],
+            ],
+        ];
+        $actual = $this->columnParser->parseIndexes(['email:string:default[null]:unique']);
+        $this->assertEquals($expected, $actual);
+
+        // Test with custom index name
+        $expected = [
+            'IDX_COUNT' => [
+                'columns' => ['count'],
+                'options' => ['unique' => false, 'name' => 'IDX_COUNT'],
+            ],
+        ];
+        $actual = $this->columnParser->parseIndexes(['count:integer:default[0]:index:IDX_COUNT']);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testValidArgumentsWithDefaultValues()
+    {
+        $this->assertEquals(
+            ['active:boolean:default[true]'],
+            $this->columnParser->validArguments(['active:boolean:default[true]']),
+        );
+        $this->assertEquals(
+            ['count:integer:default[0]:unique'],
+            $this->columnParser->validArguments(['count:integer:default[0]:unique']),
+        );
+        $this->assertEquals(
+            ["status:string:default['pending']:index:IDX_STATUS"],
+            $this->columnParser->validArguments(["status:string:default['pending']:index:IDX_STATUS"]),
+        );
+    }
+
     public function testParseForeignKeys()
     {
         // Test basic reference - infer table name from field

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -529,8 +529,9 @@ class ColumnParserTest extends TestCase
 
     public function testParseDefaultValue()
     {
-        // Test null values
+        // Test null and empty values
         $this->assertNull($this->columnParser->parseDefaultValue(null, 'string'));
+        $this->assertNull($this->columnParser->parseDefaultValue('', 'string'));
         $this->assertNull($this->columnParser->parseDefaultValue('null', 'string'));
         $this->assertNull($this->columnParser->parseDefaultValue('NULL', 'string'));
 


### PR DESCRIPTION
## Summary

- Adds support for specifying default column values in the `bake migration` command using a new `default[value]` syntax
- Updated the column grammar in the help text to document the new syntax
- Added comprehensive tests for the new functionality

## Examples

```bash
# Boolean defaults
bin/cake bake migration AddActiveToUsers active:boolean:default[true]
bin/cake bake migration AddSkipUpdatesToEventImports skip_updates:boolean:default[false]

# Integer defaults
bin/cake bake migration AddCountToProducts count:integer:default[0]

# String defaults (quoted)
bin/cake bake migration AddStatusToOrders status:string:default['pending']

# Combined with other options
bin/cake bake migration AddCountToProducts count:integer:default[0]:unique
bin/cake bake migration AddRoleToUsers role:string?:default['user']
```

## Supported Value Types

- Booleans: `true`, `false`
- Integers: `0`, `123`, `-456`
- Floats: `1.5`, `-2.75`
- Strings: `'hello'` or `"world"` (quoted)
- Null: `null` or `NULL`
- SQL expressions: `CURRENT_TIMESTAMP` (passed through as-is)

## Test plan

- [x] All existing tests pass
- [x] New tests added for `parseDefaultValue()` method
- [x] New tests added for `parseFields()` with default values
- [x] New tests added for `parseIndexes()` with default values
- [x] New tests added for `validArguments()` with default values
- [x] Code style checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)