### PR TITLE
Remove hardcoded default collation for MySQL tables

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -9,5 +9,6 @@ return [
         'unsigned_primary_keys' => null, // Default false
         'unsigned_ints' => null, // Default false, make sure this is aligned with the above config
         'column_null_default' => null, // Default false
+        'default_collation' => null, // Default null (uses database collation). Set to e.g. 'utf8mb4_unicode_ci' to override.
     ],
 ];

--- a/docs/en/writing-migrations.rst
+++ b/docs/en/writing-migrations.rst
@@ -546,10 +546,9 @@ In addition, the MySQL adapter supports following options:
 Option     Platform         Description
 ========== ================ ===========
 comment    MySQL, Postgres  set a text comment on the table
-collation  MySQL, SqlServer the default collation for a table if different than the database.
+collation  MySQL, SqlServer set the table collation *(defaults to database collation)*
 row_format MySQL            set the table row format
 engine     MySQL            define table engine *(defaults to ``InnoDB``)*
-collation  MySQL            define table collation *(defaults to ``utf8mb4_unicode_ci``)*
 signed     MySQL            whether the primary key is ``signed``  *(defaults to ``false``)*
 limit      MySQL            set the maximum length for the primary key
 ========== ================ ===========

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -251,7 +251,6 @@ class MysqlAdapter extends AbstractAdapter
         // This method is based on the MySQL docs here: https://dev.mysql.com/doc/refman/5.1/en/create-index.html
         $defaultOptions = [
             'engine' => 'InnoDB',
-            'collation' => 'utf8mb4_unicode_ci',
         ];
 
         $options = array_merge(

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -253,6 +253,11 @@ class MysqlAdapter extends AbstractAdapter
             'engine' => 'InnoDB',
         ];
 
+        $collation = Configure::read('Migrations.default_collation');
+        if ($collation) {
+            $defaultOptions['collation'] = $collation;
+        }
+
         $options = array_merge(
             $defaultOptions,
             array_intersect_key($this->getOptions(), $defaultOptions),


### PR DESCRIPTION
## Summary

- Remove the hardcoded `utf8mb4_unicode_ci` default collation from `MysqlAdapter::createTable()`
- When no collation is specified, MySQL/MariaDB will now use the database default collation instead
- Add `Migrations.default_collation` config option to allow setting a global default collation for all tables
- Fix duplicate `collation` entry in docs and update to reflect the new behavior

This avoids collation mismatches on servers with different defaults (e.g. MariaDB 11.8 defaults to `utf8mb4_uca1400_ai_ci`).

### Configuration

```php
// config/app.php
'Migrations' => [
    'default_collation' => null, // null = use database default
    // 'default_collation' => 'utf8mb4_unicode_ci', // explicit override
],
```

Per-table `'collation' => '...'` options still take precedence over the global config.

Fixes #1010