### PR TITLE
Add conflict resolution for auto-generated FK constraint names

### DIFF
--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -1197,7 +1197,7 @@ class MysqlAdapter extends AbstractAdapter
      */
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, string $tableName): string
     {
-        $constraintName = $foreignKey->getName() ?: ($tableName . '_' . implode('_', $foreignKey->getColumns()));
+        $constraintName = $foreignKey->getName() ?: $this->getUniqueForeignKeyName($tableName, $foreignKey->getColumns());
         $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName);
         $columnNames = [];
         foreach ($foreignKey->getColumns() as $column) {
@@ -1219,6 +1219,31 @@ class MysqlAdapter extends AbstractAdapter
         }
 
         return $def;
+    }
+
+    /**
+     * Generate a unique foreign key constraint name.
+     *
+     * @param string $tableName Table name
+     * @param array<string> $columns Column names
+     * @return string
+     */
+    protected function getUniqueForeignKeyName(string $tableName, array $columns): string
+    {
+        $baseName = $tableName . '_' . implode('_', $columns);
+        $existingKeys = $this->getForeignKeys($tableName);
+        $existingNames = array_column($existingKeys, 'name');
+
+        if (!in_array($baseName, $existingNames, true)) {
+            return $baseName;
+        }
+
+        $counter = 2;
+        while (in_array($baseName . '_' . $counter, $existingNames, true)) {
+            $counter++;
+        }
+
+        return $baseName . '_' . $counter;
     }
 
     /**

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -1231,8 +1231,8 @@ class MysqlAdapter extends AbstractAdapter
     protected function getUniqueForeignKeyName(string $tableName, array $columns): string
     {
         $baseName = $tableName . '_' . implode('_', $columns);
-        if (strlen($baseName) > 125) {
-            $baseName = substr($baseName, 0, 125);
+        if (strlen($baseName) > 61) {
+            $baseName = substr($baseName, 0, 61);
         }
         $existingKeys = $this->getForeignKeys($tableName);
         $existingNames = array_column($existingKeys, 'name');

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -1231,6 +1231,9 @@ class MysqlAdapter extends AbstractAdapter
     protected function getUniqueForeignKeyName(string $tableName, array $columns): string
     {
         $baseName = $tableName . '_' . implode('_', $columns);
+        if (strlen($baseName) > 125) {
+            $baseName = substr($baseName, 0, 125);
+        }
         $existingKeys = $this->getForeignKeys($tableName);
         $existingNames = array_column($existingKeys, 'name');
 

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -30,6 +30,11 @@ use Migrations\Db\Table\TableMetadata;
 class MysqlAdapter extends AbstractAdapter
 {
     /**
+     * Maximum length for identifiers (table names, column names, constraint names, etc.)
+     */
+    protected const IDENTIFIER_MAX_LENGTH = 64;
+
+    /**
      * @var string[]
      */
     protected static array $specificColumnTypes = [
@@ -1231,8 +1236,9 @@ class MysqlAdapter extends AbstractAdapter
     protected function getUniqueForeignKeyName(string $tableName, array $columns): string
     {
         $baseName = $tableName . '_' . implode('_', $columns);
-        if (strlen($baseName) > 61) {
-            $baseName = substr($baseName, 0, 61);
+        $maxLength = static::IDENTIFIER_MAX_LENGTH - 3;
+        if (strlen($baseName) > $maxLength) {
+            $baseName = substr($baseName, 0, $maxLength);
         }
         $existingKeys = $this->getForeignKeys($tableName);
         $existingNames = array_column($existingKeys, 'name');

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -949,8 +949,6 @@ class PostgresAdapter extends AbstractAdapter
      */
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, string $tableName): string
     {
-        $parts = $this->getSchemaName($tableName);
-
         $constraintName = $foreignKey->getName() ?: $this->getUniqueForeignKeyName($tableName, $foreignKey->getColumns());
         $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns()));
         $refColumnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getReferencedColumns()));

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -979,8 +979,8 @@ class PostgresAdapter extends AbstractAdapter
     {
         $parts = $this->getSchemaName($tableName);
         $baseName = $parts['table'] . '_' . implode('_', $columns) . '_fkey';
-        if (strlen($baseName) > 125) {
-            $baseName = substr($baseName, 0, 125);
+        if (strlen($baseName) > 60) {
+            $baseName = substr($baseName, 0, 60);
         }
         $existingKeys = $this->getForeignKeys($tableName);
         $existingNames = array_column($existingKeys, 'name');

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -27,6 +27,11 @@ use RuntimeException;
 
 class PostgresAdapter extends AbstractAdapter
 {
+    /**
+     * Maximum length for identifiers (table names, column names, constraint names, etc.)
+     */
+    protected const IDENTIFIER_MAX_LENGTH = 63;
+
     public const GENERATED_ALWAYS = 'ALWAYS';
     public const GENERATED_BY_DEFAULT = 'BY DEFAULT';
     /**
@@ -979,8 +984,9 @@ class PostgresAdapter extends AbstractAdapter
     {
         $parts = $this->getSchemaName($tableName);
         $baseName = $parts['table'] . '_' . implode('_', $columns) . '_fkey';
-        if (strlen($baseName) > 60) {
-            $baseName = substr($baseName, 0, 60);
+        $maxLength = static::IDENTIFIER_MAX_LENGTH - 3;
+        if (strlen($baseName) > $maxLength) {
+            $baseName = substr($baseName, 0, $maxLength);
         }
         $existingKeys = $this->getForeignKeys($tableName);
         $existingNames = array_column($existingKeys, 'name');

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -951,9 +951,7 @@ class PostgresAdapter extends AbstractAdapter
     {
         $parts = $this->getSchemaName($tableName);
 
-        $constraintName = $foreignKey->getName() ?: (
-            $parts['table'] . '_' . implode('_', $foreignKey->getColumns()) . '_fkey'
-        );
+        $constraintName = $foreignKey->getName() ?: $this->getUniqueForeignKeyName($tableName, $foreignKey->getColumns());
         $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns()));
         $refColumnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getReferencedColumns()));
         $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName) .
@@ -970,6 +968,32 @@ class PostgresAdapter extends AbstractAdapter
         }
 
         return $def;
+    }
+
+    /**
+     * Generate a unique foreign key constraint name.
+     *
+     * @param string $tableName Table name
+     * @param array<string> $columns Column names
+     * @return string
+     */
+    protected function getUniqueForeignKeyName(string $tableName, array $columns): string
+    {
+        $parts = $this->getSchemaName($tableName);
+        $baseName = $parts['table'] . '_' . implode('_', $columns) . '_fkey';
+        $existingKeys = $this->getForeignKeys($tableName);
+        $existingNames = array_column($existingKeys, 'name');
+
+        if (!in_array($baseName, $existingNames, true)) {
+            return $baseName;
+        }
+
+        $counter = 2;
+        while (in_array($baseName . '_' . $counter, $existingNames, true)) {
+            $counter++;
+        }
+
+        return $baseName . '_' . $counter;
     }
 
     /**

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -979,6 +979,9 @@ class PostgresAdapter extends AbstractAdapter
     {
         $parts = $this->getSchemaName($tableName);
         $baseName = $parts['table'] . '_' . implode('_', $columns) . '_fkey';
+        if (strlen($baseName) > 125) {
+            $baseName = substr($baseName, 0, 125);
+        }
         $existingKeys = $this->getForeignKeys($tableName);
         $existingNames = array_column($existingKeys, 'name');
 

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1675,7 +1675,7 @@ PCRE_PATTERN;
      */
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, string $tableName): string
     {
-        $constraintName = $foreignKey->getName() ?: ($tableName . '_' . implode('_', $foreignKey->getColumns()));
+        $constraintName = $foreignKey->getName() ?: $this->getUniqueForeignKeyName($tableName, $foreignKey->getColumns());
         $def = ' CONSTRAINT ' . $this->quoteColumnName($constraintName);
         $columnNames = [];
         foreach ($foreignKey->getColumns() as $column) {
@@ -1695,6 +1695,31 @@ PCRE_PATTERN;
         }
 
         return $def;
+    }
+
+    /**
+     * Generate a unique foreign key constraint name.
+     *
+     * @param string $tableName Table name
+     * @param array<string> $columns Column names
+     * @return string
+     */
+    protected function getUniqueForeignKeyName(string $tableName, array $columns): string
+    {
+        $baseName = $tableName . '_' . implode('_', $columns);
+        $existingKeys = $this->getForeignKeys($tableName);
+        $existingNames = array_column($existingKeys, 'name');
+
+        if (!in_array($baseName, $existingNames, true)) {
+            return $baseName;
+        }
+
+        $counter = 2;
+        while (in_array($baseName . '_' . $counter, $existingNames, true)) {
+            $counter++;
+        }
+
+        return $baseName . '_' . $counter;
     }
 
     /**

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1707,9 +1707,6 @@ PCRE_PATTERN;
     protected function getUniqueForeignKeyName(string $tableName, array $columns): string
     {
         $baseName = $tableName . '_' . implode('_', $columns);
-        if (strlen($baseName) > 125) {
-            $baseName = substr($baseName, 0, 125);
-        }
         $existingKeys = $this->getForeignKeys($tableName);
         $existingNames = array_column($existingKeys, 'name');
 

--- a/src/Db/Adapter/SqliteAdapter.php
+++ b/src/Db/Adapter/SqliteAdapter.php
@@ -1707,6 +1707,9 @@ PCRE_PATTERN;
     protected function getUniqueForeignKeyName(string $tableName, array $columns): string
     {
         $baseName = $tableName . '_' . implode('_', $columns);
+        if (strlen($baseName) > 125) {
+            $baseName = substr($baseName, 0, 125);
+        }
         $existingKeys = $this->getForeignKeys($tableName);
         $existingNames = array_column($existingKeys, 'name');
 

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -29,6 +29,11 @@ use Migrations\MigrationInterface;
 class SqlserverAdapter extends AbstractAdapter
 {
     /**
+     * Maximum length for identifiers (table names, column names, constraint names, etc.)
+     */
+    protected const IDENTIFIER_MAX_LENGTH = 128;
+
+    /**
      * @var string[]
      */
     protected static array $specificColumnTypes = [
@@ -891,8 +896,9 @@ DROP DATABASE %s;',
     protected function getUniqueForeignKeyName(string $tableName, array $columns): string
     {
         $baseName = $tableName . '_' . implode('_', $columns);
-        if (strlen($baseName) > 125) {
-            $baseName = substr($baseName, 0, 125);
+        $maxLength = static::IDENTIFIER_MAX_LENGTH - 3;
+        if (strlen($baseName) > $maxLength) {
+            $baseName = substr($baseName, 0, $maxLength);
         }
         $existingKeys = $this->getForeignKeys($tableName);
         $existingNames = array_column($existingKeys, 'name');

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -864,7 +864,7 @@ DROP DATABASE %s;',
      */
     protected function getForeignKeySqlDefinition(ForeignKey $foreignKey, string $tableName): string
     {
-        $constraintName = $foreignKey->getName() ?: $tableName . '_' . implode('_', $foreignKey->getColumns());
+        $constraintName = $foreignKey->getName() ?: $this->getUniqueForeignKeyName($tableName, $foreignKey->getColumns());
         $columnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getColumns()));
         $refColumnList = implode(', ', array_map($this->quoteColumnName(...), $foreignKey->getReferencedColumns()));
 
@@ -879,6 +879,31 @@ DROP DATABASE %s;',
         }
 
         return $def;
+    }
+
+    /**
+     * Generate a unique foreign key constraint name.
+     *
+     * @param string $tableName Table name
+     * @param array<string> $columns Column names
+     * @return string
+     */
+    protected function getUniqueForeignKeyName(string $tableName, array $columns): string
+    {
+        $baseName = $tableName . '_' . implode('_', $columns);
+        $existingKeys = $this->getForeignKeys($tableName);
+        $existingNames = array_column($existingKeys, 'name');
+
+        if (!in_array($baseName, $existingNames, true)) {
+            return $baseName;
+        }
+
+        $counter = 2;
+        while (in_array($baseName . '_' . $counter, $existingNames, true)) {
+            $counter++;
+        }
+
+        return $baseName . '_' . $counter;
     }
 
     /**

--- a/src/Db/Adapter/SqlserverAdapter.php
+++ b/src/Db/Adapter/SqlserverAdapter.php
@@ -891,6 +891,9 @@ DROP DATABASE %s;',
     protected function getUniqueForeignKeyName(string $tableName, array $columns): string
     {
         $baseName = $tableName . '_' . implode('_', $columns);
+        if (strlen($baseName) > 125) {
+            $baseName = substr($baseName, 0, 125);
+        }
         $existingKeys = $this->getForeignKeys($tableName);
         $existingNames = array_column($existingKeys, 'name');
 


### PR DESCRIPTION
## Summary

I feel like when we now auto generate them instead of the db, we should do this, as there could be conflict somewhere along the migrations.

- When auto-generating FK constraint names, check if the name already exists
- Append counter suffix (`_2`, `_3`, etc.) if a conflict is detected
- Prevents duplicate constraint name errors in edge cases

UPDATE:
Also now respects technical max length limit per constraint using truncate.
We could also add hashing instead of just truncate + counter suffix.

This builds on #1041 which added auto-generation of FK constraint names.

## Example

```php
// First FK: generates "articles_user_id"
$table->addForeignKey('user_id', 'users', 'id');

// Second FK on same column (unusual but possible): generates "articles_user_id_2"
$table->addForeignKey('user_id', 'admins', 'id');
```

## Changes

All 4 adapters updated with `getUniqueForeignKeyName()` method:
- `MysqlAdapter`
- `SqliteAdapter`
- `PostgresAdapter`
- `SqlserverAdapter`