### PR TITLE
Improve SQL quoting and fix docblock issues

### DIFF
--- a/src/BaseMigration.php
+++ b/src/BaseMigration.php
@@ -431,7 +431,7 @@ class BaseMigration implements MigrationInterface
     /**
      * Create a new ForeignKey object.
      *
-     * @params string|string[] $columns Columns
+     * @param string|string[] $columns Columns
      * @return \Migrations\Db\Table\ForeignKey
      */
     public function foreignKey(string|array $columns): ForeignKey
@@ -442,7 +442,7 @@ class BaseMigration implements MigrationInterface
     /**
      * Create a new Index object.
      *
-     * @params string|string[] $columns Columns
+     * @param string|string[] $columns Columns
      * @return \Migrations\Db\Table\Index
      */
     public function index(string|array $columns): Index

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -944,10 +944,11 @@ class PostgresAdapter extends AbstractAdapter
         $constraintName = $foreignKey->getName() ?: (
             $parts['table'] . '_' . implode('_', $foreignKey->getColumns()) . '_fkey'
         );
+        $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns()));
+        $refColumnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getReferencedColumns()));
         $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName) .
-        ' FOREIGN KEY ("' . implode('", "', $foreignKey->getColumns()) . '")' .
-        " REFERENCES {$this->quoteTableName($foreignKey->getReferencedTable())} (\"" .
-        implode('", "', $foreignKey->getReferencedColumns()) . '")';
+        ' FOREIGN KEY (' . $columnList . ')' .
+        ' REFERENCES ' . $this->quoteTableName($foreignKey->getReferencedTable()) . ' (' . $refColumnList . ')';
         if ($foreignKey->getOnDelete()) {
             $def .= " ON DELETE {$foreignKey->getOnDelete()}";
         }

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -236,9 +236,9 @@ class SqlserverAdapter extends AbstractAdapter
     {
         $this->updateCreatedTableName($tableName, $newTableName);
         $sql = sprintf(
-            "EXEC sp_rename '%s', '%s'",
-            $tableName,
-            $newTableName,
+            'EXEC sp_rename %s, %s',
+            $this->quoteString($tableName),
+            $this->quoteString($newTableName),
         );
 
         return new AlterInstructions([], [$sql]);
@@ -377,23 +377,21 @@ class SqlserverAdapter extends AbstractAdapter
 
         $oldConstraintName = "DF_{$tableName}_{$columnName}";
         $newConstraintName = "DF_{$tableName}_{$newColumnName}";
-        $sql = <<<SQL
-IF (OBJECT_ID('$oldConstraintName', 'D') IS NOT NULL)
+        $sql = sprintf(
+            'IF (OBJECT_ID(%s, \'D\') IS NOT NULL)
 BEGIN
-     EXECUTE sp_rename N'%s', N'%s', N'OBJECT'
-END
-SQL;
-        $instructions->addPostStep(sprintf(
-            $sql,
-            $oldConstraintName,
-            $newConstraintName,
-        ));
+     EXECUTE sp_rename %s, %s, N\'OBJECT\'
+END',
+            $this->quoteString($oldConstraintName),
+            $this->quoteString($oldConstraintName),
+            $this->quoteString($newConstraintName),
+        );
+        $instructions->addPostStep($sql);
 
         $instructions->addPostStep(sprintf(
-            "EXECUTE sp_rename N'%s.%s', N'%s', 'COLUMN' ",
-            $tableName,
-            $columnName,
-            $newColumnName,
+            'EXECUTE sp_rename %s, %s, N\'COLUMN\'',
+            $this->quoteString($tableName . '.' . $columnName),
+            $this->quoteString($newColumnName),
         ));
 
         return $instructions;
@@ -858,10 +856,12 @@ SQL;
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, string $tableName): string
     {
         $constraintName = $foreignKey->getName() ?: $tableName . '_' . implode('_', $foreignKey->getColumns());
+        $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns()));
+        $refColumnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getReferencedColumns()));
 
         $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName);
-        $def .= ' FOREIGN KEY ("' . implode('", "', $foreignKey->getColumns()) . '")';
-        $def .= " REFERENCES {$this->quoteTableName($foreignKey->getReferencedTable())} (\"" . implode('", "', $foreignKey->getReferencedColumns()) . '")';
+        $def .= ' FOREIGN KEY (' . $columnList . ')';
+        $def .= ' REFERENCES ' . $this->quoteTableName($foreignKey->getReferencedTable()) . ' (' . $refColumnList . ')';
         if ($foreignKey->getOnDelete()) {
             $def .= " ON DELETE {$foreignKey->getOnDelete()}";
         }

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -625,7 +625,7 @@ class MigrationHelper extends Helper
         if (!isset($this->tableStatementStatus[$table])) {
             $this->tableStatementStatus[$table] = true;
 
-            return '$this->table(\'' . $table . '\')';
+            return '$this->table(\'' . addslashes($table) . '\')';
         }
 
         return '';

--- a/tests/test_app/config/AltSeeds/AnotherNumbersSeed.php
+++ b/tests/test_app/config/AltSeeds/AnotherNumbersSeed.php
@@ -3,7 +3,7 @@
 use Migrations\BaseSeed;
 
 /**
- * NumbersSeed seed.
+ * AnotherNumbersSeed seed.
  */
 class AnotherNumbersSeed extends BaseSeed
 {

--- a/tests/test_app/config/AltSeeds/NumbersAltSeed.php
+++ b/tests/test_app/config/AltSeeds/NumbersAltSeed.php
@@ -3,7 +3,7 @@
 use Migrations\BaseSeed;
 
 /**
- * NumbersSeed seed.
+ * NumbersAltSeed seed.
  */
 class NumbersAltSeed extends BaseSeed
 {

--- a/tests/test_app/config/BaseSeeds/MigrationSeedNumbers.php
+++ b/tests/test_app/config/BaseSeeds/MigrationSeedNumbers.php
@@ -3,7 +3,7 @@
 use Migrations\BaseSeed;
 
 /**
- * NumbersSeed seed.
+ * MigrationSeedNumbers seed.
  */
 class MigrationSeedNumbers extends BaseSeed
 {

--- a/tests/test_app/config/CallSeeds/DatabaseSeed.php
+++ b/tests/test_app/config/CallSeeds/DatabaseSeed.php
@@ -3,7 +3,7 @@
 use Migrations\BaseSeed;
 
 /**
- * NumbersSeed seed.
+ * DatabaseSeed seed.
  */
 class DatabaseSeed extends BaseSeed
 {

--- a/tests/test_app/config/CallSeeds/LettersSeed.php
+++ b/tests/test_app/config/CallSeeds/LettersSeed.php
@@ -3,7 +3,7 @@
 use Migrations\BaseSeed;
 
 /**
- * NumbersSeed seed.
+ * LettersSeed seed.
  */
 class LettersSeed extends BaseSeed
 {

--- a/tests/test_app/config/CallSeeds/NumbersCallSeed.php
+++ b/tests/test_app/config/CallSeeds/NumbersCallSeed.php
@@ -3,7 +3,7 @@
 use Migrations\BaseSeed;
 
 /**
- * NumbersSeed seed.
+ * NumbersCallSeed seed.
  */
 class NumbersCallSeed extends BaseSeed
 {

--- a/tests/test_app/config/Seeds/StoresSeed.php
+++ b/tests/test_app/config/Seeds/StoresSeed.php
@@ -5,7 +5,7 @@ use Cake\I18n\DateTime;
 use Migrations\BaseSeed;
 
 /**
- * NumbersSeed seed.
+ * StoresSeed seed.
  */
 class StoresSeed extends BaseSeed
 {


### PR DESCRIPTION
## Summary
- Fix SQL Server sp_rename to use quoteString() for proper escaping in getRenameTableInstructions() and getRenameColumnInstructions()
- Fix foreign key column quoting in PostgreSQL and SQL Server adapters to use quoteColumnName() instead of hard-coded double quotes
- Fix MigrationHelper::tableStatement() to escape table names with addslashes()
- Fix @params typos in BaseMigration docblocks (should be @param)
- Fix copy-paste docblock errors in 7 test seed files that said "NumbersSeed seed" but were different classes

## Test plan
- [ ] Run PHPStan to verify no type errors
- [ ] Run PHPCS to verify coding standards
- [ ] Run existing test suite to verify no regressions