### PR TITLE
Show migration table name in status command output

### DIFF
--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -64,7 +64,7 @@ class StatusCommand extends Command
             '<info>migrations status -c secondary</info>',
             '<info>migrations status -c secondary  -f json</info>',
             '<info>migrations status --cleanup</info>',
-            'Remove *MISSING* migrations from the phinxlog table',
+            'Remove *MISSING* migrations from the migration tracking table',
         ])->addOption('plugin', [
             'short' => 'p',
             'help' => 'The plugin to run migrations for',
@@ -82,7 +82,7 @@ class StatusCommand extends Command
             'choices' => ['text', 'json'],
             'default' => 'text',
         ])->addOption('cleanup', [
-            'help' => 'Remove MISSING migrations from the phinxlog table',
+            'help' => 'Remove MISSING migrations from the migration tracking table',
             'boolean' => true,
             'default' => false,
         ]);
@@ -123,6 +123,7 @@ class StatusCommand extends Command
         }
 
         $migrations = $manager->printStatus($format);
+        $tableName = $manager->getSchemaTableName();
 
         switch ($format) {
             case 'json':
@@ -134,7 +135,7 @@ class StatusCommand extends Command
                 $io->out($migrationString);
                 break;
             default:
-                $this->display($migrations, $io);
+                $this->display($migrations, $io, $tableName);
                 break;
         }
 
@@ -146,10 +147,14 @@ class StatusCommand extends Command
      *
      * @param array $migrations
      * @param \Cake\Console\ConsoleIo $io The console io
+     * @param string $tableName The migration tracking table name
      * @return void
      */
-    protected function display(array $migrations, ConsoleIo $io): void
+    protected function display(array $migrations, ConsoleIo $io, string $tableName): void
     {
+        $io->out(sprintf('using migration table <info>%s</info>', $tableName));
+        $io->out('');
+
         if ($migrations) {
             $rows = [];
             $rows[] = ['Status', 'Migration ID', 'Migration Name'];

--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -651,9 +651,9 @@ interface AdapterInterface
     public function hasDatabase(string $name): bool;
 
     /**
-     * Cleanup missing migrations from the phinxlog table
+     * Cleanup missing migrations from the migration tracking table.
      *
-     * Removes entries from the phinxlog table for migrations that no longer exist
+     * Removes entries from the migrations table for migrations that no longer exist
      * in the migrations directory (marked as MISSING in status output).
      *
      * @return void
@@ -715,4 +715,15 @@ interface AdapterInterface
      * @return \Cake\Database\Connection The connection
      */
     public function getConnection(): Connection;
+
+    /**
+     * Gets the schema table name.
+     *
+     * Returns the table name used for migration tracking based on configuration:
+     * - 'cake_migrations' for unified mode
+     * - 'phinxlog' or '{plugin}_phinxlog' for legacy mode
+     *
+     * @return string The migration tracking table name
+     */
+    public function getSchemaTableName(): string;
 }

--- a/src/Db/Adapter/AdapterWrapper.php
+++ b/src/Db/Adapter/AdapterWrapper.php
@@ -572,4 +572,12 @@ abstract class AdapterWrapper implements WrapperInterface
     {
         return $this->getAdapter()->getIo();
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSchemaTableName(): string
+    {
+        return $this->getAdapter()->getSchemaTableName();
+    }
 }

--- a/src/Db/Adapter/MigrationsTableStorage.php
+++ b/src/Db/Adapter/MigrationsTableStorage.php
@@ -60,9 +60,9 @@ class MigrationsTableStorage
     }
 
     /**
-     * Cleanup missing migrations from the phinxlog table
+     * Cleanup missing migrations from the migration tracking table.
      *
-     * Removes entries from the phinxlog table for migrations that no longer exist
+     * Removes entries from the migrations table for migrations that no longer exist
      * in the migrations directory (marked as MISSING in status output).
      *
      * @param array $missingVersions The list of missing migration versions.

--- a/src/Db/Adapter/UnifiedMigrationsTableStorage.php
+++ b/src/Db/Adapter/UnifiedMigrationsTableStorage.php
@@ -47,9 +47,9 @@ class UnifiedMigrationsTableStorage
     }
 
     /**
-     * Cleanup missing migrations from the phinxlog table
+     * Cleanup missing migrations from the migration tracking table.
      *
-     * Removes entries from the phinxlog table for migrations that no longer exist
+     * Removes entries from the migrations table for migrations that no longer exist
      * in the migrations directory (marked as MISSING in status output).
      *
      * @param array $missingVersions The list of missing migration versions.

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -1331,9 +1331,23 @@ class Manager
     }
 
     /**
-     * Cleanup missing migrations from the phinxlog table
+     * Gets the schema table name being used for migration tracking.
      *
-     * Removes entries from the phinxlog table for migrations that no longer exist
+     * Returns the actual table name based on current configuration:
+     * - 'cake_migrations' for unified mode
+     * - 'phinxlog' or '{plugin}_phinxlog' for legacy mode
+     *
+     * @return string The migration tracking table name
+     */
+    public function getSchemaTableName(): string
+    {
+        return $this->getEnvironment()->getAdapter()->getSchemaTableName();
+    }
+
+    /**
+     * Cleanup missing migrations from the migration tracking table.
+     *
+     * Removes entries from the migrations table for migrations that no longer exist
      * in the migrations directory (marked as MISSING in status output).
      *
      * @return int The number of missing migrations removed
@@ -1345,7 +1359,7 @@ class Manager
         $versions = $env->getVersionLog();
         $adapter = $env->getAdapter();
 
-        // Find missing migrations (those in phinxlog but not in filesystem)
+        // Find missing migrations (those in migration table but not in filesystem)
         $missingVersions = [];
         foreach ($versions as $versionId => $versionInfo) {
             if (!isset($defaultMigrations[$versionId])) {

--- a/tests/TestCase/Command/StatusCommandTest.php
+++ b/tests/TestCase/Command/StatusCommandTest.php
@@ -28,6 +28,8 @@ class StatusCommandTest extends TestCase
     {
         $this->exec('migrations status -c test');
         $this->assertExitSuccess();
+        // Check for table name info
+        $this->assertOutputContains('using migration table');
         // Check for headers
         $this->assertOutputContains('Status');
         $this->assertOutputContains('Migration ID');


### PR DESCRIPTION
## Summary
- Display which migration tracking table is being used (`cake_migrations` or `phinxlog`) in the status command output
- This helps users understand which table format they are using during upgrades
- Updates help text to use generic 'migration tracking table' instead of 'phinxlog' since the table name varies based on configuration

Example output:
```
using migration table cake_migrations

 Status | Migration ID     | Migration Name
 up     | 20231201000000   | CreateUsers
```

## Changes
- Added `getSchemaTableName()` method to `AdapterInterface` and `AdapterWrapper`
- Added `getSchemaTableName()` method to `Manager` class  
- Updated `StatusCommand` to display table name before the migration list
- Updated help text references from 'phinxlog' to 'migration tracking table'
- Updated doc comments in storage classes