### PR TITLE
Add TYPE_BIT constant to AdapterInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=8.2",
         "cakephp/cache": "^5.3.0",
-        "cakephp/database": "^5.3.0",
+        "cakephp/database": "^5.3.2",
         "cakephp/orm": "^5.3.0"
     },
     "require-dev": {

--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -63,6 +63,7 @@ interface AdapterInterface
 
     // only for mysql so far
     public const TYPE_YEAR = TableSchemaInterface::TYPE_YEAR;
+    public const TYPE_BIT = TableSchemaInterface::TYPE_BIT;
 
     // only for postgresql so far
     public const TYPE_CIDR = TableSchemaInterface::TYPE_CIDR;


### PR DESCRIPTION
## Summary

- Adds `TYPE_BIT` constant to `AdapterInterface` mapping to `TableSchemaInterface::TYPE_BIT`
- Bumps `cakephp/database` constraint to `^5.3.2` to require the version with BIT type support
- Complements the core BIT type support added in cakephp/cakephp#19223

## Usage

After this change, users can define BIT columns in migrations:

```php
$table->addColumn('flags', 'bit', ['limit' => 8]);
// or using the constant
$table->addColumn('flags', AdapterInterface::TYPE_BIT, ['limit' => 8]);
```