### PR TITLE
Remove null collate option from generated migrations

### DIFF
--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -17,7 +17,6 @@ use ArrayAccess;
 use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
-use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Schema\CollectionInterface;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Utility\Hash;
@@ -401,18 +400,19 @@ class MigrationHelper extends Helper
         if (empty($columnOptions['autoIncrement'])) {
             unset($columnOptions['autoIncrement']);
         }
+        if (empty($columnOptions['collate'])) {
+            unset($columnOptions['collate']);
+        }
 
         // currently only MySQL supports the signed option
         $driver = $connection->getDriver();
         $isMysql = $driver instanceof Mysql;
-        $isSqlserver = $driver instanceof Sqlserver;
-
         if (!$isMysql) {
             unset($columnOptions['signed']);
         }
 
-        if (($isMysql || $isSqlserver) && !empty($columnOptions['collate'])) {
-            // due to Phinx using different naming for the collation
+        if (!empty($columnOptions['collate'])) {
+            // Phinx uses 'collation' not 'collate'
             $columnOptions['collation'] = $columnOptions['collate'];
             unset($columnOptions['collate']);
         }

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -397,4 +397,52 @@ class MigrationHelperTest extends TestCase
             ],
         ]));
     }
+
+    /**
+     * Test that getColumnOption removes null collate for all databases
+     *
+     * @see https://github.com/cakephp/migrations/issues/974
+     */
+    public function testGetColumnOptionRemovesNullCollate(): void
+    {
+        $options = [
+            'length' => 255,
+            'null' => true,
+            'default' => null,
+            'collate' => null,
+        ];
+
+        $result = $this->helper->getColumnOption($options);
+
+        // collate => null should NOT be in the output for any database
+        // because it causes "collate is not a valid column option" error
+        $this->assertArrayNotHasKey('collate', $result, 'collate => null should be removed');
+        $this->assertArrayNotHasKey('collation', $result, 'collation should not be set when collate is null');
+    }
+
+    /**
+     * Test that getColumnOption converts collate to collation for all databases
+     *
+     * Phinx uses 'collation' not 'collate', so this must be converted for any database
+     * that supports per-column collation (MySQL, SQL Server, PostgreSQL, SQLite).
+     *
+     * @see https://github.com/cakephp/migrations/issues/974
+     */
+    public function testGetColumnOptionConvertsCollateToCollation(): void
+    {
+        $options = [
+            'length' => 255,
+            'null' => true,
+            'default' => null,
+            'collate' => 'en_US.UTF-8',
+        ];
+
+        $result = $this->helper->getColumnOption($options);
+
+        // collate should be converted to collation for Phinx compatibility
+        // This is a bug: currently only MySQL/SQLServer convert this
+        $this->assertArrayNotHasKey('collate', $result, 'collate should be converted to collation');
+        $this->assertArrayHasKey('collation', $result, 'collation should be set from collate value');
+        $this->assertSame('en_US.UTF-8', $result['collation']);
+    }
 }


### PR DESCRIPTION
## Summary
- Removes empty/null `collate` option from column options in `MigrationHelper::getColumnOption()`
- Fixes "collate is not a valid column option" error when running migrations on PostgreSQL

Fixes #974