### PR TITLE
Normalize exception handling in command classes

### DIFF
--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -19,7 +19,6 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Event\EventDispatcherTrait;
 use DateTime;
-use Exception;
 use LogicException;
 use Migrations\Config\ConfigInterface;
 use Migrations\Migration\ManagerFactory;
@@ -170,11 +169,6 @@ class MigrateCommand extends Command
                 $manager->migrate($version, $fake, $count);
             }
             $end = microtime(true);
-        } catch (Exception $e) {
-            $io->err('<error>' . $e->getMessage() . '</error>');
-            $io->verbose($e->getTraceAsString());
-
-            return self::CODE_ERROR;
         } catch (Throwable $e) {
             $io->err('<error>' . $e->getMessage() . '</error>');
             $io->verbose($e->getTraceAsString());

--- a/src/Command/RollbackCommand.php
+++ b/src/Command/RollbackCommand.php
@@ -19,7 +19,6 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Event\EventDispatcherTrait;
 use DateTime;
-use Exception;
 use InvalidArgumentException;
 use LogicException;
 use Migrations\Config\ConfigInterface;
@@ -183,11 +182,6 @@ class RollbackCommand extends Command
                 $manager->rollback($target, $force, $targetMustMatch, $fake);
             }
             $end = microtime(true);
-        } catch (Exception $e) {
-            $io->err('<error>' . $e->getMessage() . '</error>');
-            $io->verbose($e->getTraceAsString());
-
-            return self::CODE_ERROR;
         } catch (Throwable $e) {
             $io->err('<error>' . $e->getMessage() . '</error>');
             $io->verbose($e->getTraceAsString());

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -18,10 +18,10 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Event\EventDispatcherTrait;
-use Exception;
 use Migrations\Config\ConfigInterface;
 use Migrations\Migration\ManagerFactory;
 use Migrations\Util\Util;
+use Throwable;
 
 /**
  * Seed command runs seeder scripts
@@ -166,8 +166,9 @@ class SeedCommand extends Command
             // Get all available seeds and ask for confirmation
             try {
                 $availableSeeds = $manager->getSeeds();
-            } catch (Exception $e) {
-                $io->error('Failed to load seeds: ' . $e->getMessage());
+            } catch (Throwable $e) {
+                $io->err('<error>Failed to load seeds: ' . $e->getMessage() . '</error>');
+                $io->verbose($e->getTraceAsString());
 
                 return static::CODE_ERROR;
             }


### PR DESCRIPTION
## Summary

Normalizes exception handling patterns across command classes for consistency.

## Changes

### MigrateCommand & RollbackCommand
- Remove redundant `catch (Exception $e)` block since `catch (Throwable $e)` already covers all exceptions
- Remove unused `use Exception;` import

### SeedCommand
- Change from `catch (Exception $e)` to `catch (Throwable $e)` for consistency
- Use `$io->err('<error>...</error>')` instead of `$io->error()` to match other commands
- Add `$io->verbose($e->getTraceAsString())` for debugging consistency

## Before/After

**Before (MigrateCommand/RollbackCommand):**
```php
} catch (Exception $e) {
    $io->err('<error>' . $e->getMessage() . '</error>');
    $io->verbose($e->getTraceAsString());
    return self::CODE_ERROR;
} catch (Throwable $e) {
    $io->err('<error>' . $e->getMessage() . '</error>');
    $io->verbose($e->getTraceAsString());
    return self::CODE_ERROR;
}
```

**After:**
```php
} catch (Throwable $e) {
    $io->err('<error>' . $e->getMessage() . '</error>');
    $io->verbose($e->getTraceAsString());
    return self::CODE_ERROR;
}
```

## Test plan

- [x] phpcs passes
- [x] phpstan passes
- [ ] Existing tests pass