### PR TITLE
Add --fake flag to seeds run and --seed option to seeds reset

### DIFF
--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -93,6 +93,10 @@ class SeedCommand extends Command
                 'short' => 'f',
                 'help' => 'Force re-running seeds that have already been executed',
                 'boolean' => true,
+            ])
+            ->addOption('fake', [
+                'help' => 'Mark seeds as executed without actually running them',
+                'boolean' => true,
             ]);
 
         return $parser;
@@ -154,8 +158,13 @@ class SeedCommand extends Command
 
         $versionOrder = $config->getVersionOrder();
 
+        $fake = (bool)$args->getOption('fake');
+
         if ($config->isDryRun()) {
             $io->info('DRY-RUN mode enabled');
+        }
+        if ($fake) {
+            $io->warning('performing fake seeding');
         }
         $io->verbose('<info>using connection</info> ' . (string)$args->getOption('connection'));
         $io->verbose('<info>using paths</info> ' . $config->getMigrationPath());
@@ -205,11 +214,11 @@ class SeedCommand extends Command
             }
 
             // run all the seed(ers)
-            $manager->seed(null, (bool)$args->getOption('force'));
+            $manager->seed(null, (bool)$args->getOption('force'), $fake);
         } else {
             // run seed(ers) specified as arguments
             foreach ($seeds as $seed) {
-                $manager->seed(trim($seed), (bool)$args->getOption('force'));
+                $manager->seed(trim($seed), (bool)$args->getOption('force'), $fake);
             }
         }
         $end = microtime(true);

--- a/src/Command/SeedResetCommand.php
+++ b/src/Command/SeedResetCommand.php
@@ -49,8 +49,12 @@ class SeedResetCommand extends Command
             'allowing seeds to be re-run without the --force flag.',
             '',
             '<info>seeds reset</info>',
+            '<info>seeds reset --seed Users</info>',
+            '<info>seeds reset --seed Users,Posts</info>',
             '<info>seeds reset --plugin Demo</info>',
             '<info>seeds reset -c secondary</info>',
+        ])->addOption('seed', [
+            'help' => 'Comma-separated list of specific seeds to reset. Resets all seeds if not specified.',
         ])->addOption('plugin', [
             'short' => 'p',
             'help' => 'The plugin to reset seeds for',
@@ -100,8 +104,24 @@ class SeedResetCommand extends Command
         $seeds = $manager->getSeeds();
         $adapter = $manager->getEnvironment()->getAdapter();
 
-        // Reset all seeds
+        // Filter seeds if --seed option is specified
+        $seedOption = $args->getOption('seed');
         $seedsToReset = $seeds;
+
+        if ($seedOption) {
+            $requestedSeeds = array_map('trim', explode(',', (string)$seedOption));
+            $seedsToReset = [];
+
+            foreach ($requestedSeeds as $requestedSeed) {
+                $normalizedName = $manager->normalizeSeedName($requestedSeed, $seeds);
+                if ($normalizedName === null) {
+                    $io->error("Seed `{$requestedSeed}` does not exist.");
+
+                    return self::CODE_ERROR;
+                }
+                $seedsToReset[$normalizedName] = $seeds[$normalizedName];
+            }
+        }
 
         if (empty($seedsToReset)) {
             $io->warning('No seeds to reset.');
@@ -111,7 +131,8 @@ class SeedResetCommand extends Command
 
         // Show what will be reset and ask for confirmation
         $io->out('');
-        $io->out('<info>All seeds will be reset:</info>');
+        $resetAllMessage = $seedOption ? '<info>The following seeds will be reset:</info>' : '<info>All seeds will be reset:</info>';
+        $io->out($resetAllMessage);
         foreach ($seedsToReset as $seed) {
             $io->out('  - ' . Util::getSeedDisplayName($seed->getName()));
         }

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -540,9 +540,10 @@ class Manager
      *
      * @param \Migrations\SeedInterface $seed Seed
      * @param bool $force Force re-execution even if seed has already been executed
+     * @param bool $fake Record seed as executed without actually running it
      * @return void
      */
-    public function executeSeed(SeedInterface $seed, bool $force = false): void
+    public function executeSeed(SeedInterface $seed, bool $force = false, bool $fake = false): void
     {
         $this->getIo()->out('');
 
@@ -560,6 +561,26 @@ class Manager
             return;
         }
 
+        // Ensure seed schema table exists
+        $adapter = $this->getEnvironment()->getAdapter();
+        if (!$adapter->hasTable($adapter->getSeedSchemaTableName())) {
+            $adapter->createSeedSchemaTable();
+        }
+
+        if ($fake) {
+            // Record seed as executed without running it
+            $this->printSeedStatus($seed, 'faking');
+
+            if (!$seed->isIdempotent()) {
+                $executedTime = date('Y-m-d H:i:s');
+                $adapter->seedExecuted($seed, $executedTime);
+            }
+
+            $this->printSeedStatus($seed, 'faked');
+
+            return;
+        }
+
         // Auto-execute missing dependencies
         $missingDeps = $this->getSeedDependenciesNotExecuted($seed);
         if (!empty($missingDeps)) {
@@ -568,17 +589,11 @@ class Manager
                     '  Auto-executing dependency: %s',
                     $depSeed->getName(),
                 ));
-                $this->executeSeed($depSeed, $force);
+                $this->executeSeed($depSeed, $force, $fake);
             }
         }
 
         $this->printSeedStatus($seed, 'seeding');
-
-        // Ensure seed schema table exists
-        $adapter = $this->getEnvironment()->getAdapter();
-        if (!$adapter->hasTable($adapter->getSeedSchemaTableName())) {
-            $adapter->createSeedSchemaTable();
-        }
 
         // Execute the seeder and log the time elapsed.
         $start = microtime(true);
@@ -794,10 +809,11 @@ class Manager
      *
      * @param string|null $seed Seeder
      * @param bool $force Force re-execution even if seed has already been executed
+     * @param bool $fake Record seed as executed without actually running it
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function seed(?string $seed = null, bool $force = false): void
+    public function seed(?string $seed = null, bool $force = false, bool $fake = false): void
     {
         $seeds = $this->getSeeds();
 
@@ -805,14 +821,14 @@ class Manager
             // run all seeders
             foreach ($seeds as $seeder) {
                 if (array_key_exists($seeder->getName(), $seeds)) {
-                    $this->executeSeed($seeder, $force);
+                    $this->executeSeed($seeder, $force, $fake);
                 }
             }
         } else {
             // run only one seeder
             $normalizedName = $this->normalizeSeedName($seed, $seeds);
             if ($normalizedName !== null) {
-                $this->executeSeed($seeds[$normalizedName], $force);
+                $this->executeSeed($seeds[$normalizedName], $force, $fake);
             } else {
                 throw new InvalidArgumentException(sprintf('The seed `%s` does not exist', $seed));
             }

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -568,13 +568,18 @@ class Manager
         }
 
         if ($fake) {
+            // Idempotent seeds are not tracked, so faking doesn't apply
+            if ($seed->isIdempotent()) {
+                $this->printSeedStatus($seed, 'skipped (idempotent)');
+
+                return;
+            }
+
             // Record seed as executed without running it
             $this->printSeedStatus($seed, 'faking');
 
-            if (!$seed->isIdempotent()) {
-                $executedTime = date('Y-m-d H:i:s');
-                $adapter->seedExecuted($seed, $executedTime);
-            }
+            $executedTime = date('Y-m-d H:i:s');
+            $adapter->seedExecuted($seed, $executedTime);
 
             $this->printSeedStatus($seed, 'faked');
 

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -691,4 +691,23 @@ class SeedCommandTest extends TestCase
         $this->assertExitError();
         $this->assertErrorContains('Seed `NonExistent` does not exist');
     }
+
+    public function testFakeIdempotentSeedIsSkipped(): void
+    {
+        $this->createTables();
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+
+        // Run idempotent seed with --fake flag
+        $this->exec('seeds run -c test -s TestSeeds IdempotentTest --fake');
+        $this->assertExitSuccess();
+        $this->assertOutputContains('skipped (idempotent)');
+        $this->assertOutputNotContains('faking');
+        $this->assertOutputNotContains('faked');
+
+        // Verify the seed was NOT tracked (idempotent seeds are never tracked)
+        $seedLog = $connection->execute('SELECT COUNT(*) FROM cake_seeds WHERE seed_name = \'IdempotentTestSeed\'');
+        $this->assertEquals(0, $seedLog->fetchColumn(0), 'Idempotent seeds should not be tracked even when faked');
+    }
 }

--- a/tests/TestCase/Command/SeedCommandTest.php
+++ b/tests/TestCase/Command/SeedCommandTest.php
@@ -570,4 +570,125 @@ class SeedCommandTest extends TestCase
         $this->assertOutputContains('already executed');
         $this->assertOutputNotContains('seeding');
     }
+
+    public function testFakeSeedMarksAsExecuted(): void
+    {
+        $this->createTables();
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+
+        // Run with --fake flag
+        $this->exec('seeds run -c test NumbersSeed --fake');
+        $this->assertExitSuccess();
+        $this->assertErrorContains('performing fake seeding');
+        $this->assertOutputContains('faking');
+        $this->assertOutputContains('faked');
+        $this->assertOutputNotContains('seeding');
+
+        // Verify NO data was inserted
+        $query = $connection->execute('SELECT COUNT(*) FROM numbers');
+        $this->assertEquals(0, $query->fetchColumn(0), 'Fake seed should not insert data');
+
+        // Verify the seed WAS tracked in cake_seeds table
+        $seedLog = $connection->execute('SELECT COUNT(*) FROM cake_seeds WHERE seed_name = \'NumbersSeed\'');
+        $this->assertEquals(1, $seedLog->fetchColumn(0), 'Fake seeds should be tracked');
+
+        // Running again should show already executed
+        $this->exec('seeds run -c test NumbersSeed');
+        $this->assertExitSuccess();
+        $this->assertOutputContains('already executed');
+    }
+
+    public function testFakeSeedWithForce(): void
+    {
+        $this->createTables();
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+
+        // Run with --fake first
+        $this->exec('seeds run -c test NumbersSeed --fake');
+        $this->assertExitSuccess();
+
+        // Verify seed is tracked
+        $seedLog = $connection->execute('SELECT COUNT(*) FROM cake_seeds WHERE seed_name = \'NumbersSeed\'');
+        $this->assertEquals(1, $seedLog->fetchColumn(0));
+
+        // Run with --force to actually execute it
+        $this->exec('seeds run -c test NumbersSeed --force');
+        $this->assertExitSuccess();
+        $this->assertOutputContains('seeding');
+
+        // Verify data was inserted
+        $query = $connection->execute('SELECT COUNT(*) FROM numbers');
+        $this->assertEquals(1, $query->fetchColumn(0));
+    }
+
+    public function testResetSpecificSeed(): void
+    {
+        $this->createTables();
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+
+        // Run two seeds
+        $this->exec('seeds run -c test NumbersSeed');
+        $this->assertExitSuccess();
+
+        $this->exec('seeds run -c test StoresSeed');
+        $this->assertExitSuccess();
+
+        // Verify both are tracked
+        $numbersLog = $connection->execute('SELECT COUNT(*) FROM cake_seeds WHERE seed_name = \'NumbersSeed\'');
+        $this->assertEquals(1, $numbersLog->fetchColumn(0));
+
+        $storesLog = $connection->execute('SELECT COUNT(*) FROM cake_seeds WHERE seed_name = \'StoresSeed\'');
+        $this->assertEquals(1, $storesLog->fetchColumn(0));
+
+        // Reset only Numbers seed
+        $this->exec('seeds reset -c test --seed Numbers', ['y']);
+        $this->assertExitSuccess();
+        $this->assertOutputContains('The following seeds will be reset:');
+        $this->assertOutputNotContains('All seeds will be reset:');
+
+        // Verify Numbers is reset but Stores is still tracked
+        $numbersLog = $connection->execute('SELECT COUNT(*) FROM cake_seeds WHERE seed_name = \'NumbersSeed\'');
+        $this->assertEquals(0, $numbersLog->fetchColumn(0), 'Numbers seed should be reset');
+
+        $storesLog = $connection->execute('SELECT COUNT(*) FROM cake_seeds WHERE seed_name = \'StoresSeed\'');
+        $this->assertEquals(1, $storesLog->fetchColumn(0), 'Stores seed should still be tracked');
+    }
+
+    public function testResetMultipleSpecificSeeds(): void
+    {
+        $this->createTables();
+
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+
+        // Run seeds
+        $this->exec('seeds run -c test NumbersSeed');
+        $this->exec('seeds run -c test StoresSeed');
+
+        // Reset both with comma-separated list
+        $this->exec('seeds reset -c test --seed Numbers,Stores', ['y']);
+        $this->assertExitSuccess();
+
+        // Verify both are reset
+        $numbersLog = $connection->execute('SELECT COUNT(*) FROM cake_seeds WHERE seed_name = \'NumbersSeed\'');
+        $this->assertEquals(0, $numbersLog->fetchColumn(0));
+
+        $storesLog = $connection->execute('SELECT COUNT(*) FROM cake_seeds WHERE seed_name = \'StoresSeed\'');
+        $this->assertEquals(0, $storesLog->fetchColumn(0));
+    }
+
+    public function testResetNonExistentSeed(): void
+    {
+        $this->createTables();
+
+        $this->exec('seeds reset -c test --seed NonExistent');
+        $this->assertExitError();
+        $this->assertErrorContains('Seed `NonExistent` does not exist');
+    }
 }


### PR DESCRIPTION
## Summary

- Add `--fake` flag to `seeds run` command to mark seeds as executed without running them
- Add `--seed` option to `seeds reset` command for selective seed reset

### New features

**Fake seeding:**
```bash
# Mark a seed as executed without running it
bin/cake seeds run Users --fake

# Useful when you've manually populated data or want to skip certain seeds
```

**Selective reset:**
```bash
# Reset only specific seeds
bin/cake seeds reset --seed Users
bin/cake seeds reset --seed Users,Posts

# Still supports resetting all seeds (existing behavior)
bin/cake seeds reset
```

Both features mirror similar functionality available in migrations.