### PR TITLE
Add ALGORITHM/LOCK support to Index operations

### DIFF
--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -899,6 +899,20 @@ class MysqlAdapter extends AbstractAdapter
                 $this->getIndexSqlDefinition($index),
             );
 
+            // FULLTEXT indexes use post-steps (raw SQL) which executeAlterSteps
+            // does not append algorithm/lock to, so we inline the clause here.
+            // Setting on instructions as well ensures validation still runs.
+            if ($index->getAlgorithm() !== null || $index->getLock() !== null) {
+                if ($index->getAlgorithm() !== null) {
+                    $alter .= ', ALGORITHM=' . strtoupper($index->getAlgorithm());
+                    $instructions->setAlgorithm($index->getAlgorithm());
+                }
+                if ($index->getLock() !== null) {
+                    $alter .= ', LOCK=' . strtoupper($index->getLock());
+                    $instructions->setLock($index->getLock());
+                }
+            }
+
             $instructions->addPostStep($alter);
         } else {
             $alter = sprintf(
@@ -907,6 +921,13 @@ class MysqlAdapter extends AbstractAdapter
             );
 
             $instructions->addAlter($alter);
+
+            if ($index->getAlgorithm() !== null) {
+                $instructions->setAlgorithm($index->getAlgorithm());
+            }
+            if ($index->getLock() !== null) {
+                $instructions->setLock($index->getLock());
+            }
         }
 
         return $instructions;

--- a/src/Db/Table/Index.php
+++ b/src/Db/Table/Index.php
@@ -47,6 +47,8 @@ class Index extends DatabaseIndex
      * @param array<string>|null $include The included columns for covering indexes.
      * @param ?string $where The where clause for partial indexes.
      * @param bool $concurrent Whether to create the index concurrently.
+     * @param ?string $algorithm The ALTER TABLE algorithm (MySQL-specific).
+     * @param ?string $lock The ALTER TABLE lock mode (MySQL-specific).
      */
     public function __construct(
         protected string $name = '',
@@ -57,6 +59,8 @@ class Index extends DatabaseIndex
         protected ?array $include = null,
         protected ?string $where = null,
         protected bool $concurrent = false,
+        protected ?string $algorithm = null,
+        protected ?string $lock = null,
     ) {
     }
 
@@ -150,6 +154,52 @@ class Index extends DatabaseIndex
     }
 
     /**
+     * Sets the ALTER TABLE algorithm (MySQL-specific).
+     *
+     * @param string $algorithm Algorithm
+     * @return $this
+     */
+    public function setAlgorithm(string $algorithm)
+    {
+        $this->algorithm = $algorithm;
+
+        return $this;
+    }
+
+    /**
+     * Gets the ALTER TABLE algorithm.
+     *
+     * @return string|null
+     */
+    public function getAlgorithm(): ?string
+    {
+        return $this->algorithm;
+    }
+
+    /**
+     * Sets the ALTER TABLE lock mode (MySQL-specific).
+     *
+     * @param string $lock Lock mode
+     * @return $this
+     */
+    public function setLock(string $lock)
+    {
+        $this->lock = $lock;
+
+        return $this;
+    }
+
+    /**
+     * Gets the ALTER TABLE lock mode.
+     *
+     * @return string|null
+     */
+    public function getLock(): ?string
+    {
+        return $this->lock;
+    }
+
+    /**
      * Utility method that maps an array of index options to this object's methods.
      *
      * @param array<string, mixed> $options Options
@@ -159,7 +209,7 @@ class Index extends DatabaseIndex
     public function setOptions(array $options)
     {
         // Valid Options
-        $validOptions = ['concurrently', 'type', 'unique', 'name', 'limit', 'order', 'include', 'where'];
+        $validOptions = ['concurrently', 'type', 'unique', 'name', 'limit', 'order', 'include', 'where', 'algorithm', 'lock'];
         foreach ($options as $option => $value) {
             if (!in_array($option, $validOptions, true)) {
                 throw new RuntimeException(sprintf('"%s" is not a valid index option.', $option));

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -3127,6 +3127,51 @@ OUTPUT;
         $this->assertTrue($this->adapter->hasColumn('mixed_case', 'col2'));
     }
 
+    public function testAddColumnWithAlgorithmAndLockSqlContainsClause(): void
+    {
+        $table = new Table('col_sql_verify', [], $this->adapter);
+        $table->addColumn('col1', 'string')
+            ->create();
+
+        $this->io->level(ConsoleIo::VERBOSE);
+        $this->out->clear();
+
+        $table->addColumn('col2', 'string', [
+            'null' => true,
+            'algorithm' => MysqlAdapter::ALGORITHM_INPLACE,
+            'lock' => MysqlAdapter::LOCK_NONE,
+        ])->update();
+
+        $output = $this->out->output();
+        $this->assertStringContainsString('ALGORITHM=INPLACE', $output);
+        $this->assertStringContainsString('LOCK=NONE', $output);
+        $this->assertTrue($this->adapter->hasColumn('col_sql_verify', 'col2'));
+    }
+
+    public function testAddColumnWithFluentColumnBuilder(): void
+    {
+        $table = new Table('col_fluent', [], $this->adapter);
+        $table->addColumn('col1', 'string')
+            ->create();
+
+        $column = new Column();
+        $column->setName('col2')
+            ->setType('string')
+            ->setNull(true)
+            ->setAlgorithm(MysqlAdapter::ALGORITHM_INPLACE)
+            ->setLock(MysqlAdapter::LOCK_NONE);
+
+        $this->io->level(ConsoleIo::VERBOSE);
+        $this->out->clear();
+
+        $table->addColumn($column)->update();
+
+        $output = $this->out->output();
+        $this->assertStringContainsString('ALGORITHM=INPLACE', $output);
+        $this->assertStringContainsString('LOCK=NONE', $output);
+        $this->assertTrue($this->adapter->hasColumn('col_fluent', 'col2'));
+    }
+
     public function testAddIndexWithAlgorithm(): void
     {
         $table = new Table('index_algo', [], $this->adapter);
@@ -3245,7 +3290,7 @@ OUTPUT;
         $this->assertTrue($this->adapter->hasIndex('index_batch', ['name']));
     }
 
-    public function testBatchedIndexesWithConflictingAlgorithmsThrowsException()
+    public function testBatchedIndexesWithConflictingAlgorithmsThrowsException(): void
     {
         $table = new Table('index_batch_conflict', [], $this->adapter);
         $table->addColumn('email', 'string')
@@ -3314,6 +3359,48 @@ OUTPUT;
             'algorithm' => MysqlAdapter::ALGORITHM_INSTANT,
             'lock' => MysqlAdapter::LOCK_NONE,
         ])->update();
+    }
+
+    public function testAddIndexWithAlgorithmAndLockSqlContainsClause(): void
+    {
+        $table = new Table('idx_sql_verify', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->create();
+
+        $this->io->level(ConsoleIo::VERBOSE);
+        $this->out->clear();
+
+        $table->addIndex('email', [
+            'algorithm' => MysqlAdapter::ALGORITHM_INPLACE,
+            'lock' => MysqlAdapter::LOCK_NONE,
+        ])->update();
+
+        $output = $this->out->output();
+        $this->assertStringContainsString('ALGORITHM=INPLACE', $output);
+        $this->assertStringContainsString('LOCK=NONE', $output);
+        $this->assertTrue($this->adapter->hasIndex('idx_sql_verify', ['email']));
+    }
+
+    public function testAddIndexWithFluentIndexBuilder(): void
+    {
+        $table = new Table('idx_fluent', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->create();
+
+        $index = new Index();
+        $index->setColumns('email')
+            ->setAlgorithm(MysqlAdapter::ALGORITHM_INPLACE)
+            ->setLock(MysqlAdapter::LOCK_NONE);
+
+        $this->io->level(ConsoleIo::VERBOSE);
+        $this->out->clear();
+
+        $table->addIndex($index)->update();
+
+        $output = $this->out->output();
+        $this->assertStringContainsString('ALGORITHM=INPLACE', $output);
+        $this->assertStringContainsString('LOCK=NONE', $output);
+        $this->assertTrue($this->adapter->hasIndex('idx_fluent', ['email']));
     }
 
     public function testInsertOrUpdateWithDuplicates(): void

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -3127,6 +3127,143 @@ OUTPUT;
         $this->assertTrue($this->adapter->hasColumn('mixed_case', 'col2'));
     }
 
+    public function testAddIndexWithAlgorithm(): void
+    {
+        $table = new Table('index_algo', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->create();
+
+        $table->addIndex('email', [
+            'algorithm' => MysqlAdapter::ALGORITHM_INPLACE,
+        ])->update();
+
+        $this->assertTrue($this->adapter->hasIndex('index_algo', ['email']));
+    }
+
+    public function testAddIndexWithAlgorithmAndLock(): void
+    {
+        $table = new Table('index_algo_lock', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->create();
+
+        $table->addIndex('email', [
+            'algorithm' => MysqlAdapter::ALGORITHM_INPLACE,
+            'lock' => MysqlAdapter::LOCK_NONE,
+        ])->update();
+
+        $this->assertTrue($this->adapter->hasIndex('index_algo_lock', ['email']));
+    }
+
+    public function testAddIndexWithAlgorithmCopy(): void
+    {
+        $table = new Table('index_copy', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->create();
+
+        $table->addIndex('email', [
+            'algorithm' => MysqlAdapter::ALGORITHM_COPY,
+        ])->update();
+
+        $this->assertTrue($this->adapter->hasIndex('index_copy', ['email']));
+    }
+
+    public function testAddIndexWithAlgorithmMixedCase(): void
+    {
+        $table = new Table('index_case', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->create();
+
+        $table->addIndex('email', [
+            'algorithm' => 'inplace',
+            'lock' => 'none',
+        ])->update();
+
+        $this->assertTrue($this->adapter->hasIndex('index_case', ['email']));
+    }
+
+    public function testAddIndexWithInvalidAlgorithmThrowsException(): void
+    {
+        $table = new Table('index_invalid_algo', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->create();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid algorithm');
+
+        $table->addIndex('email', [
+            'algorithm' => 'INVALID',
+        ])->update();
+    }
+
+    public function testAddIndexWithInvalidLockThrowsException(): void
+    {
+        $table = new Table('index_invalid_lock', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->create();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid lock');
+
+        $table->addIndex('email', [
+            'lock' => 'INVALID',
+        ])->update();
+    }
+
+    public function testAddIndexWithAlgorithmInstantAndExplicitLockThrowsException(): void
+    {
+        $table = new Table('index_instant_lock', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->create();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('ALGORITHM=INSTANT cannot be combined with LOCK=NONE');
+
+        $table->addIndex('email', [
+            'algorithm' => MysqlAdapter::ALGORITHM_INSTANT,
+            'lock' => MysqlAdapter::LOCK_NONE,
+        ])->update();
+    }
+
+    public function testBatchedIndexesWithSameAlgorithm(): void
+    {
+        $table = new Table('index_batch', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->addColumn('name', 'string')
+            ->create();
+
+        $table->addIndex('email', [
+            'algorithm' => MysqlAdapter::ALGORITHM_INPLACE,
+            'lock' => MysqlAdapter::LOCK_NONE,
+        ])
+        ->addIndex('name', [
+            'algorithm' => MysqlAdapter::ALGORITHM_INPLACE,
+            'lock' => MysqlAdapter::LOCK_NONE,
+        ])
+        ->update();
+
+        $this->assertTrue($this->adapter->hasIndex('index_batch', ['email']));
+        $this->assertTrue($this->adapter->hasIndex('index_batch', ['name']));
+    }
+
+    public function testBatchedIndexesWithConflictingAlgorithmsThrowsException()
+    {
+        $table = new Table('index_batch_conflict', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->addColumn('name', 'string')
+            ->create();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Conflicting algorithm specifications');
+
+        $table->addIndex('email', [
+            'algorithm' => MysqlAdapter::ALGORITHM_INPLACE,
+        ])
+        ->addIndex('name', [
+            'algorithm' => MysqlAdapter::ALGORITHM_COPY,
+        ])
+        ->update();
+    }
+
     public function testInsertOrUpdateWithDuplicates(): void
     {
         $table = new Table('currencies', [], $this->adapter);

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -3264,6 +3264,58 @@ OUTPUT;
         ->update();
     }
 
+    public function testBatchedIndexesWithConflictingLocksThrowsException(): void
+    {
+        $table = new Table('index_lock_conflict', [], $this->adapter);
+        $table->addColumn('email', 'string')
+            ->addColumn('name', 'string')
+            ->create();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Conflicting lock specifications');
+
+        $table->addIndex('email', [
+            'algorithm' => MysqlAdapter::ALGORITHM_INPLACE,
+            'lock' => MysqlAdapter::LOCK_NONE,
+        ])
+        ->addIndex('name', [
+            'algorithm' => MysqlAdapter::ALGORITHM_INPLACE,
+            'lock' => MysqlAdapter::LOCK_SHARED,
+        ])
+        ->update();
+    }
+
+    public function testAddFulltextIndexWithAlgorithmAndLock(): void
+    {
+        $table = new Table('index_fulltext_algo', [], $this->adapter);
+        $table->addColumn('content', 'text')
+            ->create();
+
+        $table->addIndex('content', [
+            'type' => 'fulltext',
+            'algorithm' => MysqlAdapter::ALGORITHM_INPLACE,
+            'lock' => MysqlAdapter::LOCK_SHARED,
+        ])->update();
+
+        $this->assertTrue($this->adapter->hasIndex('index_fulltext_algo', ['content']));
+    }
+
+    public function testAddFulltextIndexWithInstantAndLockThrowsException(): void
+    {
+        $table = new Table('index_fulltext_instant', [], $this->adapter);
+        $table->addColumn('content', 'text')
+            ->create();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('ALGORITHM=INSTANT cannot be combined with LOCK=NONE');
+
+        $table->addIndex('content', [
+            'type' => 'fulltext',
+            'algorithm' => MysqlAdapter::ALGORITHM_INSTANT,
+            'lock' => MysqlAdapter::LOCK_NONE,
+        ])->update();
+    }
+
     public function testInsertOrUpdateWithDuplicates(): void
     {
         $table = new Table('currencies', [], $this->adapter);


### PR DESCRIPTION
## Summary

Extends the `ALGORITHM` and `LOCK` clause support added in #955 (for Column operations) to also cover Index operations. This allows `addIndex` to pass algorithm and lock options through the fluent API on MySQL.

**Usage:**
```php
$table->addIndex('email', [
    'algorithm' => MysqlAdapter::ALGORITHM_INPLACE,
    'lock' => MysqlAdapter::LOCK_NONE,
])->update();
```

**Changes:**
- Add `algorithm` and `lock` properties, getters/setters, and valid options to `Index` class
- Wire algorithm/lock from `Index` through `getAddIndexInstructions()` in `MysqlAdapter`
- Handle FULLTEXT indexes which use post-steps (algorithm/lock clause inlined into the SQL)
- Add 9 tests mirroring the Column algorithm/lock test coverage

**Note:** Drop index operations are out of scope, matching Column behavior where `getDropColumnInstructions` also does not support algorithm/lock (the method signature only receives string parameters, not the object).

## Test plan

- [x] PHPStan passes (`composer stan`)
- [x] New Index algorithm/lock tests pass against MySQL 8.4
- [x] Existing Column algorithm/lock tests still pass (no regression)
- [x] CI passes on all PHP versions