### PR TITLE
Fix docs incorrectly stating primary keys default to unsigned

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -841,6 +841,8 @@ pass them to the method::
     // This one with the "default" connection
     $migrate = $migrations->migrate(['connection' => 'default']);
 
+.. _feature-flags:
+
 Feature Flags
 =============
 

--- a/docs/en/writing-migrations.rst
+++ b/docs/en/writing-migrations.rst
@@ -555,8 +555,10 @@ limit      MySQL            set the maximum length for the primary key
 
 By default, the primary key is ``signed``.
 To set it to be unsigned, pass the ``signed`` option with a ``false``
-value, or enable the ``Migrations.unsigned_primary_keys`` feature flag
-(see :ref:`feature-flags`)::
+value, or enable the ``Migrations.unsigned_primary_keys`` and
+``Migrations.unsigned_ints`` feature flags (see :ref:`feature-flags`).
+Both flags should be used together so that foreign key columns match
+the primary keys they reference::
 
     <?php
 

--- a/docs/en/writing-migrations.rst
+++ b/docs/en/writing-migrations.rst
@@ -549,13 +549,14 @@ comment    MySQL, Postgres  set a text comment on the table
 collation  MySQL, SqlServer set the table collation *(defaults to database collation)*
 row_format MySQL            set the table row format
 engine     MySQL            define table engine *(defaults to ``InnoDB``)*
-signed     MySQL            whether the primary key is ``signed``  *(defaults to ``false``)*
+signed     MySQL            whether the primary key is ``signed``  *(defaults to ``true``)*
 limit      MySQL            set the maximum length for the primary key
 ========== ================ ===========
 
-By default, the primary key is ``unsigned``.
-To simply set it to be signed just pass ``signed`` option with a ``true``
-value::
+By default, the primary key is ``signed``.
+To set it to be unsigned, pass the ``signed`` option with a ``false``
+value, or enable the ``Migrations.unsigned_primary_keys`` feature flag
+(see :ref:`feature-flags`)::
 
     <?php
 


### PR DESCRIPTION
## Summary

- The docs in `writing-migrations.rst` claimed primary keys are unsigned by default, but the code defaults to signed (see `MysqlAdapter` line 275 and `Column::getUnsigned()`)
- Updated the table option description: `signed` defaults to `true` (not `false`)
- Updated the prose to say "By default, the primary key is signed" and point to the `Migrations.unsigned_primary_keys` feature flag
- Added a `.. _feature-flags:` ref label to `index.rst` so the cross-reference works