### PR TITLE
Fix LONGTEXT columns becoming TEXT in generated migrations

### DIFF
--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -374,8 +374,10 @@ class MysqlAdapter extends AbstractAdapter
     protected function mapColumnData(array $data): array
     {
         if ($data['type'] == self::TYPE_TEXT && $data['length'] !== null) {
+            // Accept both migrations TEXT_LONG and CakePHP LENGTH_LONG for backward compatibility
+            // with migrations generated before the fix (LENGTH_TINY/MEDIUM are already equal to TEXT_TINY/MEDIUM)
             $data['length'] = match ($data['length']) {
-                self::TEXT_LONG => TableSchema::LENGTH_LONG,
+                self::TEXT_LONG, TableSchema::LENGTH_LONG => TableSchema::LENGTH_LONG,
                 self::TEXT_MEDIUM => TableSchema::LENGTH_MEDIUM,
                 self::TEXT_REGULAR => null,
                 self::TEXT_TINY => TableSchema::LENGTH_TINY,

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -18,11 +18,13 @@ use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Schema\CollectionInterface;
+use Cake\Database\Schema\TableSchema;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Cake\View\Helper;
 use Cake\View\View;
+use Migrations\Db\Adapter\MysqlAdapter;
 use Migrations\Db\Table\ForeignKey;
 
 /**
@@ -443,6 +445,13 @@ class MigrationHelper extends Helper
                 $columnOptions['precision'] = $columnOptions['length'];
                 unset($columnOptions['length']);
             }
+        }
+
+        // Convert CakePHP's LENGTH_LONG to migrations TEXT_LONG for text columns
+        // CakePHP uses LENGTH_LONG = 4294967295, but migrations expects TEXT_LONG = 2147483647
+        // (LENGTH_TINY and LENGTH_MEDIUM have the same values as TEXT_TINY and TEXT_MEDIUM)
+        if (isset($columnOptions['limit']) && $columnOptions['limit'] === TableSchema::LENGTH_LONG) {
+            $columnOptions['limit'] = MysqlAdapter::TEXT_LONG;
         }
 
         return $columnOptions;

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -9,6 +9,7 @@ use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use InvalidArgumentException;
 use Migrations\Db\Adapter\MysqlAdapter;
@@ -1377,6 +1378,9 @@ class MysqlAdapterTest extends TestCase
             ['text', MysqlAdapter::TEXT_TINY, 'text', MysqlAdapter::TEXT_TINY],
             ['text', MysqlAdapter::TEXT_MEDIUM, 'text', MysqlAdapter::TEXT_MEDIUM],
             ['text', MysqlAdapter::TEXT_LONG, 'text', MysqlAdapter::TEXT_LONG],
+            // Test backward compatibility: CakePHP's LENGTH_LONG (4294967295) should also work
+            // This ensures migrations generated before the fix still create LONGTEXT correctly
+            ['text', TableSchema::LENGTH_LONG, 'text', MysqlAdapter::TEXT_LONG],
         ];
     }
 

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -16,9 +16,11 @@ namespace Migrations\Test\TestCase\View\Helper;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Schema\Collection;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
+use Migrations\Db\Adapter\MysqlAdapter;
 use Migrations\View\Helper\MigrationHelper;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
@@ -489,5 +491,41 @@ class MigrationHelperTest extends TestCase
         $result = $this->helper->getColumnOption($options);
 
         $this->assertArrayNotHasKey('fixed', $result);
+    }
+
+    /**
+     * Test that getColumnOption converts CakePHP's LENGTH_LONG to migrations TEXT_LONG
+     *
+     * CakePHP uses LENGTH_LONG = 4294967295 for LONGTEXT, but migrations expects
+     * TEXT_LONG = 2147483647. This ensures generated migrations use the correct value.
+     */
+    public function testGetColumnOptionConvertsLengthLongToTextLong(): void
+    {
+        $options = [
+            'limit' => TableSchema::LENGTH_LONG, // 4294967295
+            'null' => true,
+            'default' => null,
+        ];
+
+        $result = $this->helper->getColumnOption($options);
+
+        $this->assertArrayHasKey('limit', $result);
+        $this->assertSame(MysqlAdapter::TEXT_LONG, $result['limit']); // 2147483647
+    }
+
+    /**
+     * Test that getColumnOption preserves other limit values unchanged
+     */
+    public function testGetColumnOptionPreservesOtherLimits(): void
+    {
+        $options = [
+            'limit' => 255, // TEXT_TINY / LENGTH_TINY - same value
+            'null' => true,
+            'default' => null,
+        ];
+
+        $result = $this->helper->getColumnOption($options);
+
+        $this->assertSame(255, $result['limit']);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the issue where LONGTEXT columns were being generated as TEXT when using `bake migration_diff`.

**Root cause**: Mismatch between CakePHP's `LENGTH_LONG` constant (4294967295) and migrations' `TEXT_LONG` constant (2147483647).

**Changes**:
1. `MigrationHelper::getColumnOption()` - Convert `LENGTH_LONG` to `TEXT_LONG` when generating migrations, so new migrations get the correct value
2. `MysqlAdapter::mapColumnData()` - Accept both constants for backward compatibility, so existing migrations with `4294967295` still work

Note: `LENGTH_TINY` (255) and `LENGTH_MEDIUM` (16777215) already match `TEXT_TINY` and `TEXT_MEDIUM`, so only `LENGTH_LONG` needs conversion.

Fixes #1029