### PR TITLE
Add citext column type support for PostgreSQL

### DIFF
--- a/docs/en/writing-migrations.md
+++ b/docs/en/writing-migrations.md
@@ -264,8 +264,11 @@ however with the MySQL adapter + MariaDB, the `nativeuuid` type maps to
 a native uuid column instead of `CHAR(36)` like `uuid` does.
 
 In addition, the Postgres adapter supports `interval`, `json`, `jsonb`,
-`uuid`, `cidr`, `inet` and `macaddr` column types (PostgreSQL 9.3 and
-above).
+`uuid`, `cidr`, `inet`, `macaddr` and `citext` column types (PostgreSQL 9.3
+and above). The `citext` type requires the `citext` extension to be enabled
+on the database; the migration does not create the extension automatically,
+run `CREATE EXTENSION IF NOT EXISTS citext` first (for example from an
+earlier migration via `$this->execute(...)`).
 
 ### Valid Column Options
 

--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -94,6 +94,8 @@ interface AdapterInterface
 
     public const TYPE_MACADDR = TableSchemaInterface::TYPE_MACADDR;
 
+    public const TYPE_CITEXT = TableSchemaInterface::TYPE_CITEXT;
+
     public const TYPE_INTERVAL = TableSchemaInterface::TYPE_INTERVAL;
 
     /**

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -53,6 +53,7 @@ class PostgresAdapter extends AbstractAdapter
         self::TYPE_CIDR,
         self::TYPE_INET,
         self::TYPE_MACADDR,
+        self::TYPE_CITEXT,
         self::TYPE_INTERVAL,
         self::TYPE_BINARY_UUID,
         self::TYPE_NATIVE_UUID,

--- a/src/Db/Table/Column.php
+++ b/src/Db/Table/Column.php
@@ -92,6 +92,9 @@ class Column extends DatabaseColumn
     /** Postgres-only column type */
     public const MACADDR = TableSchemaInterface::TYPE_MACADDR;
 
+    /** Postgres-only column type, requires the `citext` extension */
+    public const CITEXT = TableSchemaInterface::TYPE_CITEXT;
+
     /** Postgres-only column type */
     public const INTERVAL = TableSchemaInterface::TYPE_INTERVAL;
 

--- a/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/PostgresAdapterTest.php
@@ -669,6 +669,34 @@ class PostgresAdapterTest extends TestCase
         $this->assertTrue($table->hasColumn('config'));
     }
 
+    /**
+     * Test that adding a column with the citext type works.
+     *
+     * Requires the `citext` extension to be enabled on the database; the setUp
+     * above creates the extension when missing.
+     */
+    public function testAddColumnCitext(): void
+    {
+        $table = new Table('table1', [], $this->adapter);
+        $table->save();
+        $this->assertFalse($table->hasColumn('nickname'));
+        $table->addColumn('nickname', 'citext', ['null' => true])
+              ->save();
+        $this->assertTrue($table->hasColumn('nickname'));
+
+        $columns = $this->adapter->getColumns('table1');
+        $nickname = null;
+        foreach ($columns as $column) {
+            if ($column->getName() === 'nickname') {
+                $nickname = $column;
+                break;
+            }
+        }
+        $this->assertNotNull($nickname);
+        $this->assertSame('citext', $nickname->getType());
+        $this->assertTrue($nickname->isNull());
+    }
+
     public static function providerAddColumnIdentity(): array
     {
         return [

--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -2745,6 +2745,7 @@ INPUT;
             [SqliteAdapter::TYPE_UUID, true],
             [SqliteAdapter::TYPE_TIMESTAMP, true],
             [SqliteAdapter::TYPE_CIDR, false],
+            [SqliteAdapter::TYPE_CITEXT, false],
             [SqliteAdapter::TYPE_DECIMAL, true],
             [SqliteAdapter::TYPE_GEOMETRY, false],
             [SqliteAdapter::TYPE_INET, false],


### PR DESCRIPTION
## Summary

Adds support for the PostgreSQL `citext` extension type to the migrations adapter.

The heavy lifting was already in place: `Cake\Database\Schema\PostgresSchemaDialect::columnDefinitionSql()` already emits `CITEXT` for `TableSchemaInterface::TYPE_CITEXT`, and schema reflection already handles it (see line 147 of that dialect). The only thing blocking the type from reaching the dialect was the migrations adapter itself — `Column::$type` passes through to `isValidColumnType()` via `in_array($column->getType(), $this->getColumnTypes(), true)`, and `PostgresAdapter::$specificColumnTypes` did not include `citext`, so builder calls like

```php
$table->addColumn('nickname', 'citext', ['null' => true])
```

failed with

```
An invalid column type "citext" was specified for column "nickname".
```

Changes, modelled on how `cidr` / `inet` / `macaddr` are wired:

- Expose `AdapterInterface::TYPE_CITEXT` (mirrors `TableSchemaInterface::TYPE_CITEXT`)
- Add `Column::CITEXT` alias
- Include `self::TYPE_CITEXT` in `PostgresAdapter::$specificColumnTypes`
- Add a Postgres integration test (`testAddColumnCitext`) — note that the test bootstrap already runs `CREATE EXTENSION IF NOT EXISTS citext`, which strongly suggests this support was intended
- Add `TYPE_CITEXT` (expected `false`) to the SqliteAdapter `provideColumnTypesForValidation` data provider
- Document the new type in `writing-migrations.md`, noting that the user still needs to enable the extension on the database (the migration will not create it automatically)

No changes to DDL generation are needed — that already works end-to-end through the Cake dialect.

## Notes

- A follow-up to this would be a generic hook for registering arbitrary Postgres extension types (`hstore`, `ltree`, `vector`, `tsvector`, …). That is a larger design discussion and deliberately not included here — this PR narrowly fixes `citext`, which Cake core already supports.
