### PR TITLE
Remove phinx backend test from 5.x

### DIFF
--- a/tests/TestCase/MigrationsPluginTest.php
+++ b/tests/TestCase/MigrationsPluginTest.php
@@ -4,44 +4,22 @@ declare(strict_types=1);
 namespace Migrations\Test\TestCase;
 
 use Cake\Console\CommandCollection;
-use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
-use Migrations\Command\MigrationsRollbackCommand;
 use Migrations\Command\RollbackCommand;
 use Migrations\MigrationsPlugin;
 
 class MigrationsPluginTest extends TestCase
 {
     /**
-     * Test that builtin backend uses RollbackCommand
+     * Test that console() registers the correct RollbackCommand
      */
-    public function testConsoleBuiltinBackendUsesCorrectRollbackCommand(): void
+    public function testConsoleUsesCorrectRollbackCommand(): void
     {
-        Configure::write('Migrations.backend', 'builtin');
-
         $plugin = new MigrationsPlugin();
         $commands = new CommandCollection();
         $commands = $plugin->console($commands);
 
         $this->assertTrue($commands->has('migrations rollback'));
         $this->assertSame(RollbackCommand::class, $commands->get('migrations rollback'));
-    }
-
-    /**
-     * Test that phinx backend uses MigrationsRollbackCommand
-     *
-     * This is the reported bug in https://github.com/cakephp/migrations/issues/990
-     */
-    public function testConsolePhinxBackendUsesCorrectRollbackCommand(): void
-    {
-        Configure::write('Migrations.backend', 'phinx');
-
-        $plugin = new MigrationsPlugin();
-        $commands = new CommandCollection();
-        $commands = $plugin->console($commands);
-
-        $this->assertTrue($commands->has('migrations rollback'));
-        // Bug: RollbackCommand is loaded instead of MigrationsRollbackCommand
-        $this->assertSame(MigrationsRollbackCommand::class, $commands->get('migrations rollback'));
     }
 }

--- a/tests/comparisons/Migration/test_snapshot_postgres_timestamp_tz_pgsql.php
+++ b/tests/comparisons/Migration/test_snapshot_postgres_timestamp_tz_pgsql.php
@@ -9,7 +9,7 @@ class TestSnapshotPostgresTimestampTzPgsql extends BaseMigration
      * Up Method.
      *
      * More information on this method is available here:
-     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     * https://book.cakephp.org/migrations/5/en/migrations.html#the-up-method
      *
      * @return void
      */
@@ -47,14 +47,14 @@ class TestSnapshotPostgresTimestampTzPgsql extends BaseMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
                 'scale' => 6,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -83,14 +83,14 @@ class TestSnapshotPostgresTimestampTzPgsql extends BaseMigration
                 'limit' => 100,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
                 'scale' => 6,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -194,14 +194,14 @@ class TestSnapshotPostgresTimestampTzPgsql extends BaseMigration
                 'limit' => 10,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
                 'scale' => 6,
             ])
-            ->addColumn('modified', 'timestamp', [
+            ->addColumn('modified', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -261,7 +261,7 @@ class TestSnapshotPostgresTimestampTzPgsql extends BaseMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addColumn('highlighted_time', 'timestamp', [
+            ->addColumn('highlighted_time', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -299,14 +299,14 @@ class TestSnapshotPostgresTimestampTzPgsql extends BaseMigration
                 'limit' => 256,
                 'null' => true,
             ])
-            ->addColumn('created', 'timestamp', [
+            ->addColumn('created', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
                 'precision' => 6,
                 'scale' => 6,
             ])
-            ->addColumn('updated', 'timestamp', [
+            ->addColumn('updated', 'timestampfractional', [
                 'default' => null,
                 'limit' => null,
                 'null' => true,
@@ -359,7 +359,7 @@ class TestSnapshotPostgresTimestampTzPgsql extends BaseMigration
      * Down Method.
      *
      * More information on this method is available here:
-     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     * https://book.cakephp.org/migrations/5/en/migrations.html#the-down-method
      *
      * @return void
      */


### PR DESCRIPTION
## Summary

- Remove phinx backend test that was incorrectly merged from 4.x
- The phinx backend was removed in 5.x, so this test is not applicable

Fixes the CI failures caused by testing non-existent phinx backend functionality.