### PR TITLE
Strip 'Seed' suffix from seed names in all command output

### DIFF
--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -21,6 +21,7 @@ use Cake\Event\EventDispatcherTrait;
 use Exception;
 use Migrations\Config\ConfigInterface;
 use Migrations\Migration\ManagerFactory;
+use Migrations\Util\Util;
 
 /**
  * Seed command runs seeder scripts
@@ -182,11 +183,7 @@ class SeedCommand extends Command
                 $io->out('');
                 $io->out('<info>The following seeds will be executed:</info>');
                 foreach ($availableSeeds as $seed) {
-                    $seedName = $seed->getName();
-                    if (str_ends_with($seedName, 'Seed')) {
-                        $seedName = substr($seedName, 0, -4);
-                    }
-                    $io->out('  - ' . $seedName);
+                    $io->out('  - ' . Util::getSeedDisplayName($seed->getName()));
                 }
                 $io->out('');
                 if (!(bool)$args->getOption('force')) {

--- a/src/Command/SeedResetCommand.php
+++ b/src/Command/SeedResetCommand.php
@@ -141,10 +141,10 @@ class SeedResetCommand extends Command
                 if (!$config->isDryRun()) {
                     $adapter->removeSeedFromLog($seed);
                 }
-                $io->info("Reset: {$seedName}");
+                $io->info("Reset: {$seedName} seed");
                 $count++;
             } else {
-                $io->verbose("Skipped (not executed): {$seedName}");
+                $io->verbose("Skipped (not executed): {$seedName} seed");
             }
         }
 

--- a/src/Command/SeedResetCommand.php
+++ b/src/Command/SeedResetCommand.php
@@ -19,6 +19,7 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Migrations\Config\ConfigInterface;
 use Migrations\Migration\ManagerFactory;
+use Migrations\Util\Util;
 
 /**
  * Seed reset command removes seeds from the execution log
@@ -112,11 +113,7 @@ class SeedResetCommand extends Command
         $io->out('');
         $io->out('<info>All seeds will be reset:</info>');
         foreach ($seedsToReset as $seed) {
-            $seedName = $seed->getName();
-            if (str_ends_with($seedName, 'Seed')) {
-                $seedName = substr($seedName, 0, -4);
-            }
-            $io->out('  - ' . $seedName);
+            $io->out('  - ' . Util::getSeedDisplayName($seed->getName()));
         }
         $io->out('');
 
@@ -132,11 +129,7 @@ class SeedResetCommand extends Command
         // Reset the seeds
         $count = 0;
         foreach ($seedsToReset as $seed) {
-            $seedName = $seed->getName();
-            if (str_ends_with($seedName, 'Seed')) {
-                $seedName = substr($seedName, 0, -4);
-            }
-
+            $seedName = Util::getSeedDisplayName($seed->getName());
             if ($manager->isSeedExecuted($seed)) {
                 if (!$config->isDryRun()) {
                     $adapter->removeSeedFromLog($seed);

--- a/src/Command/SeedResetCommand.php
+++ b/src/Command/SeedResetCommand.php
@@ -132,14 +132,19 @@ class SeedResetCommand extends Command
         // Reset the seeds
         $count = 0;
         foreach ($seedsToReset as $seed) {
+            $seedName = $seed->getName();
+            if (str_ends_with($seedName, 'Seed')) {
+                $seedName = substr($seedName, 0, -4);
+            }
+
             if ($manager->isSeedExecuted($seed)) {
                 if (!$config->isDryRun()) {
                     $adapter->removeSeedFromLog($seed);
                 }
-                $io->info("Reset: {$seed->getName()}");
+                $io->info("Reset: {$seedName}");
                 $count++;
             } else {
-                $io->verbose("Skipped (not executed): {$seed->getName()}");
+                $io->verbose("Skipped (not executed): {$seedName}");
             }
         }
 

--- a/src/Command/SeedStatusCommand.php
+++ b/src/Command/SeedStatusCommand.php
@@ -129,8 +129,14 @@ class SeedStatusCommand extends Command
                 }
             }
 
+            // Strip 'Seed' suffix for display
+            $displayName = $seedName;
+            if (str_ends_with($displayName, 'Seed')) {
+                $displayName = substr($displayName, 0, -4);
+            }
+
             $statuses[] = [
-                'seedName' => $seedName,
+                'seedName' => $displayName,
                 'plugin' => $plugin,
                 'status' => $executed ? 'executed' : 'pending',
                 'executedAt' => $executedAt,

--- a/src/Command/SeedStatusCommand.php
+++ b/src/Command/SeedStatusCommand.php
@@ -20,6 +20,7 @@ use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
 use Migrations\Config\ConfigInterface;
 use Migrations\Migration\ManagerFactory;
+use Migrations\Util\Util;
 
 /**
  * Seed status command shows which seeds have been executed
@@ -130,11 +131,7 @@ class SeedStatusCommand extends Command
             }
 
             // Strip 'Seed' suffix for display and add ' seed' suffix
-            $displayName = $seedName;
-            if (str_ends_with($displayName, 'Seed')) {
-                $displayName = substr($displayName, 0, -4);
-            }
-            $displayName .= ' seed';
+            $displayName = Util::getSeedDisplayName($seedName) . ' seed';
 
             $statuses[] = [
                 'seedName' => $displayName,

--- a/src/Command/SeedStatusCommand.php
+++ b/src/Command/SeedStatusCommand.php
@@ -129,11 +129,12 @@ class SeedStatusCommand extends Command
                 }
             }
 
-            // Strip 'Seed' suffix for display
+            // Strip 'Seed' suffix for display and add ' seed' suffix
             $displayName = $seedName;
             if (str_ends_with($displayName, 'Seed')) {
                 $displayName = substr($displayName, 0, -4);
             }
+            $displayName .= ' seed';
 
             $statuses[] = [
                 'seedName' => $displayName,

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -625,7 +625,7 @@ class Manager
         }
 
         $this->printStatusOutput(
-            $seedName,
+            $seedName . ' seed',
             $status,
             $duration,
         );

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -619,13 +619,8 @@ class Manager
      */
     protected function printSeedStatus(SeedInterface $seed, string $status, ?string $duration = null): void
     {
-        $seedName = $seed->getName();
-        if (str_ends_with($seedName, 'Seed')) {
-            $seedName = substr($seedName, 0, -4);
-        }
-
         $this->printStatusOutput(
-            $seedName . ' seed',
+            Util::getSeedDisplayName($seed->getName()) . ' seed',
             $status,
             $duration,
         );

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -619,8 +619,13 @@ class Manager
      */
     protected function printSeedStatus(SeedInterface $seed, string $status, ?string $duration = null): void
     {
+        $seedName = $seed->getName();
+        if (str_ends_with($seedName, 'Seed')) {
+            $seedName = substr($seedName, 0, -4);
+        }
+
         $this->printStatusOutput(
-            $seed->getName(),
+            $seedName,
             $status,
             $duration,
         );

--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -193,6 +193,23 @@ class Util
     }
 
     /**
+     * Get a human-readable display name for a seed class.
+     *
+     * Strips the 'Seed' suffix from class names like 'UsersSeed' to produce 'Users'.
+     *
+     * @param string $seedName The seed class name
+     * @return string The display name without the 'Seed' suffix
+     */
+    public static function getSeedDisplayName(string $seedName): string
+    {
+        if (str_ends_with($seedName, 'Seed')) {
+            return substr($seedName, 0, -4);
+        }
+
+        return $seedName;
+    }
+
+    /**
      * Expands a set of paths with curly braces (if supported by the OS).
      *
      * @param string[] $paths Paths

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -96,7 +96,7 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test NumbersSeed');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('Numbers:</info> <comment>seeding');
+        $this->assertOutputContains('Numbers seed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -110,8 +110,8 @@ class SeedCommandTest extends TestCase
         $this->createTables();
         $this->exec('seeds run -c test --source BaseSeeds MigrationSeedNumbers');
         $this->assertExitSuccess();
-        $this->assertOutputContains('MigrationSeedNumbers:</info> <comment>seeding');
-        $this->assertOutputContains('AnotherNumbers:</info> <comment>seeding');
+        $this->assertOutputContains('MigrationSeedNumbers seed:</info> <comment>seeding');
+        $this->assertOutputContains('AnotherNumbers seed:</info> <comment>seeding');
         $this->assertOutputContains('radix=10');
         $this->assertOutputContains('fetchRow=121');
         $this->assertOutputContains('hasTable=1');
@@ -154,8 +154,8 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test --source CallSeeds LettersSeed,NumbersCallSeed');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('NumbersCall:</info> <comment>seeding');
-        $this->assertOutputContains('Letters:</info> <comment>seeding');
+        $this->assertOutputContains('NumbersCall seed:</info> <comment>seeding');
+        $this->assertOutputContains('Letters seed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -182,7 +182,7 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test StoresSeed');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('Stores:</info> <comment>seeding');
+        $this->assertOutputContains('Stores seed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -208,7 +208,7 @@ class SeedCommandTest extends TestCase
 
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
-        $this->assertOutputContains('Numbers:</info> <comment>seeding');
+        $this->assertOutputContains('Numbers seed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
     }
 
@@ -219,7 +219,7 @@ class SeedCommandTest extends TestCase
 
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
-        $this->assertOutputContains('Numbers:</info> <comment>seeding');
+        $this->assertOutputContains('Numbers seed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
     }
 
@@ -245,8 +245,8 @@ class SeedCommandTest extends TestCase
 
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
-        $this->assertOutputContains('NumbersCall:</info> <comment>seeding');
-        $this->assertOutputContains('Letters:</info> <comment>seeding');
+        $this->assertOutputContains('NumbersCall seed:</info> <comment>seeding');
+        $this->assertOutputContains('Letters seed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -303,7 +303,7 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test StoresSeed --dry-run');
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
-        $this->assertOutputContains('Stores:</info> <comment>seeding');
+        $this->assertOutputContains('Stores seed:</info> <comment>seeding');
 
         $finalCount = $connection->execute('SELECT COUNT(*) FROM stores')->fetchColumn(0);
         $this->assertEquals($initialCount, $finalCount, 'Dry-run mode should not modify stores table');
@@ -315,7 +315,7 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test AnonymousStoreSeed');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('AnonymousStore:</info> <comment>seeding');
+        $this->assertOutputContains('AnonymousStore seed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -334,7 +334,7 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test Numbers');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('Numbers:</info> <comment>seeding');
+        $this->assertOutputContains('Numbers seed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -349,8 +349,8 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test --source CallSeeds Letters,NumbersCall');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('NumbersCall:</info> <comment>seeding');
-        $this->assertOutputContains('Letters:</info> <comment>seeding');
+        $this->assertOutputContains('NumbersCall seed:</info> <comment>seeding');
+        $this->assertOutputContains('Letters seed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -368,7 +368,7 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test AnonymousStore');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('AnonymousStore:</info> <comment>seeding');
+        $this->assertOutputContains('AnonymousStore seed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -417,7 +417,7 @@ class SeedCommandTest extends TestCase
         $this->assertExitSuccess();
         $this->assertOutputNotContains('The following seeds will be executed:');
         $this->assertOutputNotContains('Do you want to continue?');
-        $this->assertOutputContains('Numbers:</info> <comment>seeding');
+        $this->assertOutputContains('Numbers seed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
     }
 
@@ -427,8 +427,8 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test --source CallSeeds Letters,NumbersCall');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('NumbersCall:</info> <comment>seeding');
-        $this->assertOutputContains('Letters:</info> <comment>seeding');
+        $this->assertOutputContains('NumbersCall seed:</info> <comment>seeding');
+        $this->assertOutputContains('Letters seed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -450,7 +450,7 @@ class SeedCommandTest extends TestCase
         // First run should execute the seed
         $this->exec('seeds run -c test NumbersSeed');
         $this->assertExitSuccess();
-        $this->assertOutputContains('Numbers:</info> <comment>seeding');
+        $this->assertOutputContains('Numbers seed:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         // Verify data was inserted
@@ -460,7 +460,7 @@ class SeedCommandTest extends TestCase
         // Second run should skip the seed (already executed)
         $this->exec('seeds run -c test NumbersSeed');
         $this->assertExitSuccess();
-        $this->assertOutputContains('Numbers:</info> <comment>already executed');
+        $this->assertOutputContains('Numbers seed:</info> <comment>already executed');
         $this->assertOutputNotContains('seeding');
 
         // Verify no additional data was inserted
@@ -470,7 +470,7 @@ class SeedCommandTest extends TestCase
         // Run with --force should re-execute
         $this->exec('seeds run -c test NumbersSeed --force');
         $this->assertExitSuccess();
-        $this->assertOutputContains('Numbers:</info> <comment>seeding');
+        $this->assertOutputContains('Numbers seed:</info> <comment>seeding');
 
         // Verify data was inserted again (now 2 records)
         $query = $connection->execute('SELECT COUNT(*) FROM numbers');

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -96,7 +96,7 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test NumbersSeed');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('Numbers:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -111,7 +111,7 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test --source BaseSeeds MigrationSeedNumbers');
         $this->assertExitSuccess();
         $this->assertOutputContains('MigrationSeedNumbers:</info> <comment>seeding');
-        $this->assertOutputContains('AnotherNumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('AnotherNumbers:</info> <comment>seeding');
         $this->assertOutputContains('radix=10');
         $this->assertOutputContains('fetchRow=121');
         $this->assertOutputContains('hasTable=1');
@@ -154,8 +154,8 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test --source CallSeeds LettersSeed,NumbersCallSeed');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('NumbersCallSeed:</info> <comment>seeding');
-        $this->assertOutputContains('LettersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('NumbersCall:</info> <comment>seeding');
+        $this->assertOutputContains('Letters:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -182,7 +182,7 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test StoresSeed');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('StoresSeed:</info> <comment>seeding');
+        $this->assertOutputContains('Stores:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -208,7 +208,7 @@ class SeedCommandTest extends TestCase
 
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
-        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('Numbers:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
     }
 
@@ -219,7 +219,7 @@ class SeedCommandTest extends TestCase
 
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
-        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('Numbers:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
     }
 
@@ -245,8 +245,8 @@ class SeedCommandTest extends TestCase
 
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
-        $this->assertOutputContains('NumbersCallSeed:</info> <comment>seeding');
-        $this->assertOutputContains('LettersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('NumbersCall:</info> <comment>seeding');
+        $this->assertOutputContains('Letters:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -303,7 +303,7 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test StoresSeed --dry-run');
         $this->assertExitSuccess();
         $this->assertOutputContains('DRY-RUN mode enabled');
-        $this->assertOutputContains('StoresSeed:</info> <comment>seeding');
+        $this->assertOutputContains('Stores:</info> <comment>seeding');
 
         $finalCount = $connection->execute('SELECT COUNT(*) FROM stores')->fetchColumn(0);
         $this->assertEquals($initialCount, $finalCount, 'Dry-run mode should not modify stores table');
@@ -315,7 +315,7 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test AnonymousStoreSeed');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('AnonymousStoreSeed:</info> <comment>seeding');
+        $this->assertOutputContains('AnonymousStore:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -334,7 +334,7 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test Numbers');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('Numbers:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -349,8 +349,8 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test --source CallSeeds Letters,NumbersCall');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('NumbersCallSeed:</info> <comment>seeding');
-        $this->assertOutputContains('LettersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('NumbersCall:</info> <comment>seeding');
+        $this->assertOutputContains('Letters:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -368,7 +368,7 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test AnonymousStore');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('AnonymousStoreSeed:</info> <comment>seeding');
+        $this->assertOutputContains('AnonymousStore:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -417,7 +417,7 @@ class SeedCommandTest extends TestCase
         $this->assertExitSuccess();
         $this->assertOutputNotContains('The following seeds will be executed:');
         $this->assertOutputNotContains('Do you want to continue?');
-        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('Numbers:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
     }
 
@@ -427,8 +427,8 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds run -c test --source CallSeeds Letters,NumbersCall');
 
         $this->assertExitSuccess();
-        $this->assertOutputContains('NumbersCallSeed:</info> <comment>seeding');
-        $this->assertOutputContains('LettersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('NumbersCall:</info> <comment>seeding');
+        $this->assertOutputContains('Letters:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         /** @var \Cake\Database\Connection $connection */
@@ -450,7 +450,7 @@ class SeedCommandTest extends TestCase
         // First run should execute the seed
         $this->exec('seeds run -c test NumbersSeed');
         $this->assertExitSuccess();
-        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('Numbers:</info> <comment>seeding');
         $this->assertOutputContains('All Done');
 
         // Verify data was inserted
@@ -460,7 +460,7 @@ class SeedCommandTest extends TestCase
         // Second run should skip the seed (already executed)
         $this->exec('seeds run -c test NumbersSeed');
         $this->assertExitSuccess();
-        $this->assertOutputContains('NumbersSeed:</info> <comment>already executed');
+        $this->assertOutputContains('Numbers:</info> <comment>already executed');
         $this->assertOutputNotContains('seeding');
 
         // Verify no additional data was inserted
@@ -470,7 +470,7 @@ class SeedCommandTest extends TestCase
         // Run with --force should re-execute
         $this->exec('seeds run -c test NumbersSeed --force');
         $this->assertExitSuccess();
-        $this->assertOutputContains('NumbersSeed:</info> <comment>seeding');
+        $this->assertOutputContains('Numbers:</info> <comment>seeding');
 
         // Verify data was inserted again (now 2 records)
         $query = $connection->execute('SELECT COUNT(*) FROM numbers');
@@ -495,7 +495,7 @@ class SeedCommandTest extends TestCase
         $this->exec('seeds status -c test');
         $this->assertExitSuccess();
         $this->assertOutputContains('executed');
-        $this->assertOutputContains('NumbersSeed');
+        $this->assertOutputContains('Numbers');
     }
 
     public function testSeedResetCommand(): void


### PR DESCRIPTION
## Summary

- Strip 'Seed' suffix from seed class names and add ' seed' suffix for clarity
- Status command now shows `Users seed` instead of `UsersSeed`
- Reset command output now shows `Reset: Users seed` instead of `Reset: UsersSeed`
- Execution output now shows `== Users seed: seeding` instead of `== UsersSeed: seeding`

Before:
```
  pending    ControllersActionsSeed
  executed   UsersSeed              (2026-01-02 19:40:50)

 == UsersSeed: already executed
```

After:
```
  pending    ControllersActions seed
  executed   Users seed              (2026-01-02 19:40:50)

 == Users seed: already executed
```

This makes the output clearer by showing human-readable names with "seed" suffix to indicate what type of entity is being displayed.