### PR TITLE
Fix documentation issues

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -188,7 +188,7 @@ class CreateProducts extends BaseMigration
      * Change Method.
      *
      * More information on this method is available here:
-     * https://book.cakephp.org/migrations/3/en/writing-migrations.html#the-change-method
+     * https://book.cakephp.org/migrations/5/en/writing-migrations.html#the-change-method
      * @return void
      */
     public function change(): void

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -197,7 +197,7 @@ The command line above will generate a migration file that resembles::
          * Change Method.
          *
          * More information on this method is available here:
-         * https://book.cakephp.org/migrations/3/en/writing-migrations.html#the-change-method
+         * https://book.cakephp.org/migrations/5/en/writing-migrations.html#the-change-method
          * @return void
          */
         public function change(): void

--- a/docs/en/seeding.md
+++ b/docs/en/seeding.md
@@ -254,7 +254,7 @@ class ConfigSeed extends BaseSeed
             "SELECT COUNT(*) as count FROM settings WHERE setting_key = 'maintenance_mode'"
         );
 
-        if ($exists['count'] == 0) {
+        if ($exists['count'] === 0) {
             $this->table('settings')->insert([
                 'setting_key' => 'maintenance_mode',
                 'setting_value' => 'false',

--- a/docs/en/seeding.rst
+++ b/docs/en/seeding.rst
@@ -269,7 +269,7 @@ that update configuration or reference data. For these seeds, you can override t
                 "SELECT COUNT(*) as count FROM settings WHERE setting_key = 'maintenance_mode'"
             );
 
-            if ($exists['count'] == 0) {
+            if ($exists['count'] === 0) {
                 $this->table('settings')->insert([
                     'setting_key' => 'maintenance_mode',
                     'setting_value' => 'false',


### PR DESCRIPTION
## Summary

- Update migrations documentation link: 3 -> 5
- Use strict comparison (`===`) instead of loose (`==`)