### PR TITLE
Add upgrade warning when using legacy phinxlog tables

### DIFF
--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -18,6 +18,7 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Migrations\Config\ConfigInterface;
+use Migrations\Db\Adapter\UnifiedMigrationsTableStorage;
 use Migrations\Migration\ManagerFactory;
 
 /**
@@ -153,6 +154,9 @@ class StatusCommand extends Command
     protected function display(array $migrations, ConsoleIo $io, string $tableName): void
     {
         $io->out(sprintf('using migration table <info>%s</info>', $tableName));
+        if ($tableName !== UnifiedMigrationsTableStorage::TABLE_NAME) {
+            $io->warning('You are using legacy phinxlog tables. Run `migrations upgrade` to switch to the unified `cake_migrations` table.');
+        }
         $io->out('');
 
         if ($migrations) {


### PR DESCRIPTION
Currently there is nothing in the output suggesting an action should be taken for the old table structure:
```
using migration table queue_phinxlog

+--------+-----------------+---------------------------------+
| Status | Migration ID    | Migration Name                  |
+--------+-----------------+---------------------------------+
| up     | 20240307154751  | MigrationQueueInitV8            |
| up     | 20250508121432  | MigrationQueueMemory            |
| up     | 20251119005411  | MigrationQueueIndexOptimization |
| up     | 20260129000000  | MigrationQueueOutput            |
+--------+-----------------+---------------------------------+
```

It would help if the user would be notified that there is sth to do.

## Summary

- Adds a warning in the `migrations status` command output when the migration tracking table is a legacy `phinxlog` table (e.g. `queue_phinxlog`), directing users to run `migrations upgrade` to switch to the unified `cake_migrations` table.