### PR TITLE
Stop using deprecated setOnDelete/setOnUpdate methods

### DIFF
--- a/src/Db/Table/ForeignKey.php
+++ b/src/Db/Table/ForeignKey.php
@@ -100,11 +100,11 @@ class ForeignKey extends DatabaseForeignKey
                 throw new RuntimeException(sprintf('"%s" is not a valid foreign key option.', $option));
             }
 
-            // handle $options['delete'] as $options['update']
+            // handle $options['delete'] and $options['update']
             if ($option === 'delete') {
-                $this->setOnDelete($value);
+                $this->delete = $this->normalizeAction($value);
             } elseif ($option === 'update') {
-                $this->setOnUpdate($value);
+                $this->update = $this->normalizeAction($value);
             } elseif ($option === 'deferrable') {
                 $this->setDeferrableMode($value);
             } else {

--- a/templates/bake/element/add-foreign-keys.twig
+++ b/templates/bake/element/add-foreign-keys.twig
@@ -28,8 +28,8 @@
                 $this->foreignKey({{ columnsList | raw }})
                     ->setReferencedTable('{{ constraint['references'][0] }}')
                     ->setReferencedColumns({{ columnsReference | raw }})
-                    ->setOnDelete('{{ Migration.formatConstraintAction(constraint['delete']) | raw }}')
-                    ->setOnUpdate('{{ Migration.formatConstraintAction(constraint['update']) | raw }}')
+                    ->setDelete('{{ Migration.formatConstraintAction(constraint['delete']) | raw }}')
+                    ->setUpdate('{{ Migration.formatConstraintAction(constraint['update']) | raw }}')
                     ->setName('{{ constraintName }}')
             )
     {%~ endif %}

--- a/templates/bake/element/change-method-body.twig
+++ b/templates/bake/element/change-method-body.twig
@@ -59,8 +59,8 @@
             $this->foreignKey({{ columnsList | raw }})
                 ->setReferencedTable('{{ constraint['references'][0] }}')
                 ->setReferencedColumns({{ columnsReference | raw }})
-                ->setOnDelete('{{ Migration.formatConstraintAction(constraint['delete']) | raw }}')
-                ->setOnUpdate('{{ Migration.formatConstraintAction(constraint['update']) | raw }}')
+                ->setDelete('{{ Migration.formatConstraintAction(constraint['delete']) | raw }}')
+                ->setUpdate('{{ Migration.formatConstraintAction(constraint['update']) | raw }}')
                 ->setName('{{ constraintName }}')
         );
                 {%~ endif %}

--- a/tests/TestCase/Db/Table/TableTest.php
+++ b/tests/TestCase/Db/Table/TableTest.php
@@ -144,8 +144,7 @@ class TableTest extends TestCase
             $key->setColumns('user_id')
                 ->setReferencedTable('users')
                 ->setReferencedColumns(['id'])
-                ->setOnDelete('CASCADE')
-                ->setOnUpdate('CASCADE')
+                ->setOptions(['delete' => 'CASCADE', 'update' => 'CASCADE'])
                 ->setName('fk_user_id'),
         );
 

--- a/tests/comparisons/Diff/default/the_diff_default_mysql.php
+++ b/tests/comparisons/Diff/default/the_diff_default_mysql.php
@@ -99,8 +99,8 @@ class TheDiffDefaultMysql extends BaseMigration
                 $this->foreignKey('user_id')
                     ->setReferencedTable('users')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('RESTRICT')
-                    ->setOnUpdate('RESTRICT')
+                    ->setDelete('RESTRICT')
+                    ->setUpdate('RESTRICT')
                     ->setName('categories_ibfk_1')
             )
             ->update();
@@ -232,8 +232,8 @@ class TheDiffDefaultMysql extends BaseMigration
                 $this->foreignKey('user_id')
                     ->setReferencedTable('users')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('articles_ibfk_1')
             )
             ->update();

--- a/tests/comparisons/Diff/default/the_diff_default_pgsql.php
+++ b/tests/comparisons/Diff/default/the_diff_default_pgsql.php
@@ -64,8 +64,8 @@ class TheDiffDefaultPgsql extends BaseMigration
                 $this->foreignKey('user_id')
                     ->setReferencedTable('users')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('RESTRICT')
-                    ->setOnUpdate('RESTRICT')
+                    ->setDelete('RESTRICT')
+                    ->setUpdate('RESTRICT')
             )
             ->update();
 
@@ -114,8 +114,8 @@ class TheDiffDefaultPgsql extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
             )
             ->update();
 
@@ -207,8 +207,8 @@ class TheDiffDefaultPgsql extends BaseMigration
                 $this->foreignKey('user_id')
                     ->setReferencedTable('users')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
             )
             ->update();
 

--- a/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
@@ -70,8 +70,8 @@ class TheDiffSimpleMysql extends BaseMigration
                 $this->foreignKey('user_id')
                     ->setReferencedTable('users')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('RESTRICT')
-                    ->setOnUpdate('RESTRICT')
+                    ->setDelete('RESTRICT')
+                    ->setUpdate('RESTRICT')
                     ->setName('articles_ibfk_1')
             )
             ->update();

--- a/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
@@ -370,8 +370,8 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -387,8 +387,8 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -398,8 +398,8 @@ class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
@@ -310,8 +310,8 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -327,8 +327,8 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -338,8 +338,8 @@ class TestSnapshotNotEmptyPgsql extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
@@ -310,8 +310,8 @@ class TestSnapshotPluginBlogPgsql extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -327,8 +327,8 @@ class TestSnapshotPluginBlogPgsql extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -338,8 +338,8 @@ class TestSnapshotPluginBlogPgsql extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/pgsql/test_snapshot_with_change_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_with_change_pgsql.php
@@ -310,8 +310,8 @@ class TestSnapshotWithChangePgsql extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -327,8 +327,8 @@ class TestSnapshotWithChangePgsql extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -338,8 +338,8 @@ class TestSnapshotWithChangePgsql extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
@@ -351,8 +351,8 @@ class TestSnapshotAutoIdDisabledSqlite extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -368,8 +368,8 @@ class TestSnapshotAutoIdDisabledSqlite extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -379,8 +379,8 @@ class TestSnapshotAutoIdDisabledSqlite extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
@@ -291,8 +291,8 @@ class TestSnapshotNotEmptySqlite extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -308,8 +308,8 @@ class TestSnapshotNotEmptySqlite extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -319,8 +319,8 @@ class TestSnapshotNotEmptySqlite extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
@@ -291,8 +291,8 @@ class TestSnapshotPluginBlogSqlite extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -308,8 +308,8 @@ class TestSnapshotPluginBlogSqlite extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -319,8 +319,8 @@ class TestSnapshotPluginBlogSqlite extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/sqlite/test_snapshot_with_change_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_with_change_sqlite.php
@@ -291,8 +291,8 @@ class TestSnapshotWithChangeSqlite extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -308,8 +308,8 @@ class TestSnapshotWithChangeSqlite extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -319,8 +319,8 @@ class TestSnapshotWithChangeSqlite extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_auto_id_disabled_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_auto_id_disabled_sqlserver.php
@@ -386,8 +386,8 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -403,8 +403,8 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -414,8 +414,8 @@ class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_not_empty_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_not_empty_sqlserver.php
@@ -326,8 +326,8 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -343,8 +343,8 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -354,8 +354,8 @@ class TestSnapshotNotEmptySqlserver extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_plugin_blog_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_plugin_blog_sqlserver.php
@@ -326,8 +326,8 @@ class TestSnapshotPluginBlogSqlserver extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -343,8 +343,8 @@ class TestSnapshotPluginBlogSqlserver extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -354,8 +354,8 @@ class TestSnapshotPluginBlogSqlserver extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_with_change_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_with_change_sqlserver.php
@@ -326,8 +326,8 @@ class TestSnapshotWithChangeSqlserver extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -343,8 +343,8 @@ class TestSnapshotWithChangeSqlserver extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -354,8 +354,8 @@ class TestSnapshotWithChangeSqlserver extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/testAddFieldWithReference.php
+++ b/tests/comparisons/Migration/testAddFieldWithReference.php
@@ -25,8 +25,8 @@ class AddCategoryIdToProducts extends BaseMigration
             $this->foreignKey('category_id')
                 ->setReferencedTable('categories')
                 ->setReferencedColumns('id')
-                ->setOnDelete('CASCADE')
-                ->setOnUpdate('CASCADE')
+                ->setDelete('CASCADE')
+                ->setUpdate('CASCADE')
                 ->setName('fk_category_id')
         );
         $table->update();

--- a/tests/comparisons/Migration/testCreateWithReferences.php
+++ b/tests/comparisons/Migration/testCreateWithReferences.php
@@ -30,8 +30,8 @@ class CreatePosts extends BaseMigration
             $this->foreignKey('user_id')
                 ->setReferencedTable('users')
                 ->setReferencedColumns('id')
-                ->setOnDelete('CASCADE')
-                ->setOnUpdate('CASCADE')
+                ->setDelete('CASCADE')
+                ->setUpdate('CASCADE')
                 ->setName('fk_user_id')
         );
         $table->create();

--- a/tests/comparisons/Migration/testCreateWithReferencesCustomTable.php
+++ b/tests/comparisons/Migration/testCreateWithReferencesCustomTable.php
@@ -30,8 +30,8 @@ class CreateArticles extends BaseMigration
             $this->foreignKey('author_id')
                 ->setReferencedTable('authors')
                 ->setReferencedColumns('id')
-                ->setOnDelete('CASCADE')
-                ->setOnUpdate('CASCADE')
+                ->setDelete('CASCADE')
+                ->setUpdate('CASCADE')
                 ->setName('fk_author_id')
         );
         $table->create();

--- a/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
+++ b/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
@@ -376,8 +376,8 @@ class TestSnapshotAutoIdDisabled extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -393,8 +393,8 @@ class TestSnapshotAutoIdDisabled extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -404,8 +404,8 @@ class TestSnapshotAutoIdDisabled extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/test_snapshot_not_empty.php
+++ b/tests/comparisons/Migration/test_snapshot_not_empty.php
@@ -308,8 +308,8 @@ class TestSnapshotNotEmpty extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -325,8 +325,8 @@ class TestSnapshotNotEmpty extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -336,8 +336,8 @@ class TestSnapshotNotEmpty extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/test_snapshot_plugin_blog.php
+++ b/tests/comparisons/Migration/test_snapshot_plugin_blog.php
@@ -308,8 +308,8 @@ class TestSnapshotPluginBlog extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -325,8 +325,8 @@ class TestSnapshotPluginBlog extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -336,8 +336,8 @@ class TestSnapshotPluginBlog extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/test_snapshot_postgres_timestamp_tz_pgsql.php
+++ b/tests/comparisons/Migration/test_snapshot_postgres_timestamp_tz_pgsql.php
@@ -320,8 +320,8 @@ class TestSnapshotPostgresTimestampTzPgsql extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -337,8 +337,8 @@ class TestSnapshotPostgresTimestampTzPgsql extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -348,8 +348,8 @@ class TestSnapshotPostgresTimestampTzPgsql extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_compatible_signed_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_compatible_signed_primary_keys.php
@@ -375,8 +375,8 @@ class TestSnapshotWithAutoIdCompatibleSignedPrimaryKeys extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -392,8 +392,8 @@ class TestSnapshotWithAutoIdCompatibleSignedPrimaryKeys extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -403,8 +403,8 @@ class TestSnapshotWithAutoIdCompatibleSignedPrimaryKeys extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_signed_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_signed_primary_keys.php
@@ -375,8 +375,8 @@ class TestSnapshotWithAutoIdIncompatibleSignedPrimaryKeys extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -392,8 +392,8 @@ class TestSnapshotWithAutoIdIncompatibleSignedPrimaryKeys extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -403,8 +403,8 @@ class TestSnapshotWithAutoIdIncompatibleSignedPrimaryKeys extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_unsigned_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_unsigned_primary_keys.php
@@ -376,8 +376,8 @@ class TestSnapshotWithAutoIdIncompatibleUnsignedPrimaryKeys extends BaseMigratio
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -393,8 +393,8 @@ class TestSnapshotWithAutoIdIncompatibleUnsignedPrimaryKeys extends BaseMigratio
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -404,8 +404,8 @@ class TestSnapshotWithAutoIdIncompatibleUnsignedPrimaryKeys extends BaseMigratio
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/test_snapshot_with_change.php
+++ b/tests/comparisons/Migration/test_snapshot_with_change.php
@@ -308,8 +308,8 @@ class TestSnapshotWithChange extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -325,8 +325,8 @@ class TestSnapshotWithChange extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -336,8 +336,8 @@ class TestSnapshotWithChange extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();

--- a/tests/comparisons/Migration/test_snapshot_with_non_default_collation.php
+++ b/tests/comparisons/Migration/test_snapshot_with_non_default_collation.php
@@ -309,8 +309,8 @@ class TestSnapshotWithNonDefaultCollation extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('NO_ACTION')
-                    ->setOnUpdate('NO_ACTION')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
                     ->setName('articles_category_fk')
             )
             ->update();
@@ -326,8 +326,8 @@ class TestSnapshotWithNonDefaultCollation extends BaseMigration
                         'category_id',
                         'id',
                     ])
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('orders_product_fk')
             )
             ->update();
@@ -337,8 +337,8 @@ class TestSnapshotWithNonDefaultCollation extends BaseMigration
                 $this->foreignKey('category_id')
                     ->setReferencedTable('categories')
                     ->setReferencedColumns('id')
-                    ->setOnDelete('CASCADE')
-                    ->setOnUpdate('CASCADE')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
                     ->setName('products_category_fk')
             )
             ->update();


### PR DESCRIPTION
## Summary
- Update bake templates (`add-foreign-keys.twig`, `change-method-body.twig`) to use `setDelete()` and `setUpdate()` instead of the deprecated `setOnDelete()` and `setOnUpdate()` methods
- Update `ForeignKey::setOptions()` to directly set properties instead of calling deprecated methods
- Update test comparison files to reflect the new method names
- Update `TableTest` to use `setOptions()` instead of deprecated methods

Fixes #1045