### PR TITLE
Add fixed option for binary column type

### DIFF
--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -633,6 +633,9 @@ class MysqlAdapter extends AbstractAdapter
             if ($record['onUpdate'] ?? false) {
                 $column->setUpdate($record['onUpdate']);
             }
+            if ($record['fixed'] ?? false) {
+                $column->setFixed(true);
+            }
 
             $columns[] = $column;
         }

--- a/src/Db/Table/Column.php
+++ b/src/Db/Table/Column.php
@@ -118,6 +118,11 @@ class Column extends DatabaseColumn
     protected ?string $lock = null;
 
     /**
+     * @var bool|null
+     */
+    protected ?bool $fixed = null;
+
+    /**
      * Column constructor
      *
      * @param string $name The name of the column.
@@ -773,6 +778,31 @@ class Column extends DatabaseColumn
     }
 
     /**
+     * Sets whether field should use fixed-length storage (for binary columns).
+     *
+     * When true, binary columns will use BINARY(n) instead of VARBINARY(n).
+     *
+     * @param bool $fixed Fixed
+     * @return $this
+     */
+    public function setFixed(bool $fixed)
+    {
+        $this->fixed = $fixed;
+
+        return $this;
+    }
+
+    /**
+     * Gets whether field should use fixed-length storage.
+     *
+     * @return bool|null
+     */
+    public function getFixed(): ?bool
+    {
+        return $this->fixed;
+    }
+
+    /**
      * Gets all allowed options. Each option must have a corresponding `setFoo` method.
      *
      * @return array
@@ -802,6 +832,7 @@ class Column extends DatabaseColumn
             'generated',
             'algorithm',
             'lock',
+            'fixed',
         ];
     }
 
@@ -894,6 +925,7 @@ class Column extends DatabaseColumn
             'default' => $default,
             'generated' => $this->getGenerated(),
             'unsigned' => $this->getUnsigned(),
+            'fixed' => $this->getFixed(),
             'onUpdate' => $this->getUpdate(),
             'collate' => $this->getCollation(),
             'precision' => $precision,

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -389,6 +389,7 @@ class MigrationHelper extends Helper
             'scale',
             'after',
             'collate',
+            'fixed',
         ]);
         $columnOptions = array_intersect_key($options, $wantedOptions);
         if (empty($columnOptions['comment'])) {
@@ -495,7 +496,7 @@ class MigrationHelper extends Helper
             'comment', 'unsigned',
             'signed', 'properties',
             'autoIncrement', 'unique',
-            'collate',
+            'collate', 'fixed',
         ];
 
         $attributes = [];

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -3528,6 +3528,8 @@ OUTPUT;
 
         $this->assertNotNull($hashCol);
         $this->assertNotNull($dataCol);
+        $this->assertSame('binary', $hashCol->getType());
+        $this->assertSame('binary', $dataCol->getType());
         $this->assertTrue($hashCol->getFixed());
         $this->assertNull($dataCol->getFixed());
     }

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -3484,4 +3484,51 @@ OUTPUT;
         $this->assertCount(1, $rows);
         $this->assertEquals('A description', $rows[0]['description']);
     }
+
+    public function testBinaryColumnWithFixedOption(): void
+    {
+        $table = new Table('binary_fixed_test', [], $this->adapter);
+        $table->addColumn('hash', 'binary', ['limit' => 20, 'fixed' => true])
+            ->addColumn('data', 'binary', ['limit' => 20])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasColumn('binary_fixed_test', 'hash'));
+        $this->assertTrue($this->adapter->hasColumn('binary_fixed_test', 'data'));
+
+        // Check that the fixed column is created as BINARY and the non-fixed as VARBINARY
+        $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM binary_fixed_test');
+        $hashColumn = null;
+        $dataColumn = null;
+        foreach ($rows as $row) {
+            if ($row['Field'] === 'hash') {
+                $hashColumn = $row;
+            }
+            if ($row['Field'] === 'data') {
+                $dataColumn = $row;
+            }
+        }
+
+        $this->assertNotNull($hashColumn);
+        $this->assertNotNull($dataColumn);
+        $this->assertSame('binary(20)', $hashColumn['Type']);
+        $this->assertSame('varbinary(20)', $dataColumn['Type']);
+
+        // Verify the fixed attribute is reflected back
+        $columns = $this->adapter->getColumns('binary_fixed_test');
+        $hashCol = null;
+        $dataCol = null;
+        foreach ($columns as $col) {
+            if ($col->getName() === 'hash') {
+                $hashCol = $col;
+            }
+            if ($col->getName() === 'data') {
+                $dataCol = $col;
+            }
+        }
+
+        $this->assertNotNull($hashCol);
+        $this->assertNotNull($dataCol);
+        $this->assertTrue($hashCol->getFixed());
+        $this->assertNull($dataCol->getFixed());
+    }
 }

--- a/tests/TestCase/Db/Table/ColumnTest.php
+++ b/tests/TestCase/Db/Table/ColumnTest.php
@@ -275,4 +275,56 @@ class ColumnTest extends TestCase
         $decimalColumn->setName('price')->setType('decimal');
         $this->assertFalse($decimalColumn->isUnsigned());
     }
+
+    public function testFixedOptionDefaultsToNull(): void
+    {
+        $column = new Column();
+        $column->setName('data')->setType('binary');
+
+        $this->assertNull($column->getFixed());
+    }
+
+    public function testSetFixedTrue(): void
+    {
+        $column = new Column();
+        $column->setName('hash')->setType('binary')->setFixed(true);
+
+        $this->assertTrue($column->getFixed());
+    }
+
+    public function testSetFixedFalse(): void
+    {
+        $column = new Column();
+        $column->setName('data')->setType('binary')->setFixed(false);
+
+        $this->assertFalse($column->getFixed());
+    }
+
+    public function testSetOptionsWithFixed(): void
+    {
+        $column = new Column();
+        $column->setName('hash')->setType('binary');
+        $column->setOptions(['fixed' => true, 'limit' => 20]);
+
+        $this->assertTrue($column->getFixed());
+        $this->assertSame(20, $column->getLimit());
+    }
+
+    public function testToArrayIncludesFixed(): void
+    {
+        $column = new Column();
+        $column->setName('hash')->setType('binary')->setFixed(true)->setLimit(20);
+
+        $result = $column->toArray();
+        $this->assertTrue($result['fixed']);
+    }
+
+    public function testToArrayFixedNullByDefault(): void
+    {
+        $column = new Column();
+        $column->setName('data')->setType('binary')->setLimit(20);
+
+        $result = $column->toArray();
+        $this->assertNull($result['fixed']);
+    }
 }

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -456,4 +456,38 @@ class MigrationHelperTest extends TestCase
         $this->assertArrayHasKey('collation', $result, 'collation should be set from collate value');
         $this->assertSame('en_US.UTF-8', $result['collation']);
     }
+
+    /**
+     * Test that getColumnOption includes the fixed option for binary columns
+     */
+    public function testGetColumnOptionIncludesFixed(): void
+    {
+        $options = [
+            'length' => 20,
+            'null' => true,
+            'default' => null,
+            'fixed' => true,
+        ];
+
+        $result = $this->helper->getColumnOption($options);
+
+        $this->assertArrayHasKey('fixed', $result);
+        $this->assertTrue($result['fixed']);
+    }
+
+    /**
+     * Test that getColumnOption excludes fixed when not set
+     */
+    public function testGetColumnOptionExcludesFixedWhenNotSet(): void
+    {
+        $options = [
+            'length' => 20,
+            'null' => true,
+            'default' => null,
+        ];
+
+        $result = $this->helper->getColumnOption($options);
+
+        $this->assertArrayNotHasKey('fixed', $result);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds support for the `fixed` attribute on binary columns to distinguish between fixed-length `BINARY` and variable-length `VARBINARY` types
- When reflecting a `BINARY(n)` column from the database, `fixed => true` is now passed through to the Column object
- When baking migrations, the `fixed` option is now included in the generated migration code

This is the companion PR to cakephp/cakephp#19207 which adds the core framework support for this feature.

## Usage

```php
// Creates VARBINARY(20) - variable length (default)
$table->addColumn('data', 'binary', ['length' => 20]);

// Creates BINARY(20) - fixed length  
$table->addColumn('hash', 'binary', ['length' => 20, 'fixed' => true]);
```

Refs #999

---

Constraint: This one doesnt technically need one.

Also, even if, since https://github.com/cakephp/migrations/pull/1013 is raising the constraint already, I skipped it for this PR here.