### PR TITLE
docs: Add anonymous migration classes documentation

### DIFF
--- a/docs/en/writing-migrations.md
+++ b/docs/en/writing-migrations.md
@@ -40,6 +40,60 @@ class MyNewMigration extends BaseMigration
 }
 ```
 
+### Anonymous Migration Classes
+
+Migrations also supports generating anonymous migration classes, which use PHP's
+anonymous class feature instead of named classes. This style is useful for:
+
+- Avoiding namespace declarations
+- Better PHPCS compatibility (no class name to filename matching required)
+- Simpler file structure without named class constraints
+- More readable filenames like `2024_12_08_120000_CreateProducts.php`
+
+To generate an anonymous migration class, use the `--style anonymous` option:
+
+``` bash
+$ bin/cake bake migration CreateProducts --style anonymous
+```
+
+This generates a migration file using an anonymous class:
+
+``` php
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+return new class extends BaseMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/migrations/5/en/migrations.html#the-change-method
+     * @return void
+     */
+    public function change(): void
+    {
+    }
+};
+```
+
+Both traditional and anonymous migration classes work identically at runtime and can
+be used interchangeably within the same project.
+
+You can set the default migration style globally in your application configuration:
+
+``` php
+// In config/app.php or config/app_local.php
+'Migrations' => [
+    'style' => 'anonymous',  // or 'traditional'
+],
+```
+
+This configuration also applies to seeds, allowing you to use consistent styling
+across your entire project.
+
 ## The Change Method
 
 Migrations supports 'reversible migrations'. In many scenarios, you


### PR DESCRIPTION
## Summary

- Add documentation for the `--style anonymous` option in `bake migration`
- Document the global `Migrations.style` configuration option

The anonymous migration classes feature was already documented for seeds but was missing for migrations. This adds equivalent documentation to `writing-migrations.md` including:

- Benefits of anonymous migration classes
- Command usage example with `--style anonymous`
- Generated code structure showing the anonymous class format
- Global configuration option (`Migrations.style`) that applies to both migrations and seeds