### PR TITLE
Fix EntryCommandTest for updated console help format

### DIFF
--- a/tests/TestCase/Command/EntryCommandTest.php
+++ b/tests/TestCase/Command/EntryCommandTest.php
@@ -41,7 +41,7 @@ class EntryCommandTest extends TestCase
         $this->exec('migrations --help');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('Available Commands');
+        $this->assertOutputContains('migrations:');
         $this->assertOutputContains('migrations migrate');
         $this->assertOutputContains('migrations status');
         $this->assertOutputContains('migrations rollback');


### PR DESCRIPTION
## Summary

- Fix failing `EntryCommandTest::testExecuteHelp` test
- The console help output format changed from showing "Available Commands" to category-based grouping (e.g. "migrations:")
- Updated test assertion to match the new format