### PR TITLE
Docs: Add version header and What's New section

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -1,5 +1,5 @@
-Migrations
-##########
+Migrations 5.x
+##############
 
 Migrations is a plugin that lets you track changes to your database schema over
 time as PHP code that accompanies your application. This lets you ensure each
@@ -8,6 +8,21 @@ migrations.
 
 Instead of writing schema modifications in SQL, this plugin allows you to
 define schema changes with a high-level database portable API.
+
+What's New in 5.x
+=================
+
+Migrations 5.x includes several new features:
+
+- **Seed tracking** - Seeds are now tracked in a ``cake_seeds`` table, preventing
+  accidental re-runs
+- **Check constraints** - Support for database check constraints via ``addCheckConstraint()``
+- **Default values in bake** - Specify default values when baking migrations
+  (e.g., ``active:boolean:default[true]``)
+- **MySQL ALTER options** - Control ``ALGORITHM`` and ``LOCK`` for ALTER TABLE operations
+- **insertOrSkip()** - New method for idempotent seed data insertion
+
+See the :doc:`upgrading` guide for breaking changes and migration steps from 4.x.
 
 Installation
 ============


### PR DESCRIPTION
## Summary

- Adds "5.x" to the main documentation title to make the version clearer
- Adds a prominent "What's New in 5.x" section highlighting key features near the top of the docs
- Links to the upgrade guide for breaking changes and migration steps

This helps users understand which version the documentation covers, reducing confusion when following v5-specific features (like `default[value]` in bake) while using v4.x.

Refs #1018