### PR TITLE
Handle unified migration ledger in test migrator cleanup

### DIFF
--- a/src/TestSuite/Migrator.php
+++ b/src/TestSuite/Migrator.php
@@ -213,7 +213,7 @@ class Migrator
 
     /**
      * Drops the regular tables of the provided connection
-     * and truncates the phinx tables.
+     * and truncates the migration metadata tables.
      *
      * @param string $connection Connection on which tables are dropped.
      * @param string[] $skip A fnmatch compatible list of tables to skip.
@@ -225,26 +225,26 @@ class Migrator
         if ($dropTables !== []) {
             $this->helper->dropTables($connection, $dropTables);
         }
-        $phinxTables = $this->getPhinxTables($connection);
-        if ($phinxTables !== []) {
-            $this->helper->truncateTables($connection, $phinxTables);
+        $migrationTables = $this->getMigrationTables($connection);
+        if ($migrationTables !== []) {
+            $this->helper->truncateTables($connection, $migrationTables);
         }
     }
 
     /**
-     * Get the list of tables that are phinxlog
+     * Get the list of migration metadata tables.
      *
      * @param string $connection The connection name to operate on.
-     * @return string[] The list of tables that are not related to phinx in the provided connection.
+     * @return string[] The list of migration metadata tables in the provided connection.
      */
-    protected function getPhinxTables(string $connection): array
+    protected function getMigrationTables(string $connection): array
     {
         $connection = ConnectionManager::get($connection);
         assert($connection instanceof Connection);
         $tables = $connection->getSchemaCollection()->listTables();
 
         return array_filter($tables, function (string $table): bool {
-            return str_contains($table, 'phinxlog');
+            return str_contains($table, 'phinxlog') || $table === 'cake_migrations';
         });
     }
 

--- a/tests/TestCase/TestSuite/MigratorTest.php
+++ b/tests/TestCase/TestSuite/MigratorTest.php
@@ -16,6 +16,7 @@ namespace Migrations\Test\TestCase\TestSuite;
 use Cake\Chronos\ChronosDate;
 use Cake\Core\Configure;
 use Cake\Database\Driver\Postgres;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\ConnectionHelper;
 use Cake\TestSuite\TestCase;
@@ -53,6 +54,47 @@ class MigratorTest extends TestCase
         return Configure::read('Migrations.legacyTables') === false
             ? ['plugin' => 'Migrator']
             : [];
+    }
+
+    protected function makeInspectableMigrator(): Migrator
+    {
+        return new class () extends Migrator {
+            /**
+             * @return array<string>
+             */
+            public function exposedGetMigrationTables(string $connection): array
+            {
+                return array_values($this->getMigrationTables($connection));
+            }
+
+            /**
+             * @return array<string>
+             */
+            public function exposedGetNonPhinxTables(string $connection, array $skip = []): array
+            {
+                return array_values($this->getNonPhinxTables($connection, $skip));
+            }
+        };
+    }
+
+    protected function createPortableTable(string $name, bool $withPlugin = false): void
+    {
+        $connection = ConnectionManager::get('test');
+        $schema = new TableSchema($name);
+        $schema
+            ->addColumn('version', ['type' => 'biginteger', 'null' => false])
+            ->addColumn('migration_name', ['type' => 'string', 'limit' => 100, 'null' => false])
+            ->addColumn('start_time', ['type' => 'timestamp', 'default' => null, 'null' => true])
+            ->addColumn('end_time', ['type' => 'timestamp', 'default' => null, 'null' => true])
+            ->addColumn('breakpoint', ['type' => 'boolean', 'default' => false, 'null' => false]);
+
+        if ($withPlugin) {
+            $schema->addColumn('plugin', ['type' => 'string', 'limit' => 100, 'default' => null, 'null' => true]);
+        }
+
+        foreach ($schema->createSql($connection) as $statement) {
+            $connection->execute($statement);
+        }
     }
 
     protected function setUp(): void
@@ -93,6 +135,32 @@ class MigratorTest extends TestCase
         $this->assertContains('migrator', $tables);
 
         $this->assertCount(0, $connection->selectQuery()->select(['*'])->from('migrator')->execute()->fetchAll());
+    }
+
+    public function testGetMigrationTablesIncludesUnifiedLedger(): void
+    {
+        $this->skipIf(Configure::read('Migrations.legacyTables') !== false);
+
+        $connection = ConnectionManager::get('test');
+        $connection->execute('CREATE TABLE sample_table (id INT)');
+        $this->createPortableTable('cake_migrations', true);
+
+        $migrator = $this->makeInspectableMigrator();
+
+        $this->assertSame(['cake_migrations'], $migrator->exposedGetMigrationTables('test'));
+        $this->assertSame(['sample_table'], $migrator->exposedGetNonPhinxTables('test'));
+    }
+
+    public function testGetMigrationTablesIncludesLegacyLedger(): void
+    {
+        $connection = ConnectionManager::get('test');
+        $connection->execute('CREATE TABLE sample_table (id INT)');
+        $this->createPortableTable('app_phinxlog');
+
+        $migrator = $this->makeInspectableMigrator();
+
+        $this->assertSame(['app_phinxlog'], $migrator->exposedGetMigrationTables('test'));
+        $this->assertSame(['sample_table'], $migrator->exposedGetNonPhinxTables('test'));
     }
 
     public function testMigrateDropNoTruncate(): void


### PR DESCRIPTION
## Summary

`Migrations\TestSuite\Migrator` currently excludes `cake_migrations` from normal table drops, but only truncates tables matching `*phinxlog*` during cleanup.

In unified mode, that can leave the migration ledger behind while regular tables are reset, which makes later test bootstrap runs replay migrations against an inconsistent schema state.

This patch updates the test migrator to treat `cake_migrations` as a migration metadata table alongside legacy `phinxlog` tables.

## Changes

- replace the internal `getPhinxTables()` behavior with `getMigrationTables()`
- include `cake_migrations` in the migration metadata table list
- update comments/docblocks to reflect unified-mode terminology
- add regression tests for:
  - unified mode: `cake_migrations`
  - legacy mode: `*_phinxlog`

## Why

Unified mode is already first-class in the package, but the test cleanup path was still only recognizing legacy `phinxlog` tables as migration metadata. That can leave `cake_migrations` stale across test DB rebuilds.

## Verification

- `vendor/bin/phpunit tests/TestCase/TestSuite/MigratorTest.php`
- `vendor/bin/phpcs src/TestSuite/Migrator.php tests/TestCase/TestSuite/MigratorTest.php`
