### PR TITLE
Backport bug fixes from 5.x branch

### DIFF
--- a/src/BaseSeed.php
+++ b/src/BaseSeed.php
@@ -204,7 +204,9 @@ class BaseSeed implements SeedInterface
     public function call(string $seeder, array $options = []): void
     {
         $io = $this->getIo();
-        assert($io !== null, 'Requires ConsoleIo');
+        if ($io === null) {
+            throw new RuntimeException('ConsoleIo is required for calling other seeders.');
+        }
         $io->out('');
         $io->out(
             ' ====' .
@@ -245,7 +247,9 @@ class BaseSeed implements SeedInterface
             'connection' => $options['connection'] ?? $connection,
         ]);
         $io = $this->getIo();
-        assert($io !== null, 'Missing ConsoleIo instance');
+        if ($io === null) {
+            throw new RuntimeException('ConsoleIo is required for running seeders.');
+        }
         $manager = $factory->createManager($io);
         $manager->seed($seeder);
     }

--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -141,7 +141,7 @@ class DumpCommand extends Command
 
             return self::CODE_SUCCESS;
         }
-        $io->error("An error occurred while writing dump file `{$filePath}`");
+        $io->err("<error>An error occurred while writing dump file `{$filePath}`</error>");
 
         return self::CODE_ERROR;
     }

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -612,7 +612,9 @@ class MysqlAdapter extends AbstractAdapter
         foreach ($rows as $row) {
             if (strcasecmp($row['Field'], $columnName) === 0) {
                 $null = $row['Null'] === 'NO' ? 'NOT NULL' : 'NULL';
-                $comment = isset($row['Comment']) ? ' COMMENT ' . '\'' . addslashes($row['Comment']) . '\'' : '';
+                $comment = isset($row['Comment']) && $row['Comment'] !== ''
+                    ? ' COMMENT ' . $this->getConnection()->getDriver()->schemaValue($row['Comment'])
+                    : '';
 
                 // create the extra string by also filtering out the DEFAULT_GENERATED option (MySQL 8 fix)
                 $extras = array_filter(

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -972,7 +972,11 @@ class PostgresAdapter extends AbstractAdapter
     public function createDatabase(string $name, array $options = []): void
     {
         $charset = $options['charset'] ?? 'utf8';
-        $this->execute(sprintf("CREATE DATABASE %s WITH ENCODING = '%s'", $name, $charset));
+        $this->execute(sprintf(
+            'CREATE DATABASE %s WITH ENCODING = %s',
+            $this->quoteSchemaName($name),
+            $this->quoteString($charset),
+        ));
     }
 
     /**
@@ -995,7 +999,7 @@ class PostgresAdapter extends AbstractAdapter
     public function dropDatabase($name): void
     {
         $this->disconnect();
-        $this->execute(sprintf('DROP DATABASE IF EXISTS %s', $name));
+        $this->execute(sprintf('DROP DATABASE IF EXISTS %s', $this->quoteSchemaName($name)));
         $this->createdTables = [];
         $this->connect();
     }
@@ -1091,10 +1095,11 @@ class PostgresAdapter extends AbstractAdapter
         $constraintName = $foreignKey->getName() ?: (
             $parts['table'] . '_' . implode('_', $foreignKey->getColumns()) . '_fkey'
         );
+        $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns()));
+        $refColumnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getReferencedColumns()));
         $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName) .
-        ' FOREIGN KEY ("' . implode('", "', $foreignKey->getColumns()) . '")' .
-        " REFERENCES {$this->quoteTableName($foreignKey->getReferencedTable()->getName())} (\"" .
-        implode('", "', $foreignKey->getReferencedColumns()) . '")';
+        ' FOREIGN KEY (' . $columnList . ')' .
+        ' REFERENCES ' . $this->quoteTableName($foreignKey->getReferencedTable()->getName()) . ' (' . $refColumnList . ')';
         if ($foreignKey->getOnDelete()) {
             $def .= " ON DELETE {$foreignKey->getOnDelete()}";
         }

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -248,9 +248,9 @@ class SqlserverAdapter extends AbstractAdapter
     {
         $this->updateCreatedTableName($tableName, $newTableName);
         $sql = sprintf(
-            "EXEC sp_rename '%s', '%s'",
-            $tableName,
-            $newTableName,
+            'EXEC sp_rename %s, %s',
+            $this->quoteString($tableName),
+            $this->quoteString($newTableName),
         );
 
         return new AlterInstructions([], [$sql]);
@@ -404,23 +404,21 @@ class SqlserverAdapter extends AbstractAdapter
 
         $oldConstraintName = "DF_{$tableName}_{$columnName}";
         $newConstraintName = "DF_{$tableName}_{$newColumnName}";
-        $sql = <<<SQL
-IF (OBJECT_ID('$oldConstraintName', 'D') IS NOT NULL)
+        $sql = sprintf(
+            'IF (OBJECT_ID(%s, \'D\') IS NOT NULL)
 BEGIN
-     EXECUTE sp_rename N'%s', N'%s', N'OBJECT'
-END
-SQL;
-        $instructions->addPostStep(sprintf(
-            $sql,
-            $oldConstraintName,
-            $newConstraintName,
-        ));
+     EXECUTE sp_rename %s, %s, N\'OBJECT\'
+END',
+            $this->quoteString($oldConstraintName),
+            $this->quoteString($oldConstraintName),
+            $this->quoteString($newConstraintName),
+        );
+        $instructions->addPostStep($sql);
 
         $instructions->addPostStep(sprintf(
-            "EXECUTE sp_rename N'%s.%s', N'%s', 'COLUMN' ",
-            $tableName,
-            $columnName,
-            $newColumnName,
+            'EXECUTE sp_rename %s, %s, N\'COLUMN\'',
+            $this->quoteString($tableName . '.' . $columnName),
+            $this->quoteString($newColumnName),
         ));
 
         return $instructions;
@@ -970,12 +968,17 @@ ORDER BY IC.[key_ordinal]';
      */
     public function createDatabase(string $name, array $options = []): void
     {
+        $quotedName = $this->quoteSchemaName($name);
         if (isset($options['collation'])) {
-            $this->execute(sprintf('CREATE DATABASE [%s] COLLATE [%s]', $name, $options['collation']));
+            $this->execute(sprintf(
+                'CREATE DATABASE %s COLLATE %s',
+                $quotedName,
+                $this->quoteSchemaName($options['collation']),
+            ));
         } else {
-            $this->execute(sprintf('CREATE DATABASE [%s]', $name));
+            $this->execute(sprintf('CREATE DATABASE %s', $quotedName));
         }
-        $this->execute(sprintf('USE [%s]', $name));
+        $this->execute(sprintf('USE %s', $quotedName));
     }
 
     /**
@@ -997,12 +1000,16 @@ ORDER BY IC.[key_ordinal]';
      */
     public function dropDatabase(string $name): void
     {
-        $sql = <<<SQL
-USE master;
-IF EXISTS(select * from sys.databases where name=N'$name')
-ALTER DATABASE [$name] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
-DROP DATABASE [$name];
-SQL;
+        $quotedName = $this->quoteSchemaName($name);
+        $sql = sprintf(
+            'USE master;
+IF EXISTS(select * from sys.databases where name=%s)
+ALTER DATABASE %s SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+DROP DATABASE %s;',
+            $this->quoteString($name),
+            $quotedName,
+            $quotedName,
+        );
         $this->execute($sql);
         $this->createdTables = [];
     }
@@ -1061,10 +1068,12 @@ SQL;
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, string $tableName): string
     {
         $constraintName = $foreignKey->getName() ?: $tableName . '_' . implode('_', $foreignKey->getColumns());
+        $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns()));
+        $refColumnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getReferencedColumns()));
 
         $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName);
-        $def .= ' FOREIGN KEY ("' . implode('", "', $foreignKey->getColumns()) . '")';
-        $def .= " REFERENCES {$this->quoteTableName($foreignKey->getReferencedTable()->getName())} (\"" . implode('", "', $foreignKey->getReferencedColumns()) . '")';
+        $def .= ' FOREIGN KEY (' . $columnList . ')';
+        $def .= ' REFERENCES ' . $this->quoteTableName($foreignKey->getReferencedTable()->getName()) . ' (' . $refColumnList . ')';
         if ($foreignKey->getOnDelete()) {
             $def .= " ON DELETE {$foreignKey->getOnDelete()}";
         }

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -793,7 +793,7 @@ class Table
         $c = array_keys($row);
         foreach ($this->getData() as $row) {
             $k = array_keys($row);
-            if ($k != $c) {
+            if ($k !== $c) {
                 $bulk = false;
                 break;
             }

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -64,7 +64,7 @@ class Migrations
      *
      * @var string
      */
-    protected string $command;
+    protected string $command = '';
 
     /**
      * Stub input to feed the manager class since we might not have an input ready when we get the Manager using

--- a/src/TestSuite/Migrator.php
+++ b/src/TestSuite/Migrator.php
@@ -199,7 +199,7 @@ class Migrator
         if (!empty($messages['missing'])) {
             $hasProblems = true;
             $output[] = 'Applied but missing migrations:';
-            $output = array_merge($output, array_map($itemize, $messages['down']));
+            $output = array_merge($output, array_map($itemize, $messages['missing']));
             $output[] = '';
         }
         if ($output) {


### PR DESCRIPTION
## Summary

This backports several important bug fixes from recent 5.x PRs (#1001, #1002, #1003):

**From PR #1001 (Fix release readiness issues for 5.x):**

- Fix copy-paste bug in `Migrator::shouldDropTables()` using `$messages['down']` instead of `$messages['missing']`
- Fix uninitialized `$command` property in `Migrations.php`
- Fix weak equality in `Table::saveData()` (use `!==` instead of `!=`)
- Replace `assert()` with explicit `RuntimeException` in `BaseSeed` for production safety (assertions can be disabled in production)
- Fix `DumpCommand` using non-existent `$io->error()` method (should be `$io->err()`)
- Replace unsafe `addslashes()` with proper driver escaping (`schemaValue()`) for column comments in `MysqlAdapter::getRenameColumnInstructions()`

**From PR #1002 (Quote database names in PostgreSQL and SQL Server adapters):**

- `PostgresAdapter`: Quote database name and charset in `createDatabase()`
- `PostgresAdapter`: Quote database name in `dropDatabase()`
- `SqlserverAdapter`: Use `quoteSchemaName()` instead of manual brackets in `createDatabase()` and `dropDatabase()`
- `SqlserverAdapter`: Fix SQL injection vulnerability in `dropDatabase()`

**From PR #1003 (Improve SQL quoting and fix docblock issues):**

- `SqlserverAdapter`: Use `quoteString()` for `sp_rename` parameters in `getRenameTableInstructions()` and `getRenameColumnInstructions()`
- `PostgresAdapter`/`SqlserverAdapter`: Use `quoteColumnName()` for foreign key column definitions instead of hard-coded double quotes

---

Given that 5.x requires Cake5.3+ it seems important to have the gap on bugs a bit smaller between those major versions of migrations.