### PR TITLE
Fix release readiness issues for 5.x

### DIFF
--- a/src/BaseSeed.php
+++ b/src/BaseSeed.php
@@ -238,7 +238,9 @@ class BaseSeed implements SeedInterface
     public function call(string $seeder, array $options = []): void
     {
         $io = $this->getIo();
-        assert($io !== null, 'Requires ConsoleIo');
+        if ($io === null) {
+            throw new RuntimeException('ConsoleIo is required for calling other seeders.');
+        }
         $io->out('');
         $io->out(
             ' ====' .
@@ -285,7 +287,9 @@ class BaseSeed implements SeedInterface
             'source' => $options['source'],
         ]);
         $io = $this->getIo();
-        assert($io !== null, 'Missing ConsoleIo instance');
+        if ($io === null) {
+            throw new RuntimeException('ConsoleIo is required for calling other seeders.');
+        }
         $manager = $factory->createManager($io);
         $manager->seed($seeder);
     }

--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -20,8 +20,14 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Database\Connection;
 use Cake\Database\Schema\CachedCollection;
+use Cake\Database\Schema\CheckConstraint;
 use Cake\Database\Schema\CollectionInterface;
+use Cake\Database\Schema\Column;
+use Cake\Database\Schema\Constraint;
+use Cake\Database\Schema\ForeignKey;
+use Cake\Database\Schema\Index;
 use Cake\Database\Schema\TableSchema;
+use Cake\Database\Schema\UniqueKey;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
@@ -554,6 +560,12 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             'allowed_classes' => [
                 TableSchema::class,
                 CachedCollection::class,
+                Column::class,
+                Index::class,
+                Constraint::class,
+                UniqueKey::class,
+                ForeignKey::class,
+                CheckConstraint::class,
             ],
         ]);
     }

--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -19,6 +19,7 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Database\Connection;
+use Cake\Database\Schema\CachedCollection;
 use Cake\Database\Schema\CollectionInterface;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
@@ -485,7 +486,7 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             $lastVersion = $this->migratedItems[0]['version'];
             $lastFile = end($this->migrationsFiles);
 
-            return $lastFile && (bool)strpos($lastFile, (string)$lastVersion);
+            return $lastFile && str_contains($lastFile, (string)$lastVersion);
         }
 
         return false;
@@ -546,7 +547,15 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             $this->io->abort($msg);
         }
 
-        return unserialize((string)file_get_contents($path));
+        $contents = (string)file_get_contents($path);
+
+        // Use allowed_classes to restrict deserialization to safe CakePHP schema classes
+        return unserialize($contents, [
+            'allowed_classes' => [
+                TableSchema::class,
+                CachedCollection::class,
+            ],
+        ]);
     }
 
     /**

--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -25,7 +25,6 @@ use Cake\Core\Plugin;
 use Cake\Utility\Inflector;
 use DateTime;
 use DateTimeZone;
-use InvalidArgumentException;
 use Migrations\Util\Util;
 
 /**
@@ -121,14 +120,7 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
      */
     public function getPath(Arguments $args): string
     {
-        $source = (string)$args->getOption('source');
-        // Validate source option to prevent path traversal
-        if (preg_match('/\.\.[\\/\\\\]|^[\\/\\\\]/', $source)) {
-            throw new InvalidArgumentException(
-                'The --source option cannot contain path traversal patterns or absolute paths.',
-            );
-        }
-        $migrationFolder = $this->pathFragment . DS . $source . DS;
+        $migrationFolder = $this->pathFragment . DS . $args->getOption('source') . DS;
         $path = ROOT . DS . $migrationFolder;
         if ($this->plugin) {
             $path = $this->_pluginPath($this->plugin) . $migrationFolder;

--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -25,6 +25,7 @@ use Cake\Core\Plugin;
 use Cake\Utility\Inflector;
 use DateTime;
 use DateTimeZone;
+use InvalidArgumentException;
 use Migrations\Util\Util;
 
 /**
@@ -120,7 +121,14 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
      */
     public function getPath(Arguments $args): string
     {
-        $migrationFolder = $this->pathFragment . DS . $args->getOption('source') . DS;
+        $source = (string)$args->getOption('source');
+        // Validate source option to prevent path traversal
+        if (preg_match('/\.\.[\\/\\\\]|^[\\/\\\\]/', $source)) {
+            throw new InvalidArgumentException(
+                'The --source option cannot contain path traversal patterns or absolute paths.',
+            );
+        }
+        $migrationFolder = $this->pathFragment . DS . $source . DS;
         $path = ROOT . DS . $migrationFolder;
         if ($this->plugin) {
             $path = $this->_pluginPath($this->plugin) . $migrationFolder;

--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -141,7 +141,7 @@ class DumpCommand extends Command
 
             return self::CODE_SUCCESS;
         }
-        $io->error("An error occurred while writing dump file `{$filePath}`");
+        $io->err("<error>An error occurred while writing dump file `{$filePath}`</error>");
 
         return self::CODE_ERROR;
     }

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -725,7 +725,9 @@ class MysqlAdapter extends AbstractAdapter
         foreach ($rows as $row) {
             if (strcasecmp($row['Field'], $columnName) === 0) {
                 $null = $row['Null'] === 'NO' ? 'NOT NULL' : 'NULL';
-                $comment = isset($row['Comment']) ? ' COMMENT ' . '\'' . addslashes($row['Comment']) . '\'' : '';
+                $comment = isset($row['Comment']) && $row['Comment'] !== ''
+                    ? ' COMMENT ' . $this->getConnection()->getDriver()->schemaValue($row['Comment'])
+                    : '';
 
                 // create the extra string by also filtering out the DEFAULT_GENERATED option (MySQL 8 fix)
                 $extras = array_filter(

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -1105,27 +1105,40 @@ SQL;
 
     /**
      * @inheritDoc
+     *
+     * Note: Check constraints are not supported for SQL Server adapter.
+     * This method returns an empty array. Use raw SQL via execute() if you need
+     * check constraints on SQL Server.
      */
     protected function getCheckConstraints(string $tableName): array
     {
-        // TODO: Implement check constraints for SQL Server
         return [];
     }
 
     /**
      * @inheritDoc
+     *
+     * @throws \BadMethodCallException Check constraints are not supported for SQL Server.
      */
     protected function getAddCheckConstraintInstructions(TableMetadata $table, CheckConstraint $checkConstraint): AlterInstructions
     {
-        throw new BadMethodCallException('Check constraints are not yet implemented for SQL Server adapter');
+        throw new BadMethodCallException(
+            'Check constraints are not supported for the SQL Server adapter. ' .
+            'Use $this->execute() with raw SQL to add check constraints.',
+        );
     }
 
     /**
      * @inheritDoc
+     *
+     * @throws \BadMethodCallException Check constraints are not supported for SQL Server.
      */
     protected function getDropCheckConstraintInstructions(string $tableName, string $constraintName): AlterInstructions
     {
-        throw new BadMethodCallException('Check constraints are not yet implemented for SQL Server adapter');
+        throw new BadMethodCallException(
+            'Check constraints are not supported for the SQL Server adapter. ' .
+            'Use $this->execute() with raw SQL to drop check constraints.',
+        );
     }
 
     /**

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -1117,7 +1117,6 @@ SQL;
 
     /**
      * @inheritDoc
-     *
      * @throws \BadMethodCallException Check constraints are not supported for SQL Server.
      */
     protected function getAddCheckConstraintInstructions(TableMetadata $table, CheckConstraint $checkConstraint): AlterInstructions
@@ -1130,7 +1129,6 @@ SQL;
 
     /**
      * @inheritDoc
-     *
      * @throws \BadMethodCallException Check constraints are not supported for SQL Server.
      */
     protected function getDropCheckConstraintInstructions(string $tableName, string $constraintName): AlterInstructions

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -955,7 +955,7 @@ class Table
         $c = array_keys($row);
         foreach ($this->getData() as $row) {
             $k = array_keys($row);
-            if ($k != $c) {
+            if ($k !== $c) {
                 $bulk = false;
                 break;
             }

--- a/src/Db/Table/Column.php
+++ b/src/Db/Table/Column.php
@@ -789,6 +789,7 @@ class Column extends DatabaseColumn
             'update',
             'comment',
             'signed',
+            'unsigned',
             'timezone',
             'properties',
             'values',

--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -1101,18 +1101,46 @@ class Manager
      * Order seeds by dependencies
      *
      * @param \Migrations\SeedInterface[] $seeds Seeds
+     * @param array<string, true> $visiting Seeds currently being visited (for cycle detection)
+     * @param array<string, true> $visited Seeds that have been fully processed
      * @return \Migrations\SeedInterface[]
+     * @throws \RuntimeException When a circular dependency is detected
      */
-    protected function orderSeedsByDependencies(array $seeds): array
+    protected function orderSeedsByDependencies(array $seeds, array $visiting = [], array &$visited = []): array
     {
         $orderedSeeds = [];
         foreach ($seeds as $seed) {
             $name = $seed->getName();
-            $orderedSeeds[$name] = $seed;
+
+            // Skip if already fully processed
+            if (isset($visited[$name])) {
+                continue;
+            }
+
+            // Check for circular dependency
+            if (isset($visiting[$name])) {
+                $cycle = array_keys($visiting);
+                $cycle[] = $name;
+                throw new RuntimeException(
+                    'Circular dependency detected in seeds: ' . implode(' -> ', $cycle),
+                );
+            }
+
+            // Mark as currently visiting
+            $visiting[$name] = true;
+
             $dependencies = $this->getSeedDependenciesInstances($seed);
             if ($dependencies) {
-                $orderedSeeds = array_merge($this->orderSeedsByDependencies($dependencies), $orderedSeeds);
+                $orderedSeeds = array_merge(
+                    $this->orderSeedsByDependencies($dependencies, $visiting, $visited),
+                    $orderedSeeds,
+                );
             }
+
+            // Mark as fully visited and add to result
+            $visited[$name] = true;
+            unset($visiting[$name]);
+            $orderedSeeds[$name] = $seed;
         }
 
         return $orderedSeeds;

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -36,7 +36,7 @@ class Migrations
      *
      * @var string
      */
-    protected string $command;
+    protected string $command = '';
 
     /**
      * Constructor

--- a/src/TestSuite/Migrator.php
+++ b/src/TestSuite/Migrator.php
@@ -199,7 +199,7 @@ class Migrator
         if (!empty($messages['missing'])) {
             $hasProblems = true;
             $output[] = 'Applied but missing migrations:';
-            $output = array_merge($output, array_map($itemize, $messages['down']));
+            $output = array_merge($output, array_map($itemize, $messages['missing']));
             $output[] = '';
         }
         if ($output) {


### PR DESCRIPTION
## Summary

This PR addresses several release readiness issues identified in the 5.x branch:

**First commit fixes:**

- **Seed dependency cycle detection**: Added proper cycle detection to `orderSeedsByDependencies()` to prevent infinite recursion when seeds have circular dependencies. Now throws a `RuntimeException` with a clear message showing the cycle path.

- **Column `unsigned` option**: Added `'unsigned'` to valid column options for API consistency. Previously only `'signed'` was valid, requiring users to call `setUnsigned()` directly.

- **SQL injection fix**: Replaced unsafe `addslashes()` with proper driver escaping (`schemaValue()`) for column comments in `MysqlAdapter::getRenameColumnInstructions()`.

- **DumpCommand fix**: Fixed non-existent `$io->error()` method call (should be `$io->err()`).

- **SQL Server documentation**: Documented check constraints as unsupported for SQL Server adapter with improved error messages guiding users to use raw SQL via `$this->execute()`.

**Second commit fixes (from deep dive analysis):**

- **Safer deserialization**: Restricted `unserialize()` in BakeMigrationDiffCommand to only allow safe CakePHP schema classes, mitigating potential RCE.

- **strpos() logic bug**: Fixed `strpos()` returning false when match is at position 0 by using `str_contains()` instead.

- **Path traversal prevention**: Added validation for `--source` option to prevent directory traversal attacks.

- **Uninitialized property**: Initialized `$command` property in `Migrations.php` to prevent access errors.

- **Strict comparison**: Fixed weak equality (`!=`) to strict equality (`!==`) in `Table::saveData()` for array key comparison.

- **Copy-paste bug**: Fixed `Migrator::shouldDropTables()` which was using `$messages['down']` instead of `$messages['missing']`.

- **Production-safe error handling**: Replaced `assert()` calls with explicit `RuntimeException` in `BaseSeed` since assertions can be disabled in production.

## Test plan

- [x] PHPStan passes with no errors
- [x] PHPCS passes with no errors
- [ ] All existing tests pass (CI running)
- [ ] Manual testing of seed circular dependency detection
- [ ] Manual testing of column unsigned option via setOptions()