### PR TITLE
Fix hasTable() returning stale results when mixing API and execute()

### DIFF
--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -203,7 +203,10 @@ class MysqlAdapter extends AbstractAdapter
      */
     public function hasTable(string $tableName): bool
     {
-        if ($this->hasCreatedTable($tableName)) {
+        // Only use the cache in dry-run mode where tables aren't actually created.
+        // In normal mode, always check the database to handle cases where tables
+        // are dropped via execute() which doesn't update the cache.
+        if ($this->isDryRunEnabled() && $this->hasCreatedTable($tableName)) {
             return true;
         }
 

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -100,9 +100,13 @@ class PostgresAdapter extends AbstractAdapter
      */
     public function hasTable(string $tableName): bool
     {
-        if ($this->hasCreatedTable($tableName)) {
+        // Only use the cache in dry-run mode where tables aren't actually created.
+        // In normal mode, always check the database to handle cases where tables
+        // are dropped via execute() which doesn't update the cache.
+        if ($this->isDryRunEnabled() && $this->hasCreatedTable($tableName)) {
             return true;
         }
+
         $parts = $this->getSchemaName($tableName);
         $tableName = $parts['table'];
 

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -229,7 +229,14 @@ class SqliteAdapter extends AbstractAdapter
      */
     public function hasTable(string $tableName): bool
     {
-        return $this->hasCreatedTable($tableName) || $this->resolveTable($tableName)['exists'];
+        // Only use the cache in dry-run mode where tables aren't actually created.
+        // In normal mode, always check the database to handle cases where tables
+        // are dropped via execute() which doesn't update the cache.
+        if ($this->isDryRunEnabled() && $this->hasCreatedTable($tableName)) {
+            return true;
+        }
+
+        return $this->resolveTable($tableName)['exists'];
     }
 
     /**

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -67,13 +67,17 @@ class SqlserverAdapter extends AbstractAdapter
      */
     public function hasTable(string $tableName): bool
     {
-        if ($this->hasCreatedTable($tableName)) {
+        // Only use the cache in dry-run mode where tables aren't actually created.
+        // In normal mode, always check the database to handle cases where tables
+        // are dropped via execute() which doesn't update the cache.
+        if ($this->isDryRunEnabled() && $this->hasCreatedTable($tableName)) {
             return true;
         }
+
         $parts = $this->getSchemaName($tableName);
         $dialect = $this->getSchemaDialect();
 
-        return $dialect->hasTable($tableName, $parts['schema']);
+        return $dialect->hasTable($parts['table'], $parts['schema']);
     }
 
     /**

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -2402,6 +2402,27 @@ INPUT;
         ];
     }
 
+    /**
+     * Test that hasTable() returns false after a table is dropped via execute().
+     *
+     * This verifies that hasTable() always checks the database rather than
+     * relying on an internal cache that could become stale when raw SQL is used.
+     */
+    public function testHasTableAfterExecuteDrop(): void
+    {
+        // Create table via API
+        $table = new Table('cache_test', [], $this->adapter);
+        $table->addColumn('name', 'string')
+              ->save();
+
+        $this->assertTrue($this->adapter->hasTable('cache_test'));
+
+        // Drop via execute() - hasTable() must still return false
+        $this->adapter->execute('DROP TABLE "cache_test"');
+
+        $this->assertFalse($this->adapter->hasTable('cache_test'));
+    }
+
     #[DataProvider('provideIndexColumnsToCheck')]
     public function testHasIndex($tableDef, $cols, $exp)
     {


### PR DESCRIPTION
## Summary

- Fix `hasTable()` returning stale results when mixing API calls with raw SQL via `execute()`
- When a table is created via API (e.g. `$this->table()->create()`) and dropped via `execute()`, `hasTable()` would incorrectly return `true` due to an internal cache
- The cache is now only used in dry-run mode where it's needed to track what tables "would" exist

## Problem

```php
// In a migration
$this->table('foo')->addColumn('bar', 'string')->create();
$this->table('foo')->exists();  // true ✓

$this->execute('DROP TABLE foo');
$this->table('foo')->exists();  // true ✗ (should be false!)
```

The `$createdTables` cache was being checked first in `hasTable()`, returning `true` without querying the database.

## Solution

Only use the cache in dry-run mode. In normal execution, always query the database for accurate results.


Note:
There was also a 2nd issue in code.
The issue was a latent bug in SqlserverAdapter - it was passing the full nschema.ntable to dialect->hasTable() instead of just ntable. The cache was hiding this bug before.