### PR TITLE
Fix column collation not applied for uuid type

### DIFF
--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -274,6 +274,13 @@ class MysqlAdapter extends AbstractAdapter
      */
     protected function mapColumnData(array $data): array
     {
+        // Convert uuid to char(36) to ensure collation support.
+        // The dialect only adds COLLATE for text, char, and string types.
+        if ($data['type'] === self::PHINX_TYPE_UUID) {
+            $data['type'] = 'char';
+            $data['length'] = 36;
+        }
+
         if ($data['type'] == self::PHINX_TYPE_TEXT && $data['length'] !== null) {
             $data['length'] = match ($data['length']) {
                 self::TEXT_LONG => TableSchema::LENGTH_LONG,

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -166,6 +166,29 @@ class MysqlAdapterTest extends TestCase
         $this->assertFalse($columns[0]->isSigned());
     }
 
+    public function testCreateTableWithColumnCollation()
+    {
+        $table = new Table\Table('custom_collation', ['id' => false, 'primary_key' => ['id'], 'collation' => 'utf8mb4_unicode_ci']);
+
+        $columnId = new Column();
+        $columnId
+            ->setName('id')
+            ->setType('uuid')
+            ->setCollation('ascii_general_ci')
+            ->setEncoding('ascii');
+        $columnName = new Column();
+        $columnName
+            ->setName('name')
+            ->setType('text');
+        $columns = [$columnId, $columnName];
+
+        $this->adapter->createTable($table, $columns);
+
+        $rows = $this->adapter->fetchAll('SHOW FULL COLUMNS FROM custom_collation');
+        $this->assertEquals('ascii_general_ci', $rows[0]['Collation']); // specified collation is set
+        $this->assertEquals('utf8mb4_unicode_ci', $rows[1]['Collation']); // if not specified uses table's collation
+    }
+
     public function testCreateTableWithComment()
     {
         $tableComment = 'Table comment';


### PR DESCRIPTION
## Summary

- Fixes column collation not being applied for `uuid` type columns in `createTable()`
- Converts `uuid` to `char` with length 36 in `mapColumnData()` so the dialect properly handles collation

This is a workaround for the issue reported in #1020. The root cause is that `MysqlSchemaDialect::columnDefinitionSql()` in cakephp/database only adds `COLLATE` for `text`, `char`, and `string` types. Since `uuid` columns generate `CHAR(36)` SQL but use the `uuid` type identifier, collation was being ignored.

A proper fix will be proposed to cakephp/cakephp to add `uuid` to the `$hasCollate` array in the dialect.

Closes #1020