### PR TITLE
Filter out null fixed option from generated migrations

### DIFF
--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -401,6 +401,10 @@ class MigrationHelper extends Helper
         if (empty($columnOptions['collate'])) {
             unset($columnOptions['collate']);
         }
+        // isset() returns false for null values, so this handles both missing and null cases
+        if (!isset($columnOptions['fixed'])) {
+            unset($columnOptions['fixed']);
+        }
 
         // currently only MySQL supports the signed option
         $driver = $connection->getDriver();


### PR DESCRIPTION
## Summary
- Filter out the `fixed` column option when it's `null` to prevent `Column::setFixed()` from receiving a non-bool value
- `isset()` returns false for null values, so this handles both missing and null cases

Fixes #1046