### PR TITLE
Fix dump command error when migrations directory does not exist

### DIFF
--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -112,6 +112,12 @@ class DumpCommand extends Command
         ]);
         $config = $factory->createConfig();
         $path = $config->getMigrationPath();
+
+        if (!is_dir($path)) {
+            $io->verbose('<info>No migrations directory found, skipping dump.</info>');
+
+            return self::CODE_SUCCESS;
+        }
         $connectionName = (string)$config->getConnection();
         $connection = ConnectionManager::get($connectionName);
         assert($connection instanceof Connection);

--- a/tests/TestCase/Command/DumpCommandTest.php
+++ b/tests/TestCase/Command/DumpCommandTest.php
@@ -84,6 +84,13 @@ class DumpCommandTest extends TestCase
         $this->assertEquals(['id', 'letter'], $generatedDump['letters']->columns());
     }
 
+    public function testExecuteNoMigrationsDirectory(): void
+    {
+        $this->exec('migrations dump --connection test --source NonExistentMigrations');
+
+        $this->assertExitSuccess();
+    }
+
     public function testExecutePlugin(): void
     {
         $this->loadPlugins(['Migrator']);


### PR DESCRIPTION
## Summary

- When running `migrations migrate -p SomePlugin` on a plugin without a `config/Migrations/` directory, the `DumpCommand` would fail with a `file_put_contents` error
- Now `DumpCommand` checks if the migration path directory exists before attempting to write the lock file, and gracefully returns success with a verbose info message

Fixes #1008