### PR TITLE
Fix phinx backend using incorrect RollbackCommand class

### DIFF
--- a/src/MigrationsPlugin.php
+++ b/src/MigrationsPlugin.php
@@ -131,15 +131,16 @@ class MigrationsPlugin extends BasePlugin
             return $commands;
         }
 
+        $classes = $this->migrationCommandsList;
         if (class_exists(SimpleBakeCommand::class)) {
-            $found = $commands->discoverPlugin($this->getName());
-
-            return $commands->addMany($found);
+            $classes[] = BakeMigrationCommand::class;
+            $classes[] = BakeMigrationDiffCommand::class;
+            $classes[] = BakeMigrationSnapshotCommand::class;
+            $classes[] = BakeSeedCommand::class;
         }
 
         $found = [];
-        // Convert to a method and use config to toggle command names.
-        foreach ($this->migrationCommandsList as $class) {
+        foreach ($classes as $class) {
             $name = $class::defaultName();
             // If the short name has been used, use the full name.
             // This allows app commands to have name preference.

--- a/tests/TestCase/MigrationsPluginTest.php
+++ b/tests/TestCase/MigrationsPluginTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Migrations\Test\TestCase;
+
+use Cake\Console\CommandCollection;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use Migrations\Command\MigrationsRollbackCommand;
+use Migrations\Command\RollbackCommand;
+use Migrations\MigrationsPlugin;
+
+class MigrationsPluginTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Configure::delete('Migrations.backend');
+    }
+
+    /**
+     * Test that builtin backend uses RollbackCommand
+     */
+    public function testConsoleBuiltinBackendUsesCorrectRollbackCommand(): void
+    {
+        Configure::write('Migrations.backend', 'builtin');
+
+        $plugin = new MigrationsPlugin();
+        $commands = new CommandCollection();
+        $commands = $plugin->console($commands);
+
+        $this->assertTrue($commands->has('migrations rollback'));
+        $this->assertSame(RollbackCommand::class, $commands->get('migrations rollback'));
+    }
+
+    /**
+     * Test that phinx backend uses MigrationsRollbackCommand
+     *
+     * This is the reported bug in https://github.com/cakephp/migrations/issues/990
+     */
+    public function testConsolePhinxBackendUsesCorrectRollbackCommand(): void
+    {
+        Configure::write('Migrations.backend', 'phinx');
+
+        $plugin = new MigrationsPlugin();
+        $commands = new CommandCollection();
+        $commands = $plugin->console($commands);
+
+        $this->assertTrue($commands->has('migrations rollback'));
+        // Bug: RollbackCommand is loaded instead of MigrationsRollbackCommand
+        $this->assertSame(MigrationsRollbackCommand::class, $commands->get('migrations rollback'));
+    }
+}


### PR DESCRIPTION
## Summary

- Fix phinx backend incorrectly loading `RollbackCommand` instead of `MigrationsRollbackCommand`
- Add regression test for command registration in both backends

## Root Cause

When using `Migrations.backend = 'phinx'` with Bake installed, `discoverPlugin()` scanned the entire `Command/` directory and found both:
- `RollbackCommand` (builtin) with `defaultName() => 'migrations rollback'`
- `MigrationsRollbackCommand` (phinx) also returning `'migrations rollback'`

Due to alphabetical ordering during discovery, `RollbackCommand` (R > M) was loaded after `MigrationsRollbackCommand`, overwriting it.

## Fix

Replace `discoverPlugin()` with explicit command registration for the phinx backend, matching the approach already used for the builtin backend. This ensures only the correct phinx-specific commands are registered.

Fixes #990