### PR TITLE
Bump PHPStan to level 8 and fix all errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=8.2",
         "cakephp/cache": "^5.3.0",
-        "cakephp/database": "^5.3.0",
+        "cakephp/database": "^5.3.2",
         "cakephp/orm": "^5.3.0"
     },
     "require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
 	- phpstan-baseline.neon
 
 parameters:
-    level: 7
+    level: 8
     paths:
         - src/
     bootstrapFiles:

--- a/src/BaseSeed.php
+++ b/src/BaseSeed.php
@@ -278,8 +278,8 @@ class BaseSeed implements SeedInterface
 
         $options += [
             'connection' => $connection,
-            'plugin' => $pluginName ?? $config['plugin'],
-            'source' => $config['source'],
+            'plugin' => $pluginName ?? ($config !== null ? $config['plugin'] : null),
+            'source' => $config !== null ? $config['source'] : null,
         ];
         $factory = new ManagerFactory([
             'connection' => $options['connection'],

--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -27,13 +27,17 @@ use Cake\Database\Schema\Constraint;
 use Cake\Database\Schema\ForeignKey;
 use Cake\Database\Schema\Index;
 use Cake\Database\Schema\TableSchema;
+use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Database\Schema\UniqueKey;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
+use Error;
 use Migrations\Migration\ManagerFactory;
 use Migrations\Util\TableFinder;
 use Migrations\Util\UtilTrait;
+use ReflectionException;
+use ReflectionProperty;
 
 /**
  * Task class for generating migration diff files.
@@ -259,7 +263,7 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             // brand new columns
             $addedColumns = array_diff($currentColumns, $oldColumns);
             foreach ($addedColumns as $columnName) {
-                $column = $currentSchema->getColumn($columnName);
+                $column = $this->safeGetColumn($currentSchema, $columnName);
                 /** @var int $key */
                 $key = array_search($columnName, $currentColumns);
                 if ($key > 0) {
@@ -274,8 +278,8 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
 
             // changes in columns meta-data
             foreach ($currentColumns as $columnName) {
-                $column = $currentSchema->getColumn($columnName);
-                $oldColumn = $this->dumpSchema[$table]->getColumn($columnName);
+                $column = $this->safeGetColumn($currentSchema, $columnName);
+                $oldColumn = $this->safeGetColumn($this->dumpSchema[$table], $columnName);
                 unset(
                     $column['collate'],
                     $column['fixed'],
@@ -351,7 +355,7 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             $removedColumns = array_diff($oldColumns, $currentColumns);
             if ($removedColumns) {
                 foreach ($removedColumns as $columnName) {
-                    $column = $this->dumpSchema[$table]->getColumn($columnName);
+                    $column = $this->safeGetColumn($this->dumpSchema[$table], $columnName);
                     /** @var int $key */
                     $key = array_search($columnName, $oldColumns);
                     if ($key > 0) {
@@ -619,6 +623,67 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
     public function template(): string
     {
         return 'Migrations.config/diff';
+    }
+
+    /**
+     * Safely get column information from a TableSchema.
+     *
+     * This method handles the case where Column::$fixed property may not be
+     * initialized (e.g., when loaded from a cached/serialized schema).
+     *
+     * @param \Cake\Database\Schema\TableSchemaInterface $schema The table schema
+     * @param string $columnName The column name
+     * @return array<string, mixed>|null Column data array or null if column doesn't exist
+     */
+    protected function safeGetColumn(TableSchemaInterface $schema, string $columnName): ?array
+    {
+        try {
+            return $schema->getColumn($columnName);
+        } catch (Error $e) {
+            // Handle uninitialized typed property errors (e.g., Column::$fixed)
+            // This can happen with cached/serialized schema objects
+            if (str_contains($e->getMessage(), 'must not be accessed before initialization')) {
+                // Initialize uninitialized properties using reflection and retry
+                $this->initializeColumnProperties($schema, $columnName);
+
+                return $schema->getColumn($columnName);
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Initialize potentially uninitialized Column properties using reflection.
+     *
+     * @param \Cake\Database\Schema\TableSchemaInterface $schema The table schema
+     * @param string $columnName The column name
+     * @return void
+     */
+    protected function initializeColumnProperties(TableSchemaInterface $schema, string $columnName): void
+    {
+        // Access the internal columns array via reflection
+        $reflection = new ReflectionProperty($schema, '_columns');
+        $columns = $reflection->getValue($schema);
+
+        if (!isset($columns[$columnName]) || !($columns[$columnName] instanceof Column)) {
+            return;
+        }
+
+        $column = $columns[$columnName];
+
+        // List of nullable properties that might not be initialized
+        $nullableProperties = ['fixed', 'collate', 'unsigned', 'generated', 'srid', 'onUpdate'];
+
+        foreach ($nullableProperties as $propertyName) {
+            try {
+                $propReflection = new ReflectionProperty(Column::class, $propertyName);
+                if (!$propReflection->isInitialized($column)) {
+                    $propReflection->setValue($column, null);
+                }
+            } catch (Error | ReflectionException) {
+                // Property doesn't exist or can't be accessed, skip it
+            }
+        }
     }
 
     /**

--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -279,23 +279,27 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             // changes in columns meta-data
             foreach ($currentColumns as $columnName) {
                 $column = $this->safeGetColumn($currentSchema, $columnName);
+                if ($column === null) {
+                    continue;
+                }
+
+                if (!in_array($columnName, $oldColumns, true)) {
+                    continue;
+                }
+
                 $oldColumn = $this->safeGetColumn($this->dumpSchema[$table], $columnName);
+                if ($oldColumn === null) {
+                    continue;
+                }
+
                 unset(
                     $column['collate'],
                     $column['fixed'],
+                    $oldColumn['collate'],
+                    $oldColumn['fixed'],
                 );
-                if ($oldColumn !== null) {
-                    unset(
-                        $oldColumn['collate'],
-                        $oldColumn['fixed'],
-                    );
-                }
 
-                if (
-                    in_array($columnName, $oldColumns, true) &&
-                    $oldColumn !== null &&
-                    $column !== $oldColumn
-                ) {
+                if ($column !== $oldColumn) {
                     $changedAttributes = array_diff_assoc($column, $oldColumn);
 
                     foreach (['type', 'length', 'null', 'default'] as $attribute) {

--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -405,13 +405,18 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             // if present in both, check if they are the same : if not, remove the old one and add the new one
             foreach ($currentConstraints as $constraintName) {
                 $constraint = $currentSchema->getConstraint($constraintName);
+                if ($constraint === null) {
+                    continue;
+                }
 
+                $oldConstraint = $this->dumpSchema[$table]->getConstraint($constraintName);
                 if (
                     in_array($constraintName, $oldConstraints, true) &&
-                    $constraint !== $this->dumpSchema[$table]->getConstraint($constraintName)
+                    $constraint !== $oldConstraint
                 ) {
-                    $this->templateData[$table]['constraints']['remove'][$constraintName] =
-                        $this->dumpSchema[$table]->getConstraint($constraintName);
+                    if ($oldConstraint !== null) {
+                        $this->templateData[$table]['constraints']['remove'][$constraintName] = $oldConstraint;
+                    }
                     $this->templateData[$table]['constraints']['add'][$constraintName] =
                         $constraint;
                 }

--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -283,12 +283,17 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
                 unset(
                     $column['collate'],
                     $column['fixed'],
-                    $oldColumn['collate'],
-                    $oldColumn['fixed'],
                 );
+                if ($oldColumn !== null) {
+                    unset(
+                        $oldColumn['collate'],
+                        $oldColumn['fixed'],
+                    );
+                }
 
                 if (
                     in_array($columnName, $oldColumns, true) &&
+                    $oldColumn !== null &&
                     $column !== $oldColumn
                 ) {
                     $changedAttributes = array_diff_assoc($column, $oldColumn);
@@ -385,9 +390,10 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             // brand new constraints
             $addedConstraints = array_diff($currentConstraints, $oldConstraints);
             foreach ($addedConstraints as $constraintName) {
-                $this->templateData[$table]['constraints']['add'][$constraintName] =
-                    $currentSchema->getConstraint($constraintName);
                 $constraint = $currentSchema->getConstraint($constraintName);
+                if ($constraint === null) {
+                    continue;
+                }
                 if ($constraint['type'] === TableSchema::CONSTRAINT_FOREIGN) {
                     $this->templateData[$table]['constraints']['add'][$constraintName] = $constraint;
                 } else {
@@ -415,6 +421,9 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
             $removedConstraints = array_diff($oldConstraints, $currentConstraints);
             foreach ($removedConstraints as $constraintName) {
                 $constraint = $this->dumpSchema[$table]->getConstraint($constraintName);
+                if ($constraint === null) {
+                    continue;
+                }
                 if ($constraint['type'] === TableSchema::CONSTRAINT_FOREIGN) {
                     $this->templateData[$table]['constraints']['remove'][$constraintName] = $constraint;
                 } else {

--- a/src/Command/BakeSimpleMigrationCommand.php
+++ b/src/Command/BakeSimpleMigrationCommand.php
@@ -52,16 +52,16 @@ abstract class BakeSimpleMigrationCommand extends SimpleBakeCommand
     /**
      * Console IO
      *
-     * @var \Cake\Console\ConsoleIo|null
+     * @var \Cake\Console\ConsoleIo
      */
-    protected ?ConsoleIo $io = null;
+    protected ConsoleIo $io;
 
     /**
      * Arguments
      *
-     * @var \Cake\Console\Arguments|null
+     * @var \Cake\Console\Arguments
      */
-    protected ?Arguments $args = null;
+    protected Arguments $args;
 
     /**
      * @inheritDoc

--- a/src/Command/UpgradeCommand.php
+++ b/src/Command/UpgradeCommand.php
@@ -17,6 +17,7 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
+use Cake\Core\Plugin;
 use Cake\Database\Connection;
 use Cake\Database\Exception\QueryException;
 use Cake\Datasource\ConnectionManager;
@@ -184,18 +185,49 @@ class UpgradeCommand extends Command
         $tables = $schema->listTables();
         $legacyTables = [];
 
+        // Build a map of expected table prefixes to plugin names for loaded plugins
+        // This allows matching plugins with special characters like CakeDC/Users
+        $pluginPrefixMap = $this->buildPluginPrefixMap();
+
         foreach ($tables as $table) {
             if ($table === 'phinxlog') {
                 $legacyTables[$table] = null;
             } elseif (str_ends_with($table, '_phinxlog')) {
                 // Extract plugin name from table name
                 $prefix = substr($table, 0, -9); // Remove '_phinxlog'
-                $plugin = Inflector::camelize($prefix);
+
+                // Try to match against loaded plugins first
+                if (isset($pluginPrefixMap[$prefix])) {
+                    $plugin = $pluginPrefixMap[$prefix];
+                } else {
+                    // Fall back to camelizing the prefix
+                    $plugin = Inflector::camelize($prefix);
+                }
                 $legacyTables[$table] = $plugin;
             }
         }
 
         return $legacyTables;
+    }
+
+    /**
+     * Build a map of table prefixes to plugin names for all loaded plugins.
+     *
+     * This handles plugins with special characters like CakeDC/Users where
+     * the table prefix is cake_d_c_users but the plugin name is CakeDC/Users.
+     *
+     * @return array<string, string> Map of table prefix => plugin name
+     */
+    protected function buildPluginPrefixMap(): array
+    {
+        $map = [];
+        foreach (Plugin::loaded() as $plugin) {
+            $prefix = Inflector::underscore($plugin);
+            $prefix = str_replace(['\\', '/', '.'], '_', $prefix);
+            $map[$prefix] = $plugin;
+        }
+
+        return $map;
     }
 
     /**

--- a/src/Command/UpgradeCommand.php
+++ b/src/Command/UpgradeCommand.php
@@ -156,10 +156,13 @@ class UpgradeCommand extends Command
             $io->success('Upgrade complete!');
             $io->out('');
             $io->out('Next steps:');
-            $io->out('  1. Set <info>\'Migrations\' => [\'legacyTables\' => false]</info> in your config');
-            $io->out('  2. Test your application');
-            if (!$dropTables) {
-                $io->out('  3. Optionally drop the empty phinxlog tables (re-run `bin/cake migrations upgrade --drop-tables`)');
+            if ($dropTables) {
+                $io->out('  1. Set <info>\'Migrations\' => [\'legacyTables\' => false]</info> in your config');
+                $io->out('  2. Test your application');
+            } else {
+                $io->out('  1. Test your application');
+                $io->out('  2. Drop the phinxlog tables (re-run `bin/cake migrations upgrade --drop-tables`)');
+                $io->out('  3. Set <info>\'Migrations\' => [\'legacyTables\' => false]</info> in your config');
             }
         } else {
             $io->out('');

--- a/src/Db/Action/ChangeColumn.php
+++ b/src/Db/Action/ChangeColumn.php
@@ -41,7 +41,7 @@ class ChangeColumn extends Action
         $this->column = $column;
 
         // if the name was omitted use the existing column name
-        if ($column->getName() === null || strlen($column->getName()) === 0) {
+        if (strlen($column->getName()) === 0) {
             $column->setName($columnName);
         }
     }

--- a/src/Db/Action/ChangeColumn.php
+++ b/src/Db/Action/ChangeColumn.php
@@ -41,7 +41,7 @@ class ChangeColumn extends Action
         $this->column = $column;
 
         // if the name was omitted use the existing column name
-        if ($column->getName() === null || strlen((string)$column->getName()) === 0) {
+        if ($column->getName() === null || strlen($column->getName()) === 0) {
             $column->setName($columnName);
         }
     }

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -745,7 +745,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
             return '';
         }
 
-        if ($conflictColumns !== null) {
+        if ($conflictColumns !== null && $conflictColumns !== []) {
             trigger_error(
                 'The $conflictColumns parameter is ignored by MySQL. ' .
                 'MySQL\'s ON DUPLICATE KEY UPDATE applies to all unique constraints on the table.',

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -1723,25 +1723,17 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
 
                 case $action instanceof RemoveColumn:
                     /** @var \Migrations\Db\Action\RemoveColumn $action */
-                    $columnName = $action->getColumn()->getName();
-                    if ($columnName === null) {
-                        throw new InvalidArgumentException('Column name must be set.');
-                    }
                     $instructions->merge($this->getDropColumnInstructions(
                         $table->getName(),
-                        $columnName,
+                        $action->getColumn()->getName(),
                     ));
                     break;
 
                 case $action instanceof RenameColumn:
                     /** @var \Migrations\Db\Action\RenameColumn $action */
-                    $columnName = $action->getColumn()->getName();
-                    if ($columnName === null) {
-                        throw new InvalidArgumentException('Column name must be set.');
-                    }
                     $instructions->merge($this->getRenameColumnInstructions(
                         $table->getName(),
-                        $columnName,
+                        $action->getColumn()->getName(),
                         $action->getNewName(),
                     ));
                     break;

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -1684,7 +1684,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
                     /** @var \Migrations\Db\Action\DropForeignKey $action */
                     $instructions->merge($this->getDropForeignKeyByColumnsInstructions(
                         $table->getName(),
-                        $action->getForeignKey()->getColumns() ?? [],
+                        $action->getForeignKey()->getColumns(),
                     ));
                     break;
 

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -1690,17 +1690,19 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
 
                 case $action instanceof DropForeignKey && $action->getForeignKey()->getName():
                     /** @var \Migrations\Db\Action\DropForeignKey $action */
+                    $fkName = $action->getForeignKey()->getName();
                     $instructions->merge($this->getDropForeignKeyInstructions(
                         $table->getName(),
-                        (string)$action->getForeignKey()->getName(),
+                        $fkName,
                     ));
                     break;
 
                 case $action instanceof DropIndex && $action->getIndex()->getName():
                     /** @var \Migrations\Db\Action\DropIndex $action */
+                    $indexName = $action->getIndex()->getName();
                     $instructions->merge($this->getDropIndexByNameInstructions(
                         $table->getName(),
-                        (string)$action->getIndex()->getName(),
+                        $indexName,
                     ));
                     break;
 

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -1723,17 +1723,25 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
 
                 case $action instanceof RemoveColumn:
                     /** @var \Migrations\Db\Action\RemoveColumn $action */
+                    $columnName = $action->getColumn()->getName();
+                    if ($columnName === null) {
+                        throw new InvalidArgumentException('Column name must be set.');
+                    }
                     $instructions->merge($this->getDropColumnInstructions(
                         $table->getName(),
-                        (string)$action->getColumn()->getName(),
+                        $columnName,
                     ));
                     break;
 
                 case $action instanceof RenameColumn:
                     /** @var \Migrations\Db\Action\RenameColumn $action */
+                    $columnName = $action->getColumn()->getName();
+                    if ($columnName === null) {
+                        throw new InvalidArgumentException('Column name must be set.');
+                    }
                     $instructions->merge($this->getRenameColumnInstructions(
                         $table->getName(),
-                        (string)$action->getColumn()->getName(),
+                        $columnName,
                         $action->getNewName(),
                     ));
                     break;

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -1690,7 +1690,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
 
                 case $action instanceof DropForeignKey && $action->getForeignKey()->getName():
                     /** @var \Migrations\Db\Action\DropForeignKey $action */
-                    $fkName = $action->getForeignKey()->getName();
+                    $fkName = (string)$action->getForeignKey()->getName();
                     $instructions->merge($this->getDropForeignKeyInstructions(
                         $table->getName(),
                         $fkName,
@@ -1699,7 +1699,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
 
                 case $action instanceof DropIndex && $action->getIndex()->getName():
                     /** @var \Migrations\Db\Action\DropIndex $action */
-                    $indexName = $action->getIndex()->getName();
+                    $indexName = (string)$action->getIndex()->getName();
                     $instructions->merge($this->getDropIndexByNameInstructions(
                         $table->getName(),
                         $indexName,

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -201,6 +201,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
             $this->connection = $this->getOption('connection');
             $this->connect();
         }
+        assert($this->connection !== null);
 
         return $this->connection;
     }
@@ -1681,7 +1682,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
                     /** @var \Migrations\Db\Action\DropForeignKey $action */
                     $instructions->merge($this->getDropForeignKeyByColumnsInstructions(
                         $table->getName(),
-                        $action->getForeignKey()->getColumns(),
+                        $action->getForeignKey()->getColumns() ?? [],
                     ));
                     break;
 

--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -201,7 +201,9 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
             $this->connection = $this->getOption('connection');
             $this->connect();
         }
-        assert($this->connection !== null);
+        if ($this->connection === null) {
+            throw new RuntimeException('Unable to establish database connection. Ensure a connection is configured.');
+        }
 
         return $this->connection;
     }

--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -63,6 +63,7 @@ interface AdapterInterface
 
     // only for mysql so far
     public const TYPE_YEAR = TableSchemaInterface::TYPE_YEAR;
+    public const TYPE_BIT = TableSchemaInterface::TYPE_BIT;
 
     // only for postgresql so far
     public const TYPE_CIDR = TableSchemaInterface::TYPE_CIDR;

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -594,6 +594,20 @@ class MysqlAdapter extends AbstractAdapter
                 }
             }
             // else: keep as binary or varbinary (actual BINARY/VARBINARY column)
+        } elseif ($type === TableSchema::TYPE_TEXT) {
+            // CakePHP returns TEXT columns as 'text' with specific lengths
+            // Check the raw MySQL type to distinguish TEXT variants
+            $rawType = $columnData['rawType'] ?? '';
+            if (str_contains($rawType, 'tinytext')) {
+                $length = static::TEXT_TINY;
+            } elseif (str_contains($rawType, 'mediumtext')) {
+                $length = static::TEXT_MEDIUM;
+            } elseif (str_contains($rawType, 'longtext')) {
+                $length = static::TEXT_LONG;
+            } else {
+                // Regular TEXT - use null to indicate default TEXT type
+                $length = null;
+            }
         }
 
         return [$type, $length];

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -651,6 +651,9 @@ class MysqlAdapter extends AbstractAdapter
             if ($record['onUpdate'] ?? false) {
                 $column->setUpdate($record['onUpdate']);
             }
+            if ($record['fixed'] ?? false) {
+                $column->setFixed(true);
+            }
 
             $columns[] = $column;
         }

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -1202,7 +1202,7 @@ class MysqlAdapter extends AbstractAdapter
             $def .= ' CONSTRAINT ' . $this->quoteColumnName($name);
         }
         $columnNames = [];
-        foreach ($foreignKey->getColumns() ?? [] as $column) {
+        foreach ($foreignKey->getColumns() as $column) {
             $columnNames[] = $this->quoteColumnName($column);
         }
         $def .= ' FOREIGN KEY (' . implode(',', $columnNames) . ')';

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -727,7 +727,7 @@ class MysqlAdapter extends AbstractAdapter
         $targetColumn = null;
 
         foreach ($columns as $column) {
-            if (strcasecmp((string)$column->getName(), $columnName) === 0) {
+            if ($column->getName() !== null && strcasecmp($column->getName(), $columnName) === 0) {
                 $targetColumn = $column;
                 break;
             }
@@ -1210,7 +1210,11 @@ class MysqlAdapter extends AbstractAdapter
         foreach ($foreignKey->getReferencedColumns() as $column) {
             $refColumnNames[] = $this->quoteColumnName($column);
         }
-        $def .= ' REFERENCES ' . $this->quoteTableName((string)$foreignKey->getReferencedTable()) . ' (' . implode(',', $refColumnNames) . ')';
+        $referencedTable = $foreignKey->getReferencedTable();
+        if ($referencedTable === null) {
+            throw new InvalidArgumentException('Foreign key must have a referenced table.');
+        }
+        $def .= ' REFERENCES ' . $this->quoteTableName($referencedTable) . ' (' . implode(',', $refColumnNames) . ')';
         $onDelete = $foreignKey->getOnDelete();
         if ($onDelete) {
             $def .= ' ON DELETE ' . $onDelete;

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -727,7 +727,7 @@ class MysqlAdapter extends AbstractAdapter
         $targetColumn = null;
 
         foreach ($columns as $column) {
-            if (strcasecmp($column->getName(), $columnName) === 0) {
+            if (strcasecmp((string)$column->getName(), $columnName) === 0) {
                 $targetColumn = $column;
                 break;
             }
@@ -1201,7 +1201,7 @@ class MysqlAdapter extends AbstractAdapter
             $def .= ' CONSTRAINT ' . $this->quoteColumnName((string)$foreignKey->getName());
         }
         $columnNames = [];
-        foreach ($foreignKey->getColumns() as $column) {
+        foreach ($foreignKey->getColumns() ?? [] as $column) {
             $columnNames[] = $this->quoteColumnName($column);
         }
         $def .= ' FOREIGN KEY (' . implode(',', $columnNames) . ')';
@@ -1209,7 +1209,7 @@ class MysqlAdapter extends AbstractAdapter
         foreach ($foreignKey->getReferencedColumns() as $column) {
             $refColumnNames[] = $this->quoteColumnName($column);
         }
-        $def .= ' REFERENCES ' . $this->quoteTableName($foreignKey->getReferencedTable()) . ' (' . implode(',', $refColumnNames) . ')';
+        $def .= ' REFERENCES ' . $this->quoteTableName((string)$foreignKey->getReferencedTable()) . ' (' . implode(',', $refColumnNames) . ')';
         $onDelete = $foreignKey->getOnDelete();
         if ($onDelete) {
             $def .= ' ON DELETE ' . $onDelete;

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -727,7 +727,7 @@ class MysqlAdapter extends AbstractAdapter
         $targetColumn = null;
 
         foreach ($columns as $column) {
-            if ($column->getName() !== null && strcasecmp($column->getName(), $columnName) === 0) {
+            if (strcasecmp($column->getName(), $columnName) === 0) {
                 $targetColumn = $column;
                 break;
             }

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -1197,8 +1197,9 @@ class MysqlAdapter extends AbstractAdapter
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey): string
     {
         $def = '';
-        if ($foreignKey->getName()) {
-            $def .= ' CONSTRAINT ' . $this->quoteColumnName((string)$foreignKey->getName());
+        $name = $foreignKey->getName();
+        if ($name) {
+            $def .= ' CONSTRAINT ' . $this->quoteColumnName($name);
         }
         $columnNames = [];
         foreach ($foreignKey->getColumns() ?? [] as $column) {

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -476,6 +476,12 @@ class PostgresAdapter extends AbstractAdapter
                 $quotedColumnName,
             );
         }
+        if (in_array($newColumn->getType(), ['json'])) {
+            $sql .= sprintf(
+                ' USING (%s::jsonb)',
+                $quotedColumnName,
+            );
+        }
         // NULL and DEFAULT cannot be set while changing column type
         $sql = preg_replace('/ NOT NULL/', '', $sql);
         $sql = preg_replace('/ DEFAULT NULL/', '', $sql);

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -455,9 +455,9 @@ class PostgresAdapter extends AbstractAdapter
 
         $columnSql = $dialect->columnDefinitionSql($this->mapColumnData($newColumn->toArray()));
         // Remove the column name from $columnSql
-        $columnType = preg_replace('/^"?(?:[^"]+)"?\s+/', '', $columnSql);
+        $columnType = (string)preg_replace('/^"?(?:[^"]+)"?\s+/', '', $columnSql);
         // Remove generated clause
-        $columnType = preg_replace('/GENERATED (?:ALWAYS|BY DEFAULT) AS IDENTITY/', '', $columnType);
+        $columnType = (string)preg_replace('/GENERATED (?:ALWAYS|BY DEFAULT) AS IDENTITY/', '', $columnType);
 
         $sql = sprintf(
             'ALTER COLUMN %s TYPE %s',
@@ -483,10 +483,10 @@ class PostgresAdapter extends AbstractAdapter
             );
         }
         // NULL and DEFAULT cannot be set while changing column type
-        $sql = preg_replace('/ NOT NULL/', '', $sql);
-        $sql = preg_replace('/ DEFAULT NULL/', '', $sql);
+        $sql = (string)preg_replace('/ NOT NULL/', '', $sql);
+        $sql = (string)preg_replace('/ DEFAULT NULL/', '', $sql);
         // If it is set, DEFAULT is the last definition
-        $sql = preg_replace('/DEFAULT .*/', '', $sql);
+        $sql = (string)preg_replace('/DEFAULT .*/', '', $sql);
         if ($newColumn->getType() === 'boolean') {
             $sql .= sprintf(
                 ' USING (CASE WHEN %s IS NULL THEN NULL WHEN %s::int=0 THEN FALSE ELSE TRUE END)',
@@ -952,13 +952,13 @@ class PostgresAdapter extends AbstractAdapter
         $parts = $this->getSchemaName($tableName);
 
         $constraintName = $foreignKey->getName() ?: (
-            $parts['table'] . '_' . implode('_', $foreignKey->getColumns()) . '_fkey'
+            $parts['table'] . '_' . implode('_', $foreignKey->getColumns() ?? []) . '_fkey'
         );
-        $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns()));
+        $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns() ?? []));
         $refColumnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getReferencedColumns()));
         $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName) .
         ' FOREIGN KEY (' . $columnList . ')' .
-        ' REFERENCES ' . $this->quoteTableName($foreignKey->getReferencedTable()) . ' (' . $refColumnList . ')';
+        ' REFERENCES ' . $this->quoteTableName((string)$foreignKey->getReferencedTable()) . ' (' . $refColumnList . ')';
         if ($foreignKey->getOnDelete()) {
             $def .= " ON DELETE {$foreignKey->getOnDelete()}";
         }
@@ -1327,7 +1327,7 @@ class PostgresAdapter extends AbstractAdapter
             }
             $quotedConflictColumns = array_map($this->quoteColumnName(...), $conflictColumns);
             $updates = [];
-            foreach ($updateColumns as $column) {
+            foreach ($updateColumns ?? [] as $column) {
                 $quotedColumn = $this->quoteColumnName($column);
                 $updates[] = $quotedColumn . ' = EXCLUDED.' . $quotedColumn;
             }

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -546,12 +546,16 @@ class PostgresAdapter extends AbstractAdapter
         }
 
         // rename column
-        if ($columnName !== $newColumn->getName()) {
+        $newColumnName = $newColumn->getName();
+        if ($columnName !== $newColumnName) {
+            if ($newColumnName === null) {
+                throw new InvalidArgumentException('Column name must be set.');
+            }
             $instructions->addPostStep(sprintf(
                 'ALTER TABLE %s RENAME COLUMN %s TO %s',
                 $this->quoteTableName($tableName),
                 $quotedColumnName,
-                $this->quoteColumnName((string)$newColumn->getName()),
+                $this->quoteColumnName($newColumnName),
             ));
         }
 
@@ -873,6 +877,11 @@ class PostgresAdapter extends AbstractAdapter
      */
     protected function getColumnCommentSqlDefinition(Column $column, string $tableName): string
     {
+        $columnName = $column->getName();
+        if ($columnName === null) {
+            throw new InvalidArgumentException('Column name must be set.');
+        }
+
         $comment = (string)$column->getComment();
         // passing 'null' is to remove column comment
         $comment = strcasecmp($comment, 'NULL') !== 0
@@ -882,7 +891,7 @@ class PostgresAdapter extends AbstractAdapter
         return sprintf(
             'COMMENT ON COLUMN %s.%s IS %s;',
             $this->quoteTableName($tableName),
-            $this->quoteColumnName((string)$column->getName()),
+            $this->quoteColumnName($columnName),
             $comment,
         );
     }
@@ -957,9 +966,13 @@ class PostgresAdapter extends AbstractAdapter
         );
         $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns() ?? []));
         $refColumnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getReferencedColumns()));
+        $referencedTable = $foreignKey->getReferencedTable();
+        if ($referencedTable === null) {
+            throw new InvalidArgumentException('Foreign key must have a referenced table.');
+        }
         $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName) .
         ' FOREIGN KEY (' . $columnList . ')' .
-        ' REFERENCES ' . $this->quoteTableName((string)$foreignKey->getReferencedTable()) . ' (' . $refColumnList . ')';
+        ' REFERENCES ' . $this->quoteTableName($referencedTable) . ' (' . $refColumnList . ')';
         if ($foreignKey->getOnDelete()) {
             $def .= " ON DELETE {$foreignKey->getOnDelete()}";
         }

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -548,9 +548,6 @@ class PostgresAdapter extends AbstractAdapter
         // rename column
         $newColumnName = $newColumn->getName();
         if ($columnName !== $newColumnName) {
-            if ($newColumnName === null) {
-                throw new InvalidArgumentException('Column name must be set.');
-            }
             $instructions->addPostStep(sprintf(
                 'ALTER TABLE %s RENAME COLUMN %s TO %s',
                 $this->quoteTableName($tableName),
@@ -878,10 +875,6 @@ class PostgresAdapter extends AbstractAdapter
     protected function getColumnCommentSqlDefinition(Column $column, string $tableName): string
     {
         $columnName = $column->getName();
-        if ($columnName === null) {
-            throw new InvalidArgumentException('Column name must be set.');
-        }
-
         $comment = (string)$column->getComment();
         // passing 'null' is to remove column comment
         $comment = strcasecmp($comment, 'NULL') !== 0

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -962,9 +962,9 @@ class PostgresAdapter extends AbstractAdapter
         $parts = $this->getSchemaName($tableName);
 
         $constraintName = $foreignKey->getName() ?: (
-            $parts['table'] . '_' . implode('_', $foreignKey->getColumns() ?? []) . '_fkey'
+            $parts['table'] . '_' . implode('_', $foreignKey->getColumns()) . '_fkey'
         );
-        $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns() ?? []));
+        $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns()));
         $refColumnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getReferencedColumns()));
         $referencedTable = $foreignKey->getReferencedTable();
         if ($referencedTable === null) {

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -505,11 +505,11 @@ class PostgresAdapter extends AbstractAdapter
                 'ALTER COLUMN %s',
                 $quotedColumnName,
             );
-            if ($newColumn->isIdentity() && $newColumn->getGenerated() !== null) {
+            if ($newColumn->isIdentity() && ($generated = $newColumn->getGenerated()) !== null) {
                 if ($column->isIdentity()) {
-                    $sql .= sprintf(' SET GENERATED %s', (string)$newColumn->getGenerated());
+                    $sql .= sprintf(' SET GENERATED %s', $generated);
                 } else {
-                    $sql .= sprintf(' ADD GENERATED %s AS IDENTITY', (string)$newColumn->getGenerated());
+                    $sql .= sprintf(' ADD GENERATED %s AS IDENTITY', $generated);
                 }
             } else {
                 $sql .= ' DROP IDENTITY IF EXISTS';
@@ -923,9 +923,10 @@ class PostgresAdapter extends AbstractAdapter
         } else {
             $createIndexSentence .= '(%s)%s%s;';
         }
-        $where = (string)$index->getWhere();
-        if ($where) {
-            $where = ' WHERE ' . $where;
+        $where = '';
+        $whereClause = $index->getWhere();
+        if ($whereClause) {
+            $where = ' WHERE ' . $whereClause;
         }
 
         return sprintf(

--- a/src/Db/Adapter/RecordingAdapter.php
+++ b/src/Db/Adapter/RecordingAdapter.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Migrations\Db\Adapter;
 
-use InvalidArgumentException;
 use Migrations\Db\Action\AddColumn;
 use Migrations\Db\Action\AddForeignKey;
 use Migrations\Db\Action\AddIndex;
@@ -92,9 +91,6 @@ class RecordingAdapter extends AdapterWrapper
                     /** @var \Migrations\Db\Action\RenameColumn $command */
                     $column = clone $command->getColumn();
                     $name = $column->getName();
-                    if ($name === null) {
-                        throw new InvalidArgumentException('Column name must be set.');
-                    }
                     $column->setName($command->getNewName());
                     $inverted->addAction(new RenameColumn($command->getTable(), $column, $name));
                     break;

--- a/src/Db/Adapter/RecordingAdapter.php
+++ b/src/Db/Adapter/RecordingAdapter.php
@@ -13,6 +13,7 @@ use Migrations\Db\Action\AddColumn;
 use Migrations\Db\Action\AddForeignKey;
 use Migrations\Db\Action\AddIndex;
 use Migrations\Db\Action\CreateTable;
+use InvalidArgumentException;
 use Migrations\Db\Action\DropForeignKey;
 use Migrations\Db\Action\DropIndex;
 use Migrations\Db\Action\DropTable;
@@ -90,7 +91,10 @@ class RecordingAdapter extends AdapterWrapper
                 case $command instanceof RenameColumn:
                     /** @var \Migrations\Db\Action\RenameColumn $command */
                     $column = clone $command->getColumn();
-                    $name = (string)$column->getName();
+                    $name = $column->getName();
+                    if ($name === null) {
+                        throw new InvalidArgumentException('Column name must be set.');
+                    }
                     $column->setName($command->getNewName());
                     $inverted->addAction(new RenameColumn($command->getTable(), $column, $name));
                     break;

--- a/src/Db/Adapter/RecordingAdapter.php
+++ b/src/Db/Adapter/RecordingAdapter.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Migrations\Db\Adapter;
 
+use InvalidArgumentException;
 use Migrations\Db\Action\AddColumn;
 use Migrations\Db\Action\AddForeignKey;
 use Migrations\Db\Action\AddIndex;

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1684,7 +1684,7 @@ PCRE_PATTERN;
             $def .= ' CONSTRAINT ' . $this->quoteColumnName($name);
         }
         $columnNames = [];
-        foreach ($foreignKey->getColumns() ?? [] as $column) {
+        foreach ($foreignKey->getColumns() as $column) {
             $columnNames[] = $this->quoteColumnName($column);
         }
         $def .= ' FOREIGN KEY (' . implode(',', $columnNames) . ')';

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -570,7 +570,7 @@ PCRE_PATTERN;
                 return $state;
             }
             $finalColumnName = end($columns)->getName();
-            $sql = preg_replace(
+            $sql = (string)preg_replace(
                 sprintf(
                     "/(%s(?:\/\*.*?\*\/|\([^)]+\)|'[^']*?'|[^,])+)([,)])/",
                     $this->quoteColumnName((string)$finalColumnName),
@@ -619,7 +619,7 @@ PCRE_PATTERN;
             $columnNamePattern = "\"$columnName\"|`$columnName`|\\[$columnName\\]|$columnName";
             $columnNamePattern = "#([\(,]+\\s*)($columnNamePattern)(\\s)#iU";
 
-            $sql = preg_replace_callback(
+            $sql = (string)preg_replace_callback(
                 $columnNamePattern,
                 function ($matches) use ($column) {
                     return $matches[1] . $this->quoteColumnName($column['name']) . $matches[3];
@@ -631,7 +631,7 @@ PCRE_PATTERN;
         $tableNamePattern = "\"$tableName\"|`$tableName`|\\[$tableName\\]|$tableName";
         $tableNamePattern = "#^(CREATE TABLE)\s*($tableNamePattern)\s*(\()#Ui";
 
-        $sql = preg_replace($tableNamePattern, "$1 `$tableName` $3", $sql, 1);
+        $sql = (string)preg_replace($tableNamePattern, "$1 `$tableName` $3", $sql, 1);
 
         return $sql;
     }
@@ -1115,7 +1115,7 @@ PCRE_PATTERN;
         $newColumnName = (string)$newColumn->getName();
         $instructions->addPostStep(function ($state) use ($columnName, $newColumn) {
             $dialect = $this->getSchemaDialect();
-            $sql = preg_replace(
+            $sql = (string)preg_replace(
                 sprintf("/%s(?:\/\*.*?\*\/|\([^)]+\)|'[^']*?'|[^,])+([,)])/", $this->quoteColumnName($columnName)),
                 sprintf('%s$1', $dialect->columnDefinitionSql($newColumn->toArray())),
                 (string)$state['createSQL'],
@@ -1149,7 +1149,7 @@ PCRE_PATTERN;
         });
 
         $instructions->addPostStep(function ($state) use ($columnName) {
-            $sql = preg_replace(
+            $sql = (string)preg_replace(
                 sprintf("/%s\s\w+.*(,\s(?!')|\)$)/U", preg_quote($this->quoteColumnName($columnName))),
                 '',
                 (string)$state['createSQL'],
@@ -1679,7 +1679,7 @@ PCRE_PATTERN;
             $def .= ' CONSTRAINT ' . $this->quoteColumnName((string)$foreignKey->getName());
         }
         $columnNames = [];
-        foreach ($foreignKey->getColumns() as $column) {
+        foreach ($foreignKey->getColumns() ?? [] as $column) {
             $columnNames[] = $this->quoteColumnName($column);
         }
         $def .= ' FOREIGN KEY (' . implode(',', $columnNames) . ')';
@@ -1687,7 +1687,7 @@ PCRE_PATTERN;
         foreach ($foreignKey->getReferencedColumns() as $column) {
             $refColumnNames[] = $this->quoteColumnName($column);
         }
-        $def .= ' REFERENCES ' . $this->quoteTableName($foreignKey->getReferencedTable()) . ' (' . implode(',', $refColumnNames) . ')';
+        $def .= ' REFERENCES ' . $this->quoteTableName((string)$foreignKey->getReferencedTable()) . ' (' . implode(',', $refColumnNames) . ')';
         if ($foreignKey->getOnDelete()) {
             $def .= ' ON DELETE ' . $foreignKey->getOnDelete();
         }

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1214,9 +1214,10 @@ PCRE_PATTERN;
             $indexColumnArray[] = sprintf('%s ASC', $this->quoteColumnName($column));
         }
         $indexColumns = implode(',', $indexColumnArray);
-        $where = (string)$index->getWhere();
-        if ($where) {
-            $where = ' WHERE ' . $where;
+        $where = '';
+        $whereClause = $index->getWhere();
+        if ($whereClause) {
+            $where = ' WHERE ' . $whereClause;
         }
         $sql = sprintf(
             'CREATE %s ON %s (%s)%s',
@@ -1675,8 +1676,9 @@ PCRE_PATTERN;
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey): string
     {
         $def = '';
-        if ($foreignKey->getName()) {
-            $def .= ' CONSTRAINT ' . $this->quoteColumnName((string)$foreignKey->getName());
+        $name = $foreignKey->getName();
+        if ($name) {
+            $def .= ' CONSTRAINT ' . $this->quoteColumnName($name);
         }
         $columnNames = [];
         foreach ($foreignKey->getColumns() ?? [] as $column) {

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1112,7 +1112,10 @@ PCRE_PATTERN;
     {
         $instructions = $this->beginAlterByCopyTable($tableName);
 
-        $newColumnName = (string)$newColumn->getName();
+        $newColumnName = $newColumn->getName();
+        if ($newColumnName === null) {
+            throw new InvalidArgumentException('Column name must be set.');
+        }
         $instructions->addPostStep(function ($state) use ($columnName, $newColumn) {
             $dialect = $this->getSchemaDialect();
             $sql = (string)preg_replace(
@@ -1689,7 +1692,11 @@ PCRE_PATTERN;
         foreach ($foreignKey->getReferencedColumns() as $column) {
             $refColumnNames[] = $this->quoteColumnName($column);
         }
-        $def .= ' REFERENCES ' . $this->quoteTableName((string)$foreignKey->getReferencedTable()) . ' (' . implode(',', $refColumnNames) . ')';
+        $referencedTable = $foreignKey->getReferencedTable();
+        if ($referencedTable === null) {
+            throw new InvalidArgumentException('Foreign key must have a referenced table.');
+        }
+        $def .= ' REFERENCES ' . $this->quoteTableName($referencedTable) . ' (' . implode(',', $refColumnNames) . ')';
         if ($foreignKey->getOnDelete()) {
             $def .= ' ON DELETE ' . $foreignKey->getOnDelete();
         }

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1113,9 +1113,6 @@ PCRE_PATTERN;
         $instructions = $this->beginAlterByCopyTable($tableName);
 
         $newColumnName = $newColumn->getName();
-        if ($newColumnName === null) {
-            throw new InvalidArgumentException('Column name must be set.');
-        }
         $instructions->addPostStep(function ($state) use ($columnName, $newColumn) {
             $dialect = $this->getSchemaDialect();
             $sql = (string)preg_replace(

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -214,9 +214,6 @@ class SqlserverAdapter extends AbstractAdapter
     protected function getColumnCommentSqlDefinition(Column $column, ?string $tableName): string
     {
         $columnName = $column->getName();
-        if ($columnName === null) {
-            throw new InvalidArgumentException('Column name must be set.');
-        }
         if ($tableName === null) {
             throw new InvalidArgumentException('Table name must be set.');
         }
@@ -429,9 +426,6 @@ END',
         }
 
         $newColumnName = $newColumn->getName();
-        if ($newColumnName === null) {
-            throw new InvalidArgumentException('Column name must be set.');
-        }
         $instructions->addPostStep(sprintf(
             'ALTER TABLE %s ADD CONSTRAINT %s %s FOR %s',
             $this->quoteTableName($tableName),
@@ -468,10 +462,6 @@ END',
         $dialect = $this->getSchemaDialect();
 
         $newColumnName = $newColumn->getName();
-        if ($newColumnName === null) {
-            throw new InvalidArgumentException('Column name must be set.');
-        }
-
         if ($columnName !== $newColumnName) {
             $instructions->merge(
                 $this->getRenameColumnInstructions($tableName, $columnName, $newColumnName),

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -213,8 +213,16 @@ class SqlserverAdapter extends AbstractAdapter
      */
     protected function getColumnCommentSqlDefinition(Column $column, ?string $tableName): string
     {
+        $columnName = $column->getName();
+        if ($columnName === null) {
+            throw new InvalidArgumentException('Column name must be set.');
+        }
+        if ($tableName === null) {
+            throw new InvalidArgumentException('Table name must be set.');
+        }
+
         // passing 'null' is to remove column comment
-        $currentComment = $this->getColumnComment((string)$tableName, $column->getName());
+        $currentComment = $this->getColumnComment($tableName, $columnName);
 
         $comment = strcasecmp((string)$column->getComment(), 'NULL') !== 0 ? $this->quoteString((string)$column->getComment()) : '\'\'';
         $command = $currentComment === null ? 'sp_addextendedproperty' : 'sp_updateextendedproperty';
@@ -224,8 +232,8 @@ class SqlserverAdapter extends AbstractAdapter
             $command,
             $comment,
             $this->schema,
-            (string)$tableName,
-            (string)$column->getName(),
+            $tableName,
+            $columnName,
         );
     }
 
@@ -420,12 +428,16 @@ END',
             return $instructions;
         }
 
+        $newColumnName = $newColumn->getName();
+        if ($newColumnName === null) {
+            throw new InvalidArgumentException('Column name must be set.');
+        }
         $instructions->addPostStep(sprintf(
             'ALTER TABLE %s ADD CONSTRAINT %s %s FOR %s',
             $this->quoteTableName($tableName),
             $constraintName,
             $default,
-            $this->quoteColumnName((string)$newColumn->getName()),
+            $this->quoteColumnName($newColumnName),
         ));
 
         return $instructions;
@@ -455,14 +467,19 @@ END',
         $instructions = new AlterInstructions();
         $dialect = $this->getSchemaDialect();
 
-        if ($columnName !== $newColumn->getName()) {
+        $newColumnName = $newColumn->getName();
+        if ($newColumnName === null) {
+            throw new InvalidArgumentException('Column name must be set.');
+        }
+
+        if ($columnName !== $newColumnName) {
             $instructions->merge(
-                $this->getRenameColumnInstructions($tableName, $columnName, (string)$newColumn->getName()),
+                $this->getRenameColumnInstructions($tableName, $columnName, $newColumnName),
             );
         }
 
         if ($changeDefault) {
-            $instructions->merge($this->getDropDefaultConstraint($tableName, (string)$newColumn->getName()));
+            $instructions->merge($this->getDropDefaultConstraint($tableName, $newColumnName));
         }
 
         // Sqlserver doesn't support defaults
@@ -871,7 +888,11 @@ DROP DATABASE %s;',
 
         $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName);
         $def .= ' FOREIGN KEY (' . $columnList . ')';
-        $def .= ' REFERENCES ' . $this->quoteTableName((string)$foreignKey->getReferencedTable()) . ' (' . $refColumnList . ')';
+        $referencedTable = $foreignKey->getReferencedTable();
+        if ($referencedTable === null) {
+            throw new InvalidArgumentException('Foreign key must have a referenced table.');
+        }
+        $def .= ' REFERENCES ' . $this->quoteTableName($referencedTable) . ' (' . $refColumnList . ')';
         if ($foreignKey->getOnDelete()) {
             $def .= " ON DELETE {$foreignKey->getOnDelete()}";
         }

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -839,9 +839,10 @@ DROP DATABASE %s;',
 
         $include = $index->getInclude();
         $includedColumns = $include ? sprintf(' INCLUDE ([%s])', implode('],[', $include)) : '';
-        $where = (string)$index->getWhere();
-        if ($where) {
-            $where = ' WHERE ' . $where;
+        $where = '';
+        $whereClause = $index->getWhere();
+        if ($whereClause) {
+            $where = ' WHERE ' . $whereClause;
         }
 
         return sprintf(

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -882,8 +882,8 @@ DROP DATABASE %s;',
      */
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, string $tableName): string
     {
-        $constraintName = $foreignKey->getName() ?: $tableName . '_' . implode('_', $foreignKey->getColumns() ?? []);
-        $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns() ?? []));
+        $constraintName = $foreignKey->getName() ?: $tableName . '_' . implode('_', $foreignKey->getColumns());
+        $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns()));
         $refColumnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getReferencedColumns()));
 
         $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName);

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -338,7 +338,7 @@ class SqlserverAdapter extends AbstractAdapter
 
         $result = preg_replace(["/\('(.*)'\)/", "/\(\((.*)\)\)/", "/\((.*)\)/"], '$1', $default);
 
-        if (strtoupper($result) === 'NULL') {
+        if (strtoupper((string)$result) === 'NULL') {
             $result = null;
         } elseif (is_numeric($result)) {
             $result = (int)$result;
@@ -475,7 +475,7 @@ END',
             $dialect->columnDefinitionSql($columnData),
         );
         $alterColumn = preg_replace('/DEFAULT NULL/', '', $alterColumn);
-        $instructions->addPostStep($alterColumn);
+        $instructions->addPostStep((string)$alterColumn);
 
         // change column comment if needed
         if ($newColumn->getComment()) {
@@ -864,13 +864,13 @@ DROP DATABASE %s;',
      */
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, string $tableName): string
     {
-        $constraintName = $foreignKey->getName() ?: $tableName . '_' . implode('_', $foreignKey->getColumns());
-        $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns()));
+        $constraintName = $foreignKey->getName() ?: $tableName . '_' . implode('_', $foreignKey->getColumns() ?? []);
+        $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns() ?? []));
         $refColumnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getReferencedColumns()));
 
         $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName);
         $def .= ' FOREIGN KEY (' . $columnList . ')';
-        $def .= ' REFERENCES ' . $this->quoteTableName($foreignKey->getReferencedTable()) . ' (' . $refColumnList . ')';
+        $def .= ' REFERENCES ' . $this->quoteTableName((string)$foreignKey->getReferencedTable()) . ' (' . $refColumnList . ')';
         if ($foreignKey->getOnDelete()) {
             $def .= " ON DELETE {$foreignKey->getOnDelete()}";
         }

--- a/src/Db/Adapter/TimedOutputAdapter.php
+++ b/src/Db/Adapter/TimedOutputAdapter.php
@@ -78,7 +78,7 @@ class TimedOutputAdapter extends AdapterWrapper implements DirectActionInterface
             return;
         }
 
-        $this->getIo()->verbose(' -- ' . $command);
+        $this->getIo()?->verbose(' -- ' . $command);
     }
 
     /**

--- a/src/Db/Plan/Plan.php
+++ b/src/Db/Plan/Plan.php
@@ -284,7 +284,7 @@ class Plan
             if ($action instanceof DropForeignKey) {
                 [$this->indexes, $dropIndexActions] = $this->forgetDropIndex(
                     $action->getTable(),
-                    $action->getForeignKey()->getColumns() ?? [],
+                    $action->getForeignKey()->getColumns(),
                     $this->indexes,
                 );
                 foreach ($dropIndexActions as $dropIndexAction) {

--- a/src/Db/Plan/Plan.php
+++ b/src/Db/Plan/Plan.php
@@ -284,7 +284,7 @@ class Plan
             if ($action instanceof DropForeignKey) {
                 [$this->indexes, $dropIndexActions] = $this->forgetDropIndex(
                     $action->getTable(),
-                    $action->getForeignKey()->getColumns(),
+                    $action->getForeignKey()->getColumns() ?? [],
                     $this->indexes,
                 );
                 foreach ($dropIndexActions as $dropIndexAction) {

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -362,7 +362,7 @@ class Table
         if ($columnName instanceof Column) {
             $action = new AddColumn($this->table, $columnName);
         } else {
-            $action = new AddColumn($this->table, $this->getAdapter()->getColumnForType($columnName, $type, $options));
+            $action = new AddColumn($this->table, $this->getAdapter()->getColumnForType($columnName, (string)$type, $options));
         }
 
         // Delegate to Adapters to check column type
@@ -902,7 +902,7 @@ class Table
                 return $action->getColumn();
             });
         $primaryKeyColumns = $columnsCollection->filter(function (Column $columnDef, $key) use ($primaryKey) {
-            return isset($primaryKey[$columnDef->getName()]);
+            return isset($primaryKey[(string)$columnDef->getName()]);
         })->toArray();
 
         if (!$primaryKeyColumns) {
@@ -911,7 +911,7 @@ class Table
 
         foreach ($primaryKeyColumns as $primaryKeyColumn) {
             if ($primaryKeyColumn->isIdentity()) {
-                unset($primaryKey[$primaryKeyColumn->getName()]);
+                unset($primaryKey[(string)$primaryKeyColumn->getName()]);
             }
         }
 

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -358,11 +358,12 @@ class Table
      */
     public function addColumn(string|Column $columnName, ?string $type = null, array $options = [])
     {
-        assert($columnName instanceof Column || $type !== null);
         if ($columnName instanceof Column) {
             $action = new AddColumn($this->table, $columnName);
+        } elseif ($type === null) {
+            throw new InvalidArgumentException('Column type must not be null when column name is a string.');
         } else {
-            $action = new AddColumn($this->table, $this->getAdapter()->getColumnForType($columnName, (string)$type, $options));
+            $action = new AddColumn($this->table, $this->getAdapter()->getColumnForType($columnName, $type, $options));
         }
 
         // Delegate to Adapters to check column type

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -368,15 +368,11 @@ class Table
 
         // Delegate to Adapters to check column type
         $column = $action->getColumn();
-        $colName = $column->getName();
-        if ($colName === null) {
-            throw new InvalidArgumentException('Column name must be set.');
-        }
         if (!$this->getAdapter()->isValidColumnType($column)) {
             throw new InvalidArgumentException(sprintf(
                 'An invalid column type "%s" was specified for column "%s".',
                 $column->getType(),
-                $colName,
+                $column->getName(),
             ));
         }
 
@@ -908,9 +904,7 @@ class Table
                 return $action->getColumn();
             });
         $primaryKeyColumns = $columnsCollection->filter(function (Column $columnDef, $key) use ($primaryKey) {
-            $name = $columnDef->getName();
-
-            return $name !== null && isset($primaryKey[$name]);
+            return isset($primaryKey[$columnDef->getName()]);
         })->toArray();
 
         if (!$primaryKeyColumns) {
@@ -919,11 +913,7 @@ class Table
 
         foreach ($primaryKeyColumns as $primaryKeyColumn) {
             if ($primaryKeyColumn->isIdentity()) {
-                $pkColName = $primaryKeyColumn->getName();
-                if ($pkColName === null) {
-                    continue;
-                }
-                unset($primaryKey[$pkColName]);
+                unset($primaryKey[$primaryKeyColumn->getName()]);
             }
         }
 

--- a/src/Db/Table.php
+++ b/src/Db/Table.php
@@ -367,11 +367,16 @@ class Table
         }
 
         // Delegate to Adapters to check column type
-        if (!$this->getAdapter()->isValidColumnType($action->getColumn())) {
+        $column = $action->getColumn();
+        $colName = $column->getName();
+        if ($colName === null) {
+            throw new InvalidArgumentException('Column name must be set.');
+        }
+        if (!$this->getAdapter()->isValidColumnType($column)) {
             throw new InvalidArgumentException(sprintf(
                 'An invalid column type "%s" was specified for column "%s".',
-                (string)$action->getColumn()->getType(),
-                (string)$action->getColumn()->getName(),
+                $column->getType(),
+                $colName,
             ));
         }
 
@@ -903,7 +908,9 @@ class Table
                 return $action->getColumn();
             });
         $primaryKeyColumns = $columnsCollection->filter(function (Column $columnDef, $key) use ($primaryKey) {
-            return isset($primaryKey[(string)$columnDef->getName()]);
+            $name = $columnDef->getName();
+
+            return $name !== null && isset($primaryKey[$name]);
         })->toArray();
 
         if (!$primaryKeyColumns) {
@@ -912,7 +919,11 @@ class Table
 
         foreach ($primaryKeyColumns as $primaryKeyColumn) {
             if ($primaryKeyColumn->isIdentity()) {
-                unset($primaryKey[(string)$primaryKeyColumn->getName()]);
+                $pkColName = $primaryKeyColumn->getName();
+                if ($pkColName === null) {
+                    continue;
+                }
+                unset($primaryKey[$pkColName]);
             }
         }
 

--- a/src/Db/Table/Column.php
+++ b/src/Db/Table/Column.php
@@ -118,6 +118,11 @@ class Column extends DatabaseColumn
     protected ?string $lock = null;
 
     /**
+     * @var bool|null
+     */
+    protected ?bool $fixed = null;
+
+    /**
      * Column constructor
      *
      * @param string $name The name of the column.
@@ -773,6 +778,31 @@ class Column extends DatabaseColumn
     }
 
     /**
+     * Sets whether field should use fixed-length storage (for binary columns).
+     *
+     * When true, binary columns will use BINARY(n) instead of VARBINARY(n).
+     *
+     * @param bool $fixed Fixed
+     * @return $this
+     */
+    public function setFixed(bool $fixed)
+    {
+        $this->fixed = $fixed;
+
+        return $this;
+    }
+
+    /**
+     * Gets whether field should use fixed-length storage.
+     *
+     * @return bool|null
+     */
+    public function getFixed(): ?bool
+    {
+        return $this->fixed;
+    }
+
+    /**
      * Gets all allowed options. Each option must have a corresponding `setFoo` method.
      *
      * @return array
@@ -802,6 +832,7 @@ class Column extends DatabaseColumn
             'generated',
             'algorithm',
             'lock',
+            'fixed',
         ];
     }
 
@@ -894,6 +925,7 @@ class Column extends DatabaseColumn
             'default' => $default,
             'generated' => $this->getGenerated(),
             'unsigned' => $this->getUnsigned(),
+            'fixed' => $this->getFixed(),
             'onUpdate' => $this->getUpdate(),
             'collate' => $this->getCollation(),
             'precision' => $precision,

--- a/src/Db/Table/Column.php
+++ b/src/Db/Table/Column.php
@@ -234,7 +234,7 @@ class Column extends DatabaseColumn
      */
     public function getNull(): bool
     {
-        return $this->null;
+        return $this->null ?? false;
     }
 
     /**

--- a/src/Db/Table/Column.php
+++ b/src/Db/Table/Column.php
@@ -182,9 +182,12 @@ class Column extends DatabaseColumn
     /**
      * Gets the column name.
      *
-     * @return string|null
+     * Narrows the return type from the parent's ?string to string,
+     * since $name is typed as string (not ?string) in this class.
+     *
+     * @return string
      */
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/Db/Table/ForeignKey.php
+++ b/src/Db/Table/ForeignKey.php
@@ -246,7 +246,9 @@ class ForeignKey extends DatabaseForeignKey
      */
     public function getOnDelete(): ?string
     {
-        return $this->mapAction($this->getDelete());
+        $delete = $this->getDelete();
+
+        return $delete !== null ? $this->mapAction($delete) : null;
     }
 
     /**
@@ -271,6 +273,8 @@ class ForeignKey extends DatabaseForeignKey
      */
     public function getOnUpdate(): ?string
     {
-        return $this->mapAction($this->getUpdate());
+        $update = $this->getUpdate();
+
+        return $update !== null ? $this->mapAction($update) : null;
     }
 }

--- a/src/Db/Table/ForeignKey.php
+++ b/src/Db/Table/ForeignKey.php
@@ -87,6 +87,19 @@ class ForeignKey extends DatabaseForeignKey
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * Narrows the return type from the parent's ?array to array,
+     * since $columns is always initialized as [] in this class.
+     *
+     * @return array<string>
+     */
+    public function getColumns(): array
+    {
+        return $this->columns;
+    }
+
+    /**
      * Utility method that maps an array of index options to this object's methods.
      *
      * @param array<string, mixed> $options Options

--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -213,7 +213,7 @@ class ColumnParser
             $referencedTable = $indexType;
             if (!$referencedTable) {
                 // Remove common suffixes like _id and pluralize
-                $referencedTable = preg_replace('/_id$/', '', $fieldName);
+                $referencedTable = (string)preg_replace('/_id$/', '', $fieldName);
                 $referencedTable = Inflector::pluralize($referencedTable);
             }
 

--- a/src/Util/TableFinder.php
+++ b/src/Util/TableFinder.php
@@ -183,9 +183,10 @@ class TableFinder
 
         $table = TableRegistry::getTableLocator()->get($className);
         foreach ($table->associations()->keys() as $key) {
-            if ($table->associations()->get($key)->type() === 'belongsToMany') {
+            $association = $table->associations()->get($key);
+            if ($association !== null && $association->type() === 'belongsToMany') {
                 /** @var \Cake\ORM\Association\BelongsToMany $belongsToMany */
-                $belongsToMany = $table->associations()->get($key);
+                $belongsToMany = $association;
                 $tables[] = $belongsToMany->junction()->getTable();
             }
         }

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -693,7 +693,7 @@ class MigrationHelper extends Helper
         $indexes = $this->indexes($table);
         $foreignKeys = [];
         foreach ($constraints as $constraint) {
-            if ($constraint['type'] === 'foreign') {
+            if (isset($constraint['type']) && $constraint['type'] === 'foreign') {
                 $foreignKeys[] = $constraint['columns'];
             }
         }

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -389,6 +389,7 @@ class MigrationHelper extends Helper
             'scale',
             'after',
             'collate',
+            'fixed',
         ]);
         $columnOptions = array_intersect_key($options, $wantedOptions);
         if (empty($columnOptions['comment'])) {
@@ -495,7 +496,7 @@ class MigrationHelper extends Helper
             'comment', 'unsigned',
             'signed', 'properties',
             'autoIncrement', 'unique',
-            'collate',
+            'collate', 'fixed',
         ];
 
         $attributes = [];

--- a/tests/TestCase/Command/UpgradeCommandTest.php
+++ b/tests/TestCase/Command/UpgradeCommandTest.php
@@ -166,4 +166,65 @@ class UpgradeCommandTest extends TestCase
 
         $this->assertCount(1, $rows);
     }
+
+    /**
+     * Test that plugins with slashes (like CakeDC/Users) are correctly identified
+     * during upgrade from legacy phinxlog tables.
+     */
+    public function testExecuteWithSlashInPluginName(): void
+    {
+        Configure::write('Migrations.legacyTables', true);
+
+        // Create the plugin's phinxlog table using the adapter for cross-database compatibility
+        $config = ConnectionManager::getConfig('test');
+        $environment = new Environment('default', [
+            'connection' => 'test',
+            'database' => $config['database'],
+            'migration_table' => 'cake_d_c_users_phinxlog',
+        ]);
+        $adapter = $environment->getAdapter();
+        try {
+            $adapter->createSchemaTable();
+        } catch (Exception $e) {
+            // Table probably exists
+        }
+
+        // Insert a migration record
+        $adapter->getInsertBuilder()
+            ->insert(['version', 'migration_name', 'breakpoint'])
+            ->into('cake_d_c_users_phinxlog')
+            ->values([
+                'version' => '20250118143003',
+                'migration_name' => 'SlashPluginMigration',
+                'breakpoint' => 0,
+            ])
+            ->execute();
+
+        // Load a fake plugin with a slash in the name using loadPlugins
+        // which properly integrates with the console application
+        $this->loadPlugins(['CakeDC/Users' => ['path' => TMP]]);
+
+        try {
+            $this->exec('migrations upgrade -c test');
+            $this->assertExitSuccess();
+
+            $this->assertOutputContains('cake_d_c_users_phinxlog (CakeDC/Users)');
+
+            // Verify the plugin column has the correct value with slash
+            $rows = $this->getAdapter()->getSelectBuilder()
+                ->select(['version', 'migration_name', 'plugin'])
+                ->from('cake_migrations')
+                ->where(['migration_name' => 'SlashPluginMigration'])
+                ->all();
+
+            $this->assertCount(1, $rows);
+            $this->assertSame('CakeDC/Users', $rows[0]['plugin']);
+        } finally {
+            // Cleanup
+            /** @var \Cake\Database\Connection $connection */
+            $connection = ConnectionManager::get('test');
+            $connection->execute('DROP TABLE ' . $connection->getDriver()->quoteIdentifier('cake_d_c_users_phinxlog'));
+            $this->removePlugins(['CakeDC/Users']);
+        }
+    }
 }

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -3080,6 +3080,38 @@ OUTPUT;
         ])->save();
     }
 
+    public function testInsertOrUpdateWithEmptyConflictColumnsDoesNotWarn()
+    {
+        $table = new Table('currencies', [], $this->adapter);
+        $table->addColumn('code', 'string', ['limit' => 3])
+            ->addColumn('rate', 'decimal', ['precision' => 10, 'scale' => 4])
+            ->addIndex('code', ['unique' => true])
+            ->create();
+
+        $warning = null;
+        set_error_handler(function (int $errno, string $errstr) use (&$warning) {
+            $warning = $errstr;
+
+            return true;
+        }, E_USER_WARNING);
+
+        try {
+            $table->insertOrUpdate([
+                ['code' => 'USD', 'rate' => 1.0000],
+                ['code' => 'EUR', 'rate' => 0.9000],
+            ], ['rate'], [])->save();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNull($warning, 'Empty conflictColumns should not trigger a warning for MySQL');
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM currencies ORDER BY code');
+        $this->assertCount(2, $rows);
+        $this->assertEquals('0.9000', $rows[0]['rate']);
+        $this->assertEquals('1.0000', $rows[1]['rate']);
+    }
+
     public function testCreateTableWithRangeColumnsPartitioning()
     {
         // MySQL requires RANGE COLUMNS for DATE columns

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -3541,4 +3541,53 @@ OUTPUT;
         $this->assertCount(1, $rows);
         $this->assertEquals('A description', $rows[0]['description']);
     }
+
+    public function testBinaryColumnWithFixedOption(): void
+    {
+        $table = new Table('binary_fixed_test', [], $this->adapter);
+        $table->addColumn('hash', 'binary', ['limit' => 20, 'fixed' => true])
+            ->addColumn('data', 'binary', ['limit' => 20])
+            ->save();
+
+        $this->assertTrue($this->adapter->hasColumn('binary_fixed_test', 'hash'));
+        $this->assertTrue($this->adapter->hasColumn('binary_fixed_test', 'data'));
+
+        // Check that the fixed column is created as BINARY and the non-fixed as VARBINARY
+        $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM binary_fixed_test');
+        $hashColumn = null;
+        $dataColumn = null;
+        foreach ($rows as $row) {
+            if ($row['Field'] === 'hash') {
+                $hashColumn = $row;
+            }
+            if ($row['Field'] === 'data') {
+                $dataColumn = $row;
+            }
+        }
+
+        $this->assertNotNull($hashColumn);
+        $this->assertNotNull($dataColumn);
+        $this->assertSame('binary(20)', $hashColumn['Type']);
+        $this->assertSame('varbinary(20)', $dataColumn['Type']);
+
+        // Verify the fixed attribute is reflected back
+        $columns = $this->adapter->getColumns('binary_fixed_test');
+        $hashCol = null;
+        $dataCol = null;
+        foreach ($columns as $col) {
+            if ($col->getName() === 'hash') {
+                $hashCol = $col;
+            }
+            if ($col->getName() === 'data') {
+                $dataCol = $col;
+            }
+        }
+
+        $this->assertNotNull($hashCol);
+        $this->assertNotNull($dataCol);
+        $this->assertSame('binary', $hashCol->getType());
+        $this->assertSame('binary', $dataCol->getType());
+        $this->assertTrue($hashCol->getFixed());
+        $this->assertNull($dataCol->getFixed());
+    }
 }

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -1369,6 +1369,37 @@ class MysqlAdapterTest extends TestCase
         $this->adapter->dropTable('blob_round_trip_test');
     }
 
+    public static function textRoundTripData()
+    {
+        return [
+            // type, limit, expected type after round-trip, expected limit after round-trip
+            ['text', null, 'text', null],
+            ['text', MysqlAdapter::TEXT_TINY, 'text', MysqlAdapter::TEXT_TINY],
+            ['text', MysqlAdapter::TEXT_MEDIUM, 'text', MysqlAdapter::TEXT_MEDIUM],
+            ['text', MysqlAdapter::TEXT_LONG, 'text', MysqlAdapter::TEXT_LONG],
+        ];
+    }
+
+    #[DataProvider('textRoundTripData')]
+    public function testTextRoundTrip(string $type, ?int $limit, string $expectedType, ?int $expectedLimit)
+    {
+        // Create a table with a TEXT column
+        $table = new Table('text_round_trip_test', [], $this->adapter);
+        $table->addColumn('text_col', $type, ['limit' => $limit])
+              ->save();
+
+        // Read the column back from the database
+        $columns = $this->adapter->getColumns('text_round_trip_test');
+
+        $textColumn = $columns[1];
+        $this->assertNotNull($textColumn, 'TEXT column not found');
+        $this->assertSame($expectedType, $textColumn->getType(), 'Type mismatch after round-trip');
+        $this->assertSame($expectedLimit, $textColumn->getLimit(), 'Limit mismatch after round-trip');
+
+        // Clean up
+        $this->adapter->dropTable('text_round_trip_test');
+    }
+
     public function testTimestampInvalidLimit()
     {
         $this->adapter->connect();

--- a/tests/TestCase/Db/Table/ColumnTest.php
+++ b/tests/TestCase/Db/Table/ColumnTest.php
@@ -275,4 +275,56 @@ class ColumnTest extends TestCase
         $decimalColumn->setName('price')->setType('decimal');
         $this->assertFalse($decimalColumn->isUnsigned());
     }
+
+    public function testFixedOptionDefaultsToNull(): void
+    {
+        $column = new Column();
+        $column->setName('data')->setType('binary');
+
+        $this->assertNull($column->getFixed());
+    }
+
+    public function testSetFixedTrue(): void
+    {
+        $column = new Column();
+        $column->setName('hash')->setType('binary')->setFixed(true);
+
+        $this->assertTrue($column->getFixed());
+    }
+
+    public function testSetFixedFalse(): void
+    {
+        $column = new Column();
+        $column->setName('data')->setType('binary')->setFixed(false);
+
+        $this->assertFalse($column->getFixed());
+    }
+
+    public function testSetOptionsWithFixed(): void
+    {
+        $column = new Column();
+        $column->setName('hash')->setType('binary');
+        $column->setOptions(['fixed' => true, 'limit' => 20]);
+
+        $this->assertTrue($column->getFixed());
+        $this->assertSame(20, $column->getLimit());
+    }
+
+    public function testToArrayIncludesFixed(): void
+    {
+        $column = new Column();
+        $column->setName('hash')->setType('binary')->setFixed(true)->setLimit(20);
+
+        $result = $column->toArray();
+        $this->assertTrue($result['fixed']);
+    }
+
+    public function testToArrayFixedNullByDefault(): void
+    {
+        $column = new Column();
+        $column->setName('data')->setType('binary')->setLimit(20);
+
+        $result = $column->toArray();
+        $this->assertNull($result['fixed']);
+    }
 }

--- a/tests/TestCase/Db/Table/ForeignKeyTest.php
+++ b/tests/TestCase/Db/Table/ForeignKeyTest.php
@@ -151,4 +151,5 @@ class ForeignKeyTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->fk->setDeferrableMode('invalid_value');
     }
+
 }

--- a/tests/TestCase/Db/Table/TableTest.php
+++ b/tests/TestCase/Db/Table/TableTest.php
@@ -80,6 +80,15 @@ class TableTest extends TestCase
         $this->assertSame($column, $actions[0]->getColumn());
     }
 
+    public function testAddColumnWithNullTypeThrows()
+    {
+        $adapter = new MysqlAdapter([]);
+        $table = new Table('ntable', [], $adapter);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Column type must not be null when column name is a string.');
+        $table->addColumn('email', null);
+    }
+
     public function testAddColumnWithNoAdapterSpecified()
     {
         try {

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -15,7 +15,6 @@ namespace Migrations\Test\TestCase;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
@@ -218,14 +217,19 @@ class MigrationsTest extends TestCase
         $expected = ['id', 'name', 'created', 'updated'];
         $this->assertEquals($expected, $columns);
         $createdColumn = $storesTable->getSchema()->getColumn('created');
-        $expected = 'CURRENT_TIMESTAMP';
         $driver = $this->Connection->getDriver();
-        if ($driver instanceof Mysql && $driver->isMariadb()) {
-            $expected = 'current_timestamp()';
-        } elseif ($driver instanceof Sqlserver) {
+        if ($driver instanceof Sqlserver) {
             $expected = 'getdate()';
+            $this->assertEquals($expected, $createdColumn['default']);
+        } else {
+            // MySQL and MariaDB may return CURRENT_TIMESTAMP in different formats
+            // depending on version: CURRENT_TIMESTAMP, current_timestamp(), CURRENT_TIMESTAMP()
+            $this->assertMatchesRegularExpression(
+                '/^current_timestamp(\(\))?$/i',
+                $createdColumn['default'],
+                'Default value should be CURRENT_TIMESTAMP in some form',
+            );
         }
-        $this->assertEquals($expected, $createdColumn['default']);
 
         // Rollback last
         $rollback = $this->migrations->rollback();

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -456,4 +456,38 @@ class MigrationHelperTest extends TestCase
         $this->assertArrayHasKey('collation', $result, 'collation should be set from collate value');
         $this->assertSame('en_US.UTF-8', $result['collation']);
     }
+
+    /**
+     * Test that getColumnOption includes the fixed option for binary columns
+     */
+    public function testGetColumnOptionIncludesFixed(): void
+    {
+        $options = [
+            'length' => 20,
+            'null' => true,
+            'default' => null,
+            'fixed' => true,
+        ];
+
+        $result = $this->helper->getColumnOption($options);
+
+        $this->assertArrayHasKey('fixed', $result);
+        $this->assertTrue($result['fixed']);
+    }
+
+    /**
+     * Test that getColumnOption excludes fixed when not set
+     */
+    public function testGetColumnOptionExcludesFixedWhenNotSet(): void
+    {
+        $options = [
+            'length' => 20,
+            'null' => true,
+            'default' => null,
+        ];
+
+        $result = $this->helper->getColumnOption($options);
+
+        $this->assertArrayNotHasKey('fixed', $result);
+    }
 }


### PR DESCRIPTION
## Summary

- Bumps PHPStan analysis level from 7 to 8
- Makes `$io` and `$args` properties non-nullable in `BakeSimpleMigrationCommand` (they are always set before use in `bake()`)
- Fixes all 52 PHPStan level 8 errors across the codebase

## Changes by category

**Command classes**
- `BakeSimpleMigrationCommand`: Made `$io`/`$args` non-nullable — these properties are always assigned in `bake()` before any method reads them
- `BakeMigrationDiffCommand`: Added null guards for `getColumn()`/`getConstraint()` nullable returns

**Db/Table value objects**
- `Column::getNull()`: Coalesce nullable `?bool` property to `false` (matches SQL default)
- `ForeignKey::getOnDelete()`/`getOnUpdate()`: Guard null from `getDelete()`/`getUpdate()` before calling `mapAction()`

**Db adapters** (Mysql, Postgres, Sqlite, Sqlserver, Abstract, TimedOutput)
- Cast `preg_replace` results to `(string)` where hardcoded patterns can't fail
- Coalesce `Constraint::getColumns()` nullable return with `?? []`
- Cast `ForeignKey::getReferencedTable()` and `Column::getName()` at call sites
- Assert non-null in `AbstractAdapter::getConnection()` after lazy init
- Use null-safe `?->` for optional `ConsoleIo` in `TimedOutputAdapter`

**Other**
- `Db/Plan/Plan.php`, `Db/Table.php`: Same `getColumns()`/`getName()` patterns
- `BaseSeed.php`: Guard nullable `getConfig()` offset access
- `Util/ColumnParser.php`: Cast `preg_replace` result
- `Util/TableFinder.php`: Null-check association before method call
- `View/Helper/MigrationHelper.php`: Use `isset()` for constraint type check

## Test plan

- [x] `tools/phpstan analyse --memory-limit=-1` passes with 0 errors at level 8
- [ ] Existing test suite still passes