### PR TITLE
Fix spurious warning when using empty conflictColumns with MySQL

### DIFF
--- a/src/Db/Adapter/AbstractAdapter.php
+++ b/src/Db/Adapter/AbstractAdapter.php
@@ -745,7 +745,7 @@ abstract class AbstractAdapter implements AdapterInterface, DirectActionInterfac
             return '';
         }
 
-        if ($conflictColumns !== null) {
+        if ($conflictColumns !== null && $conflictColumns !== []) {
             trigger_error(
                 'The $conflictColumns parameter is ignored by MySQL. ' .
                 'MySQL\'s ON DUPLICATE KEY UPDATE applies to all unique constraints on the table.',

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -3080,6 +3080,38 @@ OUTPUT;
         ])->save();
     }
 
+    public function testInsertOrUpdateWithEmptyConflictColumnsDoesNotWarn()
+    {
+        $table = new Table('currencies', [], $this->adapter);
+        $table->addColumn('code', 'string', ['limit' => 3])
+            ->addColumn('rate', 'decimal', ['precision' => 10, 'scale' => 4])
+            ->addIndex('code', ['unique' => true])
+            ->create();
+
+        $warning = null;
+        set_error_handler(function (int $errno, string $errstr) use (&$warning) {
+            $warning = $errstr;
+
+            return true;
+        }, E_USER_WARNING);
+
+        try {
+            $table->insertOrUpdate([
+                ['code' => 'USD', 'rate' => 1.0000],
+                ['code' => 'EUR', 'rate' => 0.9000],
+            ], ['rate'], [])->save();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNull($warning, 'Empty conflictColumns should not trigger a warning for MySQL');
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM currencies ORDER BY code');
+        $this->assertCount(2, $rows);
+        $this->assertEquals('0.9000', $rows[0]['rate']);
+        $this->assertEquals('1.0000', $rows[1]['rate']);
+    }
+
     public function testCreateTableWithRangeColumnsPartitioning()
     {
         // MySQL requires RANGE COLUMNS for DATE columns


### PR DESCRIPTION
## Summary

- `AbstractAdapter::getUpsertClause()` checked `$conflictColumns !== null` to decide whether to warn MySQL users about ignored conflict columns, but `BaseSeed::insertOrUpdate()` requires callers to pass an `array` (no null default). The natural MySQL value is `[]`, which passed the `!== null` check and triggered a spurious `E_USER_WARNING`.
- Added `&& $conflictColumns !== []` to the condition, matching the pattern already used by `SqliteAdapter::getUpsertClause()`.

## Test plan

- [x] Added `testInsertOrUpdateWithEmptyConflictColumnsDoesNotWarn` to `MysqlAdapterTest`
- [x] Verified existing `insertOrUpdate` tests still pass for MySQL and SQLite