### PR TITLE
improve error message if a migration contains the old base migration class

### DIFF
--- a/src/Migration/Manager.php
+++ b/src/Migration/Manager.php
@@ -975,7 +975,8 @@ class Manager
 
                     $io->verbose("Loading class <info>$class</info> from <info>$filePath</info>.");
 
-                    // load the migration file
+                    $this->checkMigrationClass($filePath);
+
                     $orig_display_errors_setting = ini_get('display_errors');
                     ini_set('display_errors', 'On');
 
@@ -1023,6 +1024,32 @@ class Manager
         }
 
         return (array)$this->migrations;
+    }
+
+    /**
+     * Prevent fatal errors when loading legacy migration files that still reference old classes
+     *
+     * @param string $filePath Migration file path
+     * @return void
+     */
+    protected function checkMigrationClass(string $filePath): void
+    {
+        $contents = file_get_contents($filePath);
+        if ($contents === false) {
+            return;
+        }
+
+        $usesLegacyAbstractMigration =
+            str_contains($contents, 'use Migrations\AbstractMigration;') ||
+            str_contains($contents, 'extends AbstractMigration') ||
+            str_contains($contents, 'extends \Migrations\AbstractMigration');
+
+        if ($usesLegacyAbstractMigration) {
+            throw new RuntimeException(sprintf(
+                'Migration file `%s` uses the legacy `Migrations\\AbstractMigration` class, which is not available in this version. Update the migration to extend `Migrations\\BaseMigration`.',
+                $filePath,
+            ));
+        }
     }
 
     /**

--- a/tests/TestCase/Migration/ManagerTest.php
+++ b/tests/TestCase/Migration/ManagerTest.php
@@ -639,6 +639,18 @@ class ManagerTest extends TestCase
         $manager->getMigrations();
     }
 
+    public function testGetMigrationsWithLegacyAbstractMigrationClass(): void
+    {
+        $config = new Config(['paths' => ['migrations' => ROOT . '/config/LegacyAbstractMigration']]);
+        $manager = new Manager($config, $this->io);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/uses the legacy `Migrations\\\\AbstractMigration` class/');
+        $this->expectExceptionMessageMatches('/20260327000000_LegacyAbstractMigration\\.php/');
+
+        $manager->getMigrations();
+    }
+
     public function testGetMigrationsWithAnonymousClass()
     {
         $config = new Config(['paths' => ['migrations' => ROOT . '/config/AnonymousMigrations']]);

--- a/tests/test_app/config/LegacyAbstractMigration/20260327000000_LegacyAbstractMigration.php
+++ b/tests/test_app/config/LegacyAbstractMigration/20260327000000_LegacyAbstractMigration.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+
+class LegacyAbstractMigration extends AbstractMigration
+{
+    public function change(): void
+    {
+    }
+}


### PR DESCRIPTION
Fixes #1058

Now PHPUnit fails with this error:
```
PHPUnit 13.0.5 by Sebastian Bergmann and contributors.

Error in bootstrap script: RuntimeException:
Could not apply migrations for {"connection":"test"}

Migrations failed to apply with message:

Migration file `/Users/kevin/Documents/sunlime/alfred/config/Migrations/20260311200000_Initial.php` uses the legacy `Migrations\AbstractMigration` class, which is not available in this version. Update the migration to extend `Migrations\BaseMigration`.

If you are using the `skip` option and running multiple sets of migrations on the same connection, you can't skip tables managed by CakePHP in the connection.
#0 /Users/kevin/Documents/sunlime/alfred/tests/bootstrap.php(62): Migrations\TestSuite\Migrator->runMany(Array)
#1 /Users/kevin/Documents/sunlime/alfred/vendor/phpunit/phpunit/src/TextUI/Configuration/BootstrapLoader.php(61): include_once('/Users/kevin/Do...')
#2 /Users/kevin/Documents/sunlime/alfred/vendor/phpunit/phpunit/src/TextUI/Configuration/BootstrapLoader.php(36): PHPUnit\TextUI\Configuration\BootstrapLoader->load('/Users/kevin/Do...')
#3 /Users/kevin/Documents/sunlime/alfred/vendor/phpunit/phpunit/src/TextUI/Application.php(132): PHPUnit\TextUI\Configuration\BootstrapLoader->handle(Object(PHPUnit\TextUI\Configuration\Configuration))
#4 /Users/kevin/Documents/sunlime/alfred/vendor/phpunit/phpunit/phpunit(104): PHPUnit\TextUI\Application->run(Array)
#5 /Users/kevin/Documents/sunlime/alfred/vendor/bin/phpunit(122): include('/Users/kevin/Do...')
#6 {main}

Previous error: RuntimeException:
Migration file `/Users/kevin/Documents/sunlime/alfred/config/Migrations/20260311200000_Initial.php` uses the legacy `Migrations\AbstractMigration` class, which is not available in this version. Update the migration to extend `Migrations\BaseMigration`.
#0 /Users/kevin/Documents/sunlime/alfred/vendor/cakephp/migrations/src/Migration/Manager.php(978): Migrations\Migration\Manager->checkMigrationClass('/Users/kevin/Do...')
#1 /Users/kevin/Documents/sunlime/alfred/vendor/cakephp/migrations/src/Migration/Manager.php(452): Migrations\Migration\Manager->getMigrations()
#2 /Users/kevin/Documents/sunlime/alfred/vendor/cakephp/migrations/src/Migration/BuiltinBackend.php(96): Migrations\Migration\Manager->migrate(NULL)
#3 /Users/kevin/Documents/sunlime/alfred/vendor/cakephp/migrations/src/Migrations.php(114): Migrations\Migration\BuiltinBackend->migrate(Array)
#4 /Users/kevin/Documents/sunlime/alfred/vendor/cakephp/migrations/src/TestSuite/Migrator.php(116): Migrations\Migrations->migrate(Array)
#5 /Users/kevin/Documents/sunlime/alfred/tests/bootstrap.php(62): Migrations\TestSuite\Migrator->runMany(Array)
#6 /Users/kevin/Documents/sunlime/alfred/vendor/phpunit/phpunit/src/TextUI/Configuration/BootstrapLoader.php(61): include_once('/Users/kevin/Do...')
#7 /Users/kevin/Documents/sunlime/alfred/vendor/phpunit/phpunit/src/TextUI/Configuration/BootstrapLoader.php(36): PHPUnit\TextUI\Configuration\BootstrapLoader->load('/Users/kevin/Do...')
#8 /Users/kevin/Documents/sunlime/alfred/vendor/phpunit/phpunit/src/TextUI/Application.php(132): PHPUnit\TextUI\Configuration\BootstrapLoader->handle(Object(PHPUnit\TextUI\Configuration\Configuration))
#9 /Users/kevin/Documents/sunlime/alfred/vendor/phpunit/phpunit/phpunit(104): PHPUnit\TextUI\Application->run(Array)
#10 /Users/kevin/Documents/sunlime/alfred/vendor/bin/phpunit(122): include('/Users/kevin/Do...')
#11 {main}
```