### PR TITLE
Quote database names in PostgreSQL and SQL Server adapters

### DIFF
--- a/src/BaseMigration.php
+++ b/src/BaseMigration.php
@@ -431,7 +431,7 @@ class BaseMigration implements MigrationInterface
     /**
      * Create a new ForeignKey object.
      *
-     * @params string|string[] $columns Columns
+     * @param string|string[] $columns Columns
      * @return \Migrations\Db\Table\ForeignKey
      */
     public function foreignKey(string|array $columns): ForeignKey
@@ -442,7 +442,7 @@ class BaseMigration implements MigrationInterface
     /**
      * Create a new Index object.
      *
-     * @params string|string[] $columns Columns
+     * @param string|string[] $columns Columns
      * @return \Migrations\Db\Table\Index
      */
     public function index(string|array $columns): Index

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -823,7 +823,11 @@ class PostgresAdapter extends AbstractAdapter
     public function createDatabase(string $name, array $options = []): void
     {
         $charset = $options['charset'] ?? 'utf8';
-        $this->execute(sprintf("CREATE DATABASE %s WITH ENCODING = '%s'", $name, $charset));
+        $this->execute(sprintf(
+            'CREATE DATABASE %s WITH ENCODING = %s',
+            $this->quoteSchemaName($name),
+            $this->quoteString($charset),
+        ));
     }
 
     /**
@@ -849,7 +853,7 @@ class PostgresAdapter extends AbstractAdapter
     public function dropDatabase($name): void
     {
         $this->disconnect();
-        $this->execute(sprintf('DROP DATABASE IF EXISTS %s', $name));
+        $this->execute(sprintf('DROP DATABASE IF EXISTS %s', $this->quoteSchemaName($name)));
         $this->createdTables = [];
         $this->connect();
     }

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -767,12 +767,17 @@ ORDER BY IC.[key_ordinal]';
      */
     public function createDatabase(string $name, array $options = []): void
     {
+        $quotedName = $this->quoteSchemaName($name);
         if (isset($options['collation'])) {
-            $this->execute(sprintf('CREATE DATABASE [%s] COLLATE [%s]', $name, $options['collation']));
+            $this->execute(sprintf(
+                'CREATE DATABASE %s COLLATE %s',
+                $quotedName,
+                $this->quoteSchemaName($options['collation']),
+            ));
         } else {
-            $this->execute(sprintf('CREATE DATABASE [%s]', $name));
+            $this->execute(sprintf('CREATE DATABASE %s', $quotedName));
         }
-        $this->execute(sprintf('USE [%s]', $name));
+        $this->execute(sprintf('USE %s', $quotedName));
     }
 
     /**
@@ -794,12 +799,16 @@ ORDER BY IC.[key_ordinal]';
      */
     public function dropDatabase(string $name): void
     {
-        $sql = <<<SQL
-USE master;
-IF EXISTS(select * from sys.databases where name=N'$name')
-ALTER DATABASE [$name] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
-DROP DATABASE [$name];
-SQL;
+        $quotedName = $this->quoteSchemaName($name);
+        $sql = sprintf(
+            'USE master;
+IF EXISTS(select * from sys.databases where name=%s)
+ALTER DATABASE %s SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+DROP DATABASE %s;',
+            $this->quoteString($name),
+            $quotedName,
+            $quotedName,
+        );
         $this->execute($sql);
         $this->createdTables = [];
     }

--- a/tests/test_app/config/AltSeeds/AnotherNumbersSeed.php
+++ b/tests/test_app/config/AltSeeds/AnotherNumbersSeed.php
@@ -3,7 +3,7 @@
 use Migrations\BaseSeed;
 
 /**
- * NumbersSeed seed.
+ * AnotherNumbersSeed seed.
  */
 class AnotherNumbersSeed extends BaseSeed
 {

--- a/tests/test_app/config/AltSeeds/NumbersAltSeed.php
+++ b/tests/test_app/config/AltSeeds/NumbersAltSeed.php
@@ -3,7 +3,7 @@
 use Migrations\BaseSeed;
 
 /**
- * NumbersSeed seed.
+ * NumbersAltSeed seed.
  */
 class NumbersAltSeed extends BaseSeed
 {

--- a/tests/test_app/config/BaseSeeds/MigrationSeedNumbers.php
+++ b/tests/test_app/config/BaseSeeds/MigrationSeedNumbers.php
@@ -3,7 +3,7 @@
 use Migrations\BaseSeed;
 
 /**
- * NumbersSeed seed.
+ * MigrationSeedNumbers seed.
  */
 class MigrationSeedNumbers extends BaseSeed
 {

--- a/tests/test_app/config/CallSeeds/DatabaseSeed.php
+++ b/tests/test_app/config/CallSeeds/DatabaseSeed.php
@@ -3,7 +3,7 @@
 use Migrations\BaseSeed;
 
 /**
- * NumbersSeed seed.
+ * DatabaseSeed seed.
  */
 class DatabaseSeed extends BaseSeed
 {

--- a/tests/test_app/config/CallSeeds/LettersSeed.php
+++ b/tests/test_app/config/CallSeeds/LettersSeed.php
@@ -3,7 +3,7 @@
 use Migrations\BaseSeed;
 
 /**
- * NumbersSeed seed.
+ * LettersSeed seed.
  */
 class LettersSeed extends BaseSeed
 {

--- a/tests/test_app/config/CallSeeds/NumbersCallSeed.php
+++ b/tests/test_app/config/CallSeeds/NumbersCallSeed.php
@@ -3,7 +3,7 @@
 use Migrations\BaseSeed;
 
 /**
- * NumbersSeed seed.
+ * NumbersCallSeed seed.
  */
 class NumbersCallSeed extends BaseSeed
 {

--- a/tests/test_app/config/Seeds/StoresSeed.php
+++ b/tests/test_app/config/Seeds/StoresSeed.php
@@ -5,7 +5,7 @@ use Cake\I18n\DateTime;
 use Migrations\BaseSeed;
 
 /**
- * NumbersSeed seed.
+ * StoresSeed seed.
  */
 class StoresSeed extends BaseSeed
 {


### PR DESCRIPTION
## Summary

- MySQL adapter properly quotes database names in `createDatabase()` and `dropDatabase()` using `quoteTableName()`, but PostgreSQL and SQL Server did not quote these identifiers consistently.

**PostgreSQL fixes:**
- `createDatabase()`: Use `quoteSchemaName()` for database name and `quoteString()` for charset encoding
- `dropDatabase()`: Use `quoteSchemaName()` for database name

**SQL Server fixes:**
- `createDatabase()`: Use `quoteSchemaName()` for database name and collation instead of manual `[brackets]`
- `dropDatabase()`: Replace heredoc with sprintf using `quoteSchemaName()` for identifiers and `quoteString()` for string comparisons

**Docblock fixes:**
- Fix `@params` typo to `@param` in `BaseMigration.php` `foreignKey()` and `index()` methods
- Fix copy-paste docblock errors in 7 test seed files where "NumbersSeed seed" was incorrectly used

This ensures consistent identifier quoting across all database adapters and fixes documentation errors.

## Test plan

- [x] PHPStan passes
- [x] PHPCS passes
- [ ] Existing tests pass