### PR TITLE
Disable FK checks during Migrator::dropTables

### DIFF
--- a/src/TestSuite/Migrator.php
+++ b/src/TestSuite/Migrator.php
@@ -223,7 +223,15 @@ class Migrator
     {
         $dropTables = $this->getNonPhinxTables($connection, $skip);
         if ($dropTables !== []) {
-            $this->helper->dropTables($connection, $dropTables);
+            $connectionObject = ConnectionManager::get($connection);
+            assert($connectionObject instanceof Connection);
+            // Disable FK checks so bulk drops don't block on cross-table references.
+            // Without this, dropping a parent table before its children fails on
+            // MySQL with error 3730 ("Cannot drop table X referenced by FK on Y")
+            // when the schema has constraints the drop-order can't satisfy.
+            $connectionObject->disableConstraints(function () use ($connection, $dropTables): void {
+                $this->helper->dropTables($connection, $dropTables);
+            });
         }
         $migrationTables = $this->getMigrationTables($connection);
         if ($migrationTables !== []) {

--- a/tests/TestCase/TestSuite/MigratorTest.php
+++ b/tests/TestCase/TestSuite/MigratorTest.php
@@ -15,6 +15,7 @@ namespace Migrations\Test\TestCase\TestSuite;
 
 use Cake\Chronos\ChronosDate;
 use Cake\Core\Configure;
+use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Postgres;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
@@ -73,6 +74,11 @@ class MigratorTest extends TestCase
             public function exposedGetNonPhinxTables(string $connection, array $skip = []): array
             {
                 return array_values($this->getNonPhinxTables($connection, $skip));
+            }
+
+            public function exposedDropTables(string $connection, array $skip = []): void
+            {
+                $this->dropTables($connection, $skip);
             }
         };
     }
@@ -149,6 +155,33 @@ class MigratorTest extends TestCase
 
         $this->assertSame(['cake_migrations'], $migrator->exposedGetMigrationTables('test'));
         $this->assertSame(['sample_table'], $migrator->exposedGetNonPhinxTables('test'));
+    }
+
+    public function testDropTablesHandlesCrossTableForeignKeys(): void
+    {
+        $connection = ConnectionManager::get('test');
+        // MySQL rejects dropping a FK-referenced parent table if children
+        // still have the FK. Guard the bulk-drop path for that.
+        $this->skipIf(!($connection->getDriver() instanceof Mysql));
+
+        $connection->execute('CREATE TABLE fk_a (id INT PRIMARY KEY) ENGINE=InnoDB');
+        $connection->execute(
+            'CREATE TABLE fk_b (id INT PRIMARY KEY, a_id INT, ' .
+            'CONSTRAINT fk_b_to_a FOREIGN KEY (a_id) REFERENCES fk_a (id)) ENGINE=InnoDB',
+        );
+        $connection->execute(
+            'CREATE TABLE fk_c (id INT PRIMARY KEY, a_id INT, b_id INT, ' .
+            'CONSTRAINT fk_c_to_a FOREIGN KEY (a_id) REFERENCES fk_a (id), ' .
+            'CONSTRAINT fk_c_to_b FOREIGN KEY (b_id) REFERENCES fk_b (id)) ENGINE=InnoDB',
+        );
+
+        $migrator = $this->makeInspectableMigrator();
+        $migrator->exposedDropTables('test');
+
+        $remaining = $connection->getSchemaCollection()->listTables();
+        $this->assertNotContains('fk_a', $remaining);
+        $this->assertNotContains('fk_b', $remaining);
+        $this->assertNotContains('fk_c', $remaining);
     }
 
     public function testGetMigrationTablesIncludesLegacyLedger(): void


### PR DESCRIPTION
## Problem

On MySQL, `Migrator::dropTables()` (called during test-suite rebuilds when `shouldDropTables()` returns true) can fail with error 3730:

```
SQLSTATE[HY000]: General error: 3730 Cannot drop table 'X' referenced by
a foreign key constraint 'fk_name' on table 'Y'.
Query: DROP TABLE \`X\`
```

`ConnectionHelper::dropTables()` drops each table's **outgoing** FKs first and then drops the tables. With complex schemas (many cross-referencing FKs across plugins, unified-mode ledgers, and migrations that add/drop FKs in non-trivial patterns) the drop pass can still hit an ordering MySQL refuses.

This showed up in a project with ~80 migrations and ~15 FK-linked tables: after clearing the ledger to force a rebuild, `Migrator::dropTables` bombed on `DROP TABLE bank_transactions` because a FK on `rent_payments` pointing at it hadn't been fully resolved by the drop-constraints pass.

Projects work around this by dropping tables by hand inside `$connection->disableConstraints(...)` in their `tests/bootstrap.php` — exactly what this PR moves upstream.

## Fix

Wrap `$this->helper->dropTables(...)` in `$connection->disableConstraints(...)` so MySQL doesn't enforce FK checks during the bulk drop. Drop order becomes irrelevant.

No behaviour change on SQLite or Postgres — they handle the drop order without help.

## Test

Adds a MySQL-only regression test (`testDropTablesHandlesCrossTableForeignKeys`) that creates three tables with cascading FK references and calls `dropTables` directly. Skipped on SQLite/Postgres because they don't block on this pattern.

## Notes

Tagged as draft while folks sanity-check the approach and the minimal test. Happy to iterate on naming / add more coverage if wanted.