### PR TITLE
Add runtime deprecation warnings for AbstractMigration and AbstractSeed

### DIFF
--- a/src/AbstractMigration.php
+++ b/src/AbstractMigration.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
  */
 namespace Migrations;
 
+use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Migration\AbstractMigration as BaseAbstractMigration;
+use Phinx\Migration\MigrationInterface;
+use function Cake\Core\deprecationWarning;
 
 /**
  * @deprecated 4.5.0 You should use Migrations\BaseMigration for new migrations.
@@ -31,6 +34,19 @@ class AbstractMigration extends BaseAbstractMigration
      * @var bool
      */
     public bool $autoId = true;
+
+    /**
+     * @inheritDoc
+     */
+    public function setAdapter(AdapterInterface $adapter): MigrationInterface
+    {
+        deprecationWarning(
+            '4.5.0',
+            'Migrations\AbstractMigration is deprecated. Use Migrations\BaseMigration instead.',
+        );
+
+        return parent::setAdapter($adapter);
+    }
 
     /**
      * Hook method to decide if this migration should use transactions

--- a/src/AbstractSeed.php
+++ b/src/AbstractSeed.php
@@ -17,6 +17,7 @@ use Migrations\Command\Phinx\Seed;
 use Phinx\Seed\AbstractSeed as BaseAbstractSeed;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
+use function Cake\Core\deprecationWarning;
 use function Cake\Core\pluginSplit;
 
 /**
@@ -34,6 +35,17 @@ abstract class AbstractSeed extends BaseAbstractSeed
      * @var \Symfony\Component\Console\Input\InputInterface
      */
     protected InputInterface $input;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        deprecationWarning(
+            '4.5.0',
+            'Migrations\AbstractSeed is deprecated. Use Migrations\BaseSeed instead.',
+        );
+    }
 
     /**
      * Gives the ability to a seeder to call another seeder.


### PR DESCRIPTION
## Summary

- Add runtime `deprecationWarning()` calls to `AbstractMigration` and `AbstractSeed`
- These classes had `@deprecated 4.5.0` docblock annotations but no runtime warnings
- Users will now see deprecation notices during execution, helping them upgrade early

### Changes

- `AbstractMigration`: Added `setAdapter()` override with deprecation warning (constructor is `final` in Phinx)
- `AbstractSeed`: Added constructor with deprecation warning

This helps users migrate to `BaseMigration` and `BaseSeed` before the 5.0 release.