### PR TITLE
Fix TEXT column variants not round-tripping correctly

### DIFF
--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -594,6 +594,20 @@ class MysqlAdapter extends AbstractAdapter
                 }
             }
             // else: keep as binary or varbinary (actual BINARY/VARBINARY column)
+        } elseif ($type === TableSchema::TYPE_TEXT) {
+            // CakePHP returns TEXT columns as 'text' with specific lengths
+            // Check the raw MySQL type to distinguish TEXT variants
+            $rawType = $columnData['rawType'] ?? '';
+            if (str_contains($rawType, 'tinytext')) {
+                $length = static::TEXT_TINY;
+            } elseif (str_contains($rawType, 'mediumtext')) {
+                $length = static::TEXT_MEDIUM;
+            } elseif (str_contains($rawType, 'longtext')) {
+                $length = static::TEXT_LONG;
+            } else {
+                // Regular TEXT - use null to indicate default TEXT type
+                $length = null;
+            }
         }
 
         return [$type, $length];

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -1369,6 +1369,37 @@ class MysqlAdapterTest extends TestCase
         $this->adapter->dropTable('blob_round_trip_test');
     }
 
+    public static function textRoundTripData()
+    {
+        return [
+            // type, limit, expected type after round-trip, expected limit after round-trip
+            ['text', null, 'text', null],
+            ['text', MysqlAdapter::TEXT_TINY, 'text', MysqlAdapter::TEXT_TINY],
+            ['text', MysqlAdapter::TEXT_MEDIUM, 'text', MysqlAdapter::TEXT_MEDIUM],
+            ['text', MysqlAdapter::TEXT_LONG, 'text', MysqlAdapter::TEXT_LONG],
+        ];
+    }
+
+    #[DataProvider('textRoundTripData')]
+    public function testTextRoundTrip(string $type, ?int $limit, string $expectedType, ?int $expectedLimit)
+    {
+        // Create a table with a TEXT column
+        $table = new Table('text_round_trip_test', [], $this->adapter);
+        $table->addColumn('text_col', $type, ['limit' => $limit])
+              ->save();
+
+        // Read the column back from the database
+        $columns = $this->adapter->getColumns('text_round_trip_test');
+
+        $textColumn = $columns[1];
+        $this->assertNotNull($textColumn, 'TEXT column not found');
+        $this->assertSame($expectedType, $textColumn->getType(), 'Type mismatch after round-trip');
+        $this->assertSame($expectedLimit, $textColumn->getLimit(), 'Limit mismatch after round-trip');
+
+        // Clean up
+        $this->adapter->dropTable('text_round_trip_test');
+    }
+
     public function testTimestampInvalidLimit()
     {
         $this->adapter->connect();


### PR DESCRIPTION
## Summary

- Adds rawType-based mapping for TEXT columns in `mapColumnType()` to properly distinguish TINYTEXT, MEDIUMTEXT, and LONGTEXT variants
- Mirrors the existing BLOB handling pattern that was already working correctly
- Adds round-trip tests for TEXT column variants

Fixes #1029

## Problem

When using `migration_diff`, TEXT column variants (TINYTEXT, MEDIUMTEXT, LONGTEXT) were not being properly mapped back from the database. The code already handled BLOB variants correctly by checking the raw MySQL type string, but TEXT variants were missing equivalent handling.

For example, a LONGTEXT column would:
1. Be read from the database with `rawType='longtext'` and `length=4294967295`
2. Not be recognized as LONGTEXT (no rawType check for TEXT)
3. Fall through to `mapColumnData()` where 4294967295 didn't match any case
4. Result in a plain TEXT column being created instead of LONGTEXT

## Solution

Added equivalent rawType-based handling for TEXT columns in `mapColumnType()`:
- `tinytext` → `TEXT_TINY` (255)
- `mediumtext` → `TEXT_MEDIUM` (16777215)
- `longtext` → `TEXT_LONG` (2147483647)
- Regular `text` → `null` (default TEXT)