### PR TITLE
Improve insertOrUpdate() API consistency across database adapters

### DIFF
--- a/docs/en/seeding.rst
+++ b/docs/en/seeding.rst
@@ -450,6 +450,89 @@ within your seed class and then use the ``insert()`` method to insert data:
     You must call the ``saveData()`` method to commit your data to the table.
     Migrations will buffer data until you do so.
 
+Insert Modes
+============
+
+In addition to the standard ``insert()`` method, Migrations provides specialized
+insert methods for handling conflicts with existing data.
+
+Insert or Skip
+--------------
+
+The ``insertOrSkip()`` method inserts rows but silently skips any that would
+violate a unique constraint:
+
+.. code-block:: php
+
+    <?php
+
+    use Migrations\BaseSeed;
+
+    class CurrencySeed extends BaseSeed
+    {
+        public function run(): void
+        {
+            $data = [
+                ['code' => 'USD', 'name' => 'US Dollar'],
+                ['code' => 'EUR', 'name' => 'Euro'],
+            ];
+
+            $this->table('currencies')
+                ->insertOrSkip($data)
+                ->saveData();
+        }
+    }
+
+Insert or Update (Upsert)
+-------------------------
+
+The ``insertOrUpdate()`` method performs an "upsert" operation - inserting new
+rows and updating existing rows that conflict on unique columns:
+
+.. code-block:: php
+
+    <?php
+
+    use Migrations\BaseSeed;
+
+    class ExchangeRateSeed extends BaseSeed
+    {
+        public function run(): void
+        {
+            $data = [
+                ['code' => 'USD', 'rate' => 1.0000],
+                ['code' => 'EUR', 'rate' => 0.9234],
+            ];
+
+            $this->table('exchange_rates')
+                ->insertOrUpdate($data, ['rate'], ['code'])
+                ->saveData();
+        }
+    }
+
+The method takes three arguments:
+
+- ``$data``: The rows to insert (same format as ``insert()``)
+- ``$updateColumns``: Which columns to update when a conflict occurs
+- ``$conflictColumns``: Which columns define uniqueness (must have a unique index)
+
+.. warning::
+
+    Database-specific behavior differences:
+
+    **MySQL**: Uses ``ON DUPLICATE KEY UPDATE``. The ``$conflictColumns`` parameter
+    is ignored because MySQL automatically applies the update to *all* unique
+    constraint violations on the table. Passing ``$conflictColumns`` will trigger
+    a warning. If your table has multiple unique constraints, be aware that a
+    conflict on *any* of them will trigger the update.
+
+    **PostgreSQL/SQLite**: Uses ``ON CONFLICT (...) DO UPDATE SET``. The
+    ``$conflictColumns`` parameter is required and specifies exactly which unique
+    constraint should trigger the update. A ``RuntimeException`` will be thrown
+    if this parameter is empty.
+
+    **SQL Server**: Not currently supported. Use separate insert/update logic.
+
 Truncating Tables
 =================
 

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -732,7 +732,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
      *
      * MySQL's ON DUPLICATE KEY UPDATE applies to all unique key constraints on the table,
      * so the $conflictColumns parameter is not used. If you pass conflictColumns when using
-     * MySQL, a deprecation warning will be triggered.
+     * MySQL, a warning will be triggered.
      *
      * @param \Migrations\Db\InsertMode|null $mode Insert mode
      * @param array<string>|null $updateColumns Columns to update on conflict
@@ -746,10 +746,10 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
         }
 
         if ($conflictColumns !== null) {
-            deprecationWarning(
-                '5.1.0',
+            trigger_error(
                 'The $conflictColumns parameter is ignored by MySQL. ' .
                 'MySQL\'s ON DUPLICATE KEY UPDATE applies to all unique constraints on the table.',
+                E_USER_WARNING,
             );
         }
 

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -730,6 +730,10 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     /**
      * Get the upsert clause for MySQL (ON DUPLICATE KEY UPDATE).
      *
+     * MySQL's ON DUPLICATE KEY UPDATE applies to all unique key constraints on the table,
+     * so the $conflictColumns parameter is not used. If you pass conflictColumns when using
+     * MySQL, a deprecation warning will be triggered.
+     *
      * @param \Migrations\Db\InsertMode|null $mode Insert mode
      * @param array<string>|null $updateColumns Columns to update on conflict
      * @param array<string>|null $conflictColumns Columns that define uniqueness (unused in MySQL)
@@ -739,6 +743,14 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
     {
         if ($mode !== InsertMode::UPSERT || $updateColumns === null) {
             return '';
+        }
+
+        if ($conflictColumns !== null) {
+            deprecationWarning(
+                '5.1.0',
+                'The $conflictColumns parameter is ignored by MySQL. ' .
+                'MySQL\'s ON DUPLICATE KEY UPDATE applies to all unique constraints on the table.',
+            );
         }
 
         $updates = [];

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -1288,10 +1288,15 @@ class PostgresAdapter extends AbstractAdapter
     /**
      * Get the ON CONFLICT clause based on insert mode.
      *
+     * PostgreSQL requires explicit conflict columns to determine which unique constraint
+     * should trigger the update. Unlike MySQL's ON DUPLICATE KEY UPDATE which applies
+     * to all unique constraints, PostgreSQL's ON CONFLICT clause must specify the columns.
+     *
      * @param \Migrations\Db\InsertMode|null $mode Insert mode
      * @param array<string>|null $updateColumns Columns to update on upsert conflict
-     * @param array<string>|null $conflictColumns Columns that define uniqueness for upsert
+     * @param array<string>|null $conflictColumns Columns that define uniqueness for upsert (required for PostgreSQL)
      * @return string
+     * @throws \RuntimeException When using UPSERT mode without conflictColumns
      */
     protected function getConflictClause(
         ?InsertMode $mode = null,
@@ -1302,7 +1307,13 @@ class PostgresAdapter extends AbstractAdapter
             return ' ON CONFLICT DO NOTHING';
         }
 
-        if ($mode === InsertMode::UPSERT && $updateColumns !== null && $conflictColumns !== null) {
+        if ($mode === InsertMode::UPSERT) {
+            if ($conflictColumns === null || $conflictColumns === []) {
+                throw new RuntimeException(
+                    'PostgreSQL requires the $conflictColumns parameter for insertOrUpdate(). ' .
+                    'Specify the columns that have a unique constraint to determine conflict resolution.',
+                );
+            }
             $quotedConflictColumns = array_map($this->quoteColumnName(...), $conflictColumns);
             $updates = [];
             foreach ($updateColumns as $column) {

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1713,15 +1713,27 @@ PCRE_PATTERN;
     /**
      * Get the upsert clause for SQLite (ON CONFLICT ... DO UPDATE SET).
      *
+     * SQLite requires explicit conflict columns to determine which unique constraint
+     * should trigger the update. Unlike MySQL's ON DUPLICATE KEY UPDATE which applies
+     * to all unique constraints, SQLite's ON CONFLICT clause must specify the columns.
+     *
      * @param \Migrations\Db\InsertMode|null $mode Insert mode
      * @param array<string>|null $updateColumns Columns to update on conflict
-     * @param array<string>|null $conflictColumns Columns that define uniqueness for upsert
+     * @param array<string>|null $conflictColumns Columns that define uniqueness for upsert (required for SQLite)
      * @return string
+     * @throws \RuntimeException When using UPSERT mode without conflictColumns
      */
     protected function getUpsertClause(?InsertMode $mode, ?array $updateColumns, ?array $conflictColumns = null): string
     {
-        if ($mode !== InsertMode::UPSERT || $updateColumns === null || $conflictColumns === null) {
+        if ($mode !== InsertMode::UPSERT || $updateColumns === null) {
             return '';
+        }
+
+        if ($conflictColumns === null || $conflictColumns === []) {
+            throw new RuntimeException(
+                'SQLite requires the $conflictColumns parameter for insertOrUpdate(). ' .
+                'Specify the columns that have a unique constraint to determine conflict resolution.',
+            );
         }
 
         $quotedConflictColumns = array_map($this->quoteColumnName(...), $conflictColumns);

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -810,7 +810,7 @@ class Table
      *
      * - **MySQL**: Uses `ON DUPLICATE KEY UPDATE`. The `$conflictColumns` parameter is
      *   ignored because MySQL automatically applies the update to all unique constraint
-     *   violations. Passing `$conflictColumns` will trigger a deprecation warning.
+     *   violations. Passing `$conflictColumns` will trigger a warning.
      *
      * - **PostgreSQL/SQLite**: Uses `ON CONFLICT (...) DO UPDATE SET`. The `$conflictColumns`
      *   parameter is required and must specify the columns that have a unique constraint.
@@ -830,7 +830,7 @@ class Table
      * @param array $data array of data in the same format as insert()
      * @param array<string> $updateColumns Columns to update when a conflict occurs
      * @param array<string> $conflictColumns Columns that define uniqueness. Required for PostgreSQL/SQLite,
-     *   ignored by MySQL (triggers deprecation warning if provided).
+     *   ignored by MySQL (triggers warning if provided).
      * @return $this
      * @throws \RuntimeException When using PostgreSQL or SQLite without specifying conflictColumns
      */

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -806,8 +806,21 @@ class Table
      * This method performs an "upsert" operation - inserting new rows and updating
      * existing rows that conflict on the specified unique columns.
      *
-     * Example:
+     * ### Database-specific behavior:
+     *
+     * - **MySQL**: Uses `ON DUPLICATE KEY UPDATE`. The `$conflictColumns` parameter is
+     *   ignored because MySQL automatically applies the update to all unique constraint
+     *   violations. Passing `$conflictColumns` will trigger a deprecation warning.
+     *
+     * - **PostgreSQL/SQLite**: Uses `ON CONFLICT (...) DO UPDATE SET`. The `$conflictColumns`
+     *   parameter is required and must specify the columns that have a unique constraint.
+     *   A RuntimeException will be thrown if this parameter is empty.
+     *
+     * - **SQL Server**: Not currently supported. Use separate insert/update logic.
+     *
+     * ### Example:
      * ```php
+     * // Works on all supported databases
      * $table->insertOrUpdate([
      *     ['code' => 'USD', 'rate' => 1.0000],
      *     ['code' => 'EUR', 'rate' => 0.9234],
@@ -816,8 +829,10 @@ class Table
      *
      * @param array $data array of data in the same format as insert()
      * @param array<string> $updateColumns Columns to update when a conflict occurs
-     * @param array<string> $conflictColumns Columns that define uniqueness (must have unique index)
+     * @param array<string> $conflictColumns Columns that define uniqueness. Required for PostgreSQL/SQLite,
+     *   ignored by MySQL (triggers deprecation warning if provided).
      * @return $this
+     * @throws \RuntimeException When using PostgreSQL or SQLite without specifying conflictColumns
      */
     public function insertOrUpdate(array $data, array $updateColumns, array $conflictColumns)
     {

--- a/src/SeedInterface.php
+++ b/src/SeedInterface.php
@@ -161,14 +161,25 @@ interface SeedInterface
      * This method performs an "upsert" operation - inserting new rows and updating
      * existing rows that conflict on the specified unique columns.
      *
-     * Uses ON DUPLICATE KEY UPDATE (MySQL), or ON CONFLICT ... DO UPDATE SET
-     * (PostgreSQL/SQLite).
+     * ### Database-specific behavior:
+     *
+     * - **MySQL**: Uses `ON DUPLICATE KEY UPDATE`. The `$conflictColumns` parameter is
+     *   ignored because MySQL automatically applies the update to all unique constraint
+     *   violations. Passing `$conflictColumns` will trigger a deprecation warning.
+     *
+     * - **PostgreSQL/SQLite**: Uses `ON CONFLICT (...) DO UPDATE SET`. The `$conflictColumns`
+     *   parameter is required and must specify the columns that have a unique constraint.
+     *   A RuntimeException will be thrown if this parameter is empty.
+     *
+     * - **SQL Server**: Not currently supported. Use separate insert/update logic.
      *
      * @param string $tableName Table name
      * @param array $data Data
      * @param array<string> $updateColumns Columns to update when a conflict occurs
-     * @param array<string> $conflictColumns Columns that define uniqueness (must have unique index)
+     * @param array<string> $conflictColumns Columns that define uniqueness. Required for PostgreSQL/SQLite,
+     *   ignored by MySQL (triggers deprecation warning if provided).
      * @return void
+     * @throws \RuntimeException When using PostgreSQL or SQLite without specifying conflictColumns
      */
     public function insertOrUpdate(string $tableName, array $data, array $updateColumns, array $conflictColumns): void;
 

--- a/src/SeedInterface.php
+++ b/src/SeedInterface.php
@@ -165,7 +165,7 @@ interface SeedInterface
      *
      * - **MySQL**: Uses `ON DUPLICATE KEY UPDATE`. The `$conflictColumns` parameter is
      *   ignored because MySQL automatically applies the update to all unique constraint
-     *   violations. Passing `$conflictColumns` will trigger a deprecation warning.
+     *   violations. Passing `$conflictColumns` will trigger a warning.
      *
      * - **PostgreSQL/SQLite**: Uses `ON CONFLICT (...) DO UPDATE SET`. The `$conflictColumns`
      *   parameter is required and must specify the columns that have a unique constraint.
@@ -177,7 +177,7 @@ interface SeedInterface
      * @param array $data Data
      * @param array<string> $updateColumns Columns to update when a conflict occurs
      * @param array<string> $conflictColumns Columns that define uniqueness. Required for PostgreSQL/SQLite,
-     *   ignored by MySQL (triggers deprecation warning if provided).
+     *   ignored by MySQL (triggers warning if provided).
      * @return void
      * @throws \RuntimeException When using PostgreSQL or SQLite without specifying conflictColumns
      */

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -10,6 +10,7 @@ use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
 use InvalidArgumentException;
 use Migrations\Db\Adapter\AdapterInterface;
+use RuntimeException;
 use Migrations\Db\Adapter\PostgresAdapter;
 use Migrations\Db\Literal;
 use Migrations\Db\Table;
@@ -2983,6 +2984,22 @@ OUTPUT;
         $table->insert([
             ['code' => 'ITEM1', 'name' => 'Different Name'],
         ])->save();
+    }
+
+    public function testInsertOrUpdateRequiresConflictColumns()
+    {
+        $table = new Table('currencies', [], $this->adapter);
+        $table->addColumn('code', 'string', ['limit' => 3])
+            ->addColumn('rate', 'decimal', ['precision' => 10, 'scale' => 4])
+            ->addIndex('code', ['unique' => true])
+            ->create();
+
+        // PostgreSQL requires conflictColumns for insertOrUpdate
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('PostgreSQL requires the $conflictColumns parameter');
+        $table->insertOrUpdate([
+            ['code' => 'USD', 'rate' => 1.0000],
+        ], ['rate'], [])->save();
     }
 
     public function testAddSinglePartitionToExistingTable()

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -10,7 +10,6 @@ use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
 use InvalidArgumentException;
 use Migrations\Db\Adapter\AdapterInterface;
-use RuntimeException;
 use Migrations\Db\Adapter\PostgresAdapter;
 use Migrations\Db\Literal;
 use Migrations\Db\Table;
@@ -24,6 +23,7 @@ use PDOException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class PostgresAdapterTest extends TestCase
 {

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -3377,4 +3377,20 @@ INPUT;
             ['code' => 'ITEM1', 'name' => 'Different Name'],
         ])->save();
     }
+
+    public function testInsertOrUpdateRequiresConflictColumns()
+    {
+        $table = new Table('currencies', [], $this->adapter);
+        $table->addColumn('code', 'string', ['limit' => 3])
+            ->addColumn('rate', 'decimal', ['precision' => 10, 'scale' => 4])
+            ->addIndex('code', ['unique' => true])
+            ->create();
+
+        // SQLite requires conflictColumns for insertOrUpdate
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('SQLite requires the $conflictColumns parameter');
+        $table->insertOrUpdate([
+            ['code' => 'USD', 'rate' => 1.0000],
+        ], ['rate'], [])->save();
+    }
 }


### PR DESCRIPTION
## Summary

Addresses API consistency issues with `insertOrUpdate()` across different database adapters:

- **MySQL**: The `$conflictColumns` parameter is ignored because MySQL's `ON DUPLICATE KEY UPDATE` automatically applies to all unique constraints. Now triggers a deprecation warning when passed.

- **PostgreSQL/SQLite**: The `$conflictColumns` parameter is required. Now throws a `RuntimeException` with a clear message if missing or empty.

- **Documentation**: Added comprehensive docblocks explaining the database-specific behavior in `Table.php` and `SeedInterface.php`.

## Changes

- Add deprecation warning in `AbstractAdapter::getUpsertClause()` when `$conflictColumns` is passed (MySQL)
- Add RuntimeException in `PostgresAdapter::getConflictClause()` when `$conflictColumns` is missing
- Add RuntimeException in `SqliteAdapter::getUpsertClause()` when `$conflictColumns` is missing
- Update documentation for `Table::insertOrUpdate()` and `SeedInterface::insertOrUpdate()`
- Add tests for conflict column validation in PostgreSQL and SQLite adapters

## Test plan

- [x] Run SQLite adapter test for conflict column validation
- [ ] Run PostgreSQL adapter test for conflict column validation
- [ ] Run MySQL adapter tests to verify deprecation doesn't break existing functionality
- [ ] Run phpcs and phpstan checks