### PR TITLE
Add --all flag to migrations status command

### DIFF
--- a/docs/en/advanced/integration-and-deployment.md
+++ b/docs/en/advanced/integration-and-deployment.md
@@ -62,6 +62,19 @@ bin/cake migrations status -p PluginName
 bin/cake migrations migrate -p PluginName
 ```
 
+To check the app and every loaded plugin in a single call — a typical need on
+deploy gates — use `migrations status --all` instead of looping over plugins
+manually:
+
+```bash
+bin/cake migrations status --all
+```
+
+The command prints a compact per-section summary and exits non-zero when
+anything is pending, so it slots straight into a CI step. See
+[Checking All Plugins at Once](../getting-started/running-and-managing-migrations#checking-all-plugins-at-once)
+for the full description of the output and exit codes.
+
 ## Running Migrations in a Non-shell Environment
 
 While typical usage of migrations is from the command line, you can also run

--- a/docs/en/getting-started/running-and-managing-migrations.md
+++ b/docs/en/getting-started/running-and-managing-migrations.md
@@ -70,7 +70,7 @@ bin/cake migrations status --all
 The default output is a compact summary listing only sections that need
 action:
 
-```
+```text
 Summary: 2 of 3 sections require action:
   - APP: 2 pending
   - Migrator: 1 pending

--- a/docs/en/getting-started/running-and-managing-migrations.md
+++ b/docs/en/getting-started/running-and-managing-migrations.md
@@ -58,6 +58,38 @@ bin/cake migrations status --format json
 You can also use the `--source`, `--connection`, and `--plugin` options just
 like for the `migrate` command.
 
+### Checking All Plugins at Once
+
+The `--all` flag prints the status for the app and every loaded plugin that
+ships migrations in a single call:
+
+```bash
+bin/cake migrations status --all
+```
+
+The default output is a compact summary listing only sections that need
+action:
+
+```
+Summary: 2 of 3 sections require action:
+  - APP: 2 pending
+  - Migrator: 1 pending
+```
+
+When everything is migrated, it collapses to a single
+`Summary: all N sections are up to date.` line. Add `-v` to also print the
+full per-section migration tables before the summary.
+
+The exit code reflects the worst state across all sections — `0` when clean,
+`3` (`CODE_STATUS_DOWN`) when migrations are pending, `2`
+(`CODE_STATUS_MISSING`) when entries in the tracking table no longer have
+matching files. This makes `status --all` directly usable as a deploy gate
+in CI.
+
+`--format json` returns one combined object keyed by section name,
+e.g. `{"app": [...], "PluginName": [...]}`. `--all` cannot be combined with
+`--plugin` or `--cleanup`.
+
 ### Cleaning Up Missing Migrations
 
 Sometimes migration files may be deleted from the filesystem but still exist in

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -225,12 +225,10 @@ class StatusCommand extends Command
                 continue;
             }
 
-            $heading = $label === 'app'
-                ? '<info>App</info>'
-                : sprintf('<info>Plugin: %s</info>', $label);
+            $heading = $label === 'app' ? 'APP' : $label;
             $io->out('');
             $io->out('==================================================');
-            $io->out($heading);
+            $io->out(sprintf('<info>%s</info>', $heading));
             $io->out('==================================================');
             $this->display($migrations, $io, $manager->getSchemaTableName());
         }
@@ -303,7 +301,7 @@ class StatusCommand extends Command
             count($summary),
         ));
         foreach ($needsAction as $label => $counts) {
-            $heading = $label === 'app' ? 'App' : sprintf('Plugin: %s', $label);
+            $heading = $label === 'app' ? 'APP' : $label;
             $parts = [];
             if ($counts['down'] > 0) {
                 $parts[] = sprintf('%d pending', $counts['down']);

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -66,14 +66,16 @@ class StatusCommand extends Command
             '<info>migrations status -c secondary</info>',
             '<info>migrations status -c secondary  -f json</info>',
             '<info>migrations status --all</info>',
-            'Print status for the app and every loaded plugin that has migrations.',
+            'Print a summary for the app and every loaded plugin that has migrations.',
+            'Add <info>-v</info> to also print the per-section migration tables.',
             '<info>migrations status --cleanup</info>',
             'Remove *MISSING* migrations from the migration tracking table',
         ])->addOption('plugin', [
             'short' => 'p',
             'help' => 'The plugin to run migrations for',
         ])->addOption('all', [
-            'help' => 'Print status for the app and every loaded plugin that has migrations. '
+            'help' => 'Print a status summary for the app and every loaded plugin that has migrations. '
+                . 'Use -v to also print the per-section migration tables. '
                 . 'Cannot be combined with --plugin or --cleanup.',
             'boolean' => true,
             'default' => false,
@@ -189,7 +191,9 @@ class StatusCommand extends Command
             $sections[$pluginName] = $pluginName;
         }
 
+        $verbose = (bool)$args->getOption('verbose');
         $jsonResults = [];
+        $summary = [];
         $exitCode = Command::CODE_SUCCESS;
 
         foreach ($sections as $label => $plugin) {
@@ -210,8 +214,14 @@ class StatusCommand extends Command
                 $exitCode = self::CODE_STATUS_DOWN;
             }
 
+            $summary[$label] = $this->countActions($migrations);
+
             if ($format === 'json') {
                 $jsonResults[$label] = $migrations;
+                continue;
+            }
+
+            if (!$verbose) {
                 continue;
             }
 
@@ -227,13 +237,82 @@ class StatusCommand extends Command
 
         if ($format === 'json') {
             $flags = 0;
-            if ($args->getOption('verbose')) {
+            if ($verbose) {
                 $flags = JSON_PRETTY_PRINT;
             }
             $io->out((string)json_encode($jsonResults, $flags));
+
+            return $exitCode;
         }
 
+        $this->displaySummary($io, $summary);
+
         return $exitCode;
+    }
+
+    /**
+     * Count actionable items (down + missing) in a section's migrations array.
+     *
+     * @param array $migrations The result of {@see Manager::printStatus()}.
+     * @return array{down: int, missing: int}
+     */
+    protected function countActions(array $migrations): array
+    {
+        $down = 0;
+        $missing = 0;
+        foreach ($migrations as $migration) {
+            if (!empty($migration['missing'])) {
+                $missing++;
+                continue;
+            }
+            if (($migration['status'] ?? null) === 'down') {
+                $down++;
+            }
+        }
+
+        return ['down' => $down, 'missing' => $missing];
+    }
+
+    /**
+     * Render the trailing summary block listing sections that need action.
+     *
+     * @param \Cake\Console\ConsoleIo $io The console io.
+     * @param array<string, array{down: int, missing: int}> $summary
+     * @return void
+     */
+    protected function displaySummary(ConsoleIo $io, array $summary): void
+    {
+        $needsAction = array_filter(
+            $summary,
+            fn(array $counts): bool => $counts['down'] > 0 || $counts['missing'] > 0,
+        );
+
+        $io->out('');
+        if (!$needsAction) {
+            $io->out(sprintf(
+                '<success>Summary: all %d sections are up to date.</success>',
+                count($summary),
+            ));
+
+            return;
+        }
+
+        $io->out(sprintf(
+            '<warning>Summary: %d of %d sections require action:</warning>',
+            count($needsAction),
+            count($summary),
+        ));
+        foreach ($needsAction as $label => $counts) {
+            $heading = $label === 'app' ? 'App' : sprintf('Plugin: %s', $label);
+            $parts = [];
+            if ($counts['down'] > 0) {
+                $parts[] = sprintf('%d pending', $counts['down']);
+            }
+            if ($counts['missing'] > 0) {
+                $parts[] = sprintf('%d missing', $counts['missing']);
+            }
+            $io->out(sprintf('  - %s: %s', $heading, implode(', ', $parts)));
+        }
     }
 
     /**

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -17,6 +17,7 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
+use Cake\Core\Plugin;
 use Migrations\Config\ConfigInterface;
 use Migrations\Db\Adapter\UnifiedMigrationsTableStorage;
 use Migrations\Migration\ManagerFactory;
@@ -64,11 +65,18 @@ class StatusCommand extends Command
             '',
             '<info>migrations status -c secondary</info>',
             '<info>migrations status -c secondary  -f json</info>',
+            '<info>migrations status --all</info>',
+            'Print status for the app and every loaded plugin that has migrations.',
             '<info>migrations status --cleanup</info>',
             'Remove *MISSING* migrations from the migration tracking table',
         ])->addOption('plugin', [
             'short' => 'p',
             'help' => 'The plugin to run migrations for',
+        ])->addOption('all', [
+            'help' => 'Print status for the app and every loaded plugin that has migrations. '
+                . 'Cannot be combined with --plugin or --cleanup.',
+            'boolean' => true,
+            'default' => false,
         ])->addOption('connection', [
             'short' => 'c',
             'help' => 'The datasource connection to use',
@@ -103,6 +111,22 @@ class StatusCommand extends Command
         /** @var string|null $format */
         $format = $args->getOption('format');
         $clean = $args->getOption('cleanup');
+        $all = (bool)$args->getOption('all');
+
+        if ($all) {
+            if ($args->getOption('plugin')) {
+                $io->err('<error>The --all option cannot be combined with --plugin.</error>');
+
+                return Command::CODE_ERROR;
+            }
+            if ($clean) {
+                $io->err('<error>The --all option cannot be combined with --cleanup.</error>');
+
+                return Command::CODE_ERROR;
+            }
+
+            return $this->executeAll($args, $io, $format);
+        }
 
         $factory = new ManagerFactory([
             'plugin' => $args->getOption('plugin'),
@@ -141,6 +165,97 @@ class StatusCommand extends Command
         }
 
         return Command::CODE_SUCCESS;
+    }
+
+    /**
+     * Execute the status command for the app and every loaded plugin
+     * that ships migrations.
+     *
+     * @param \Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\ConsoleIo $io The console io.
+     * @param string|null $format Output format.
+     * @return int The exit code: CODE_STATUS_MISSING (2) when there are missing entries,
+     *   CODE_STATUS_DOWN (3) when there are pending down migrations, CODE_SUCCESS otherwise.
+     */
+    protected function executeAll(Arguments $args, ConsoleIo $io, ?string $format): int
+    {
+        $sections = ['app' => null];
+        foreach (Plugin::loaded() as $pluginName) {
+            $migrationsPath = Plugin::path($pluginName) . 'config' . DS
+                . (string)$args->getOption('source') . DS;
+            if (!is_dir($migrationsPath)) {
+                continue;
+            }
+            $sections[$pluginName] = $pluginName;
+        }
+
+        $jsonResults = [];
+        $exitCode = Command::CODE_SUCCESS;
+
+        foreach ($sections as $label => $plugin) {
+            $factory = new ManagerFactory([
+                'plugin' => $plugin,
+                'source' => $args->getOption('source'),
+                'connection' => $args->getOption('connection'),
+                'dry-run' => $args->getOption('dry-run'),
+            ]);
+            $manager = $factory->createManager($io);
+            $migrations = $manager->printStatus($format);
+
+            $sectionExit = $this->statusExitCode($migrations);
+            // Precedence: MISSING > DOWN > SUCCESS — once we see MISSING anywhere, keep it.
+            if ($sectionExit === self::CODE_STATUS_MISSING) {
+                $exitCode = self::CODE_STATUS_MISSING;
+            } elseif ($sectionExit === self::CODE_STATUS_DOWN && $exitCode === Command::CODE_SUCCESS) {
+                $exitCode = self::CODE_STATUS_DOWN;
+            }
+
+            if ($format === 'json') {
+                $jsonResults[$label] = $migrations;
+                continue;
+            }
+
+            $heading = $label === 'app'
+                ? '<info>App</info>'
+                : sprintf('<info>Plugin: %s</info>', $label);
+            $io->out('');
+            $io->out('==================================================');
+            $io->out($heading);
+            $io->out('==================================================');
+            $this->display($migrations, $io, $manager->getSchemaTableName());
+        }
+
+        if ($format === 'json') {
+            $flags = 0;
+            if ($args->getOption('verbose')) {
+                $flags = JSON_PRETTY_PRINT;
+            }
+            $io->out((string)json_encode($jsonResults, $flags));
+        }
+
+        return $exitCode;
+    }
+
+    /**
+     * Compute the appropriate status exit code for a single section's migrations array.
+     *
+     * @param array $migrations The result of {@see Manager::printStatus()}.
+     * @return int CODE_STATUS_MISSING when missing entries exist, CODE_STATUS_DOWN when
+     *   any migration is pending (down), otherwise CODE_SUCCESS.
+     */
+    protected function statusExitCode(array $migrations): int
+    {
+        $hasDown = false;
+        foreach ($migrations as $migration) {
+            if (!empty($migration['missing'])) {
+                return self::CODE_STATUS_MISSING;
+            }
+            if (($migration['status'] ?? null) === 'down') {
+                $hasDown = true;
+            }
+        }
+
+        return $hasDown ? self::CODE_STATUS_DOWN : Command::CODE_SUCCESS;
     }
 
     /**

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -182,7 +182,7 @@ class StatusCommand extends Command
         $sections = ['app' => null];
         foreach (Plugin::loaded() as $pluginName) {
             $migrationsPath = Plugin::path($pluginName) . 'config' . DS
-                . (string)$args->getOption('source') . DS;
+                . $args->getOption('source') . DS;
             if (!is_dir($migrationsPath)) {
                 continue;
             }

--- a/tests/TestCase/Command/CompletionTest.php
+++ b/tests/TestCase/Command/CompletionTest.php
@@ -134,7 +134,7 @@ class CompletionTest extends TestCase
         $this->exec('completion options migrations.migrations status');
         $this->assertCount(1, $this->_out->messages());
         $output = $this->_out->messages()[0];
-        $expected = '--cleanup --connection -c --format -f --help -h --plugin -p --quiet -q --source -s --verbose -v';
+        $expected = '--all --cleanup --connection -c --format -f --help -h --plugin -p --quiet -q --source -s --verbose -v';
         $outputExplode = explode(' ', trim($output));
         sort($outputExplode);
         $expectedExplode = explode(' ', $expected);

--- a/tests/TestCase/Command/StatusCommandTest.php
+++ b/tests/TestCase/Command/StatusCommandTest.php
@@ -122,7 +122,7 @@ class StatusCommandTest extends TestCase
         $this->assertExitCode(StatusCommand::CODE_STATUS_DOWN);
         // Default output is summary only — no per-section table.
         $this->assertOutputContains('Summary:');
-        $this->assertOutputContains('App:');
+        $this->assertOutputContains('APP:');
         $this->assertOutputContains('pending');
         $this->assertOutputNotContains('Migration ID');
     }
@@ -133,8 +133,9 @@ class StatusCommandTest extends TestCase
         $this->exec('migrations status -c test --all');
         $this->assertExitCode(StatusCommand::CODE_STATUS_DOWN);
         $this->assertOutputContains('Summary:');
-        $this->assertOutputContains('App:');
-        $this->assertOutputContains('Plugin: Migrator:');
+        $this->assertOutputContains('- APP:');
+        $this->assertOutputContains('- Migrator:');
+        $this->assertOutputNotContains('Plugin:');
     }
 
     public function testAllVerboseShowsPerSectionTables(): void
@@ -143,7 +144,9 @@ class StatusCommandTest extends TestCase
         $this->exec('migrations status -c test --all -v');
         $this->assertExitCode(StatusCommand::CODE_STATUS_DOWN);
         $this->assertOutputContains('Migration ID');
-        $this->assertOutputContains('Plugin: Migrator');
+        // Plugin section header reads as just the plugin name now.
+        $this->assertOutputContains('Migrator');
+        $this->assertOutputNotContains('Plugin: Migrator');
         // Summary still rendered after the tables.
         $this->assertOutputContains('Summary:');
     }

--- a/tests/TestCase/Command/StatusCommandTest.php
+++ b/tests/TestCase/Command/StatusCommandTest.php
@@ -5,6 +5,7 @@ namespace Migrations\Test\TestCase\Command;
 
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Core\Exception\MissingPluginException;
+use Migrations\Command\StatusCommand;
 use Migrations\Test\TestCase\TestCase;
 use RuntimeException;
 
@@ -104,5 +105,64 @@ class StatusCommandTest extends TestCase
         $this->assertExitSuccess();
         $this->assertOutputContains('--cleanup');
         $this->assertOutputContains('Remove MISSING migrations from the');
+    }
+
+    public function testAllHelp(): void
+    {
+        $this->exec('migrations status --help');
+        $this->assertExitSuccess();
+        $this->assertOutputContains('--all');
+        $this->assertOutputContains('every loaded plugin');
+    }
+
+    public function testAllAppOnlyExitCodeDownWhenPending(): void
+    {
+        $this->exec('migrations status -c test --all');
+        // App has unmigrated migrations, so the exit code signals pending.
+        $this->assertExitCode(StatusCommand::CODE_STATUS_DOWN);
+        $this->assertOutputContains('App');
+        $this->assertOutputContains('Status');
+        $this->assertOutputContains('Migration ID');
+    }
+
+    public function testAllIncludesLoadedPluginWithMigrations(): void
+    {
+        $this->loadPlugins(['Migrator']);
+        $this->exec('migrations status -c test --all');
+        $this->assertExitCode(StatusCommand::CODE_STATUS_DOWN);
+        $this->assertOutputContains('App');
+        $this->assertOutputContains('Plugin: Migrator');
+    }
+
+    public function testAllJsonOutput(): void
+    {
+        $this->loadPlugins(['Migrator']);
+        $this->exec('migrations status -c test --all --format json');
+        $this->assertExitCode(StatusCommand::CODE_STATUS_DOWN);
+
+        assert($this->_out instanceof StubConsoleOutput);
+        $messages = $this->_out->messages();
+        $jsonLine = end($messages);
+        $parsed = json_decode((string)$jsonLine, true);
+        $this->assertIsArray($parsed);
+        $this->assertArrayHasKey('app', $parsed);
+        $this->assertArrayHasKey('Migrator', $parsed);
+        $this->assertIsArray($parsed['app']);
+        $this->assertIsArray($parsed['Migrator']);
+    }
+
+    public function testAllRejectsPluginOption(): void
+    {
+        $this->loadPlugins(['Migrator']);
+        $this->exec('migrations status -c test --all -p Migrator');
+        $this->assertExitError();
+        $this->assertErrorContains('cannot be combined with --plugin');
+    }
+
+    public function testAllRejectsCleanupOption(): void
+    {
+        $this->exec('migrations status -c test --all --cleanup');
+        $this->assertExitError();
+        $this->assertErrorContains('cannot be combined with --cleanup');
     }
 }

--- a/tests/TestCase/Command/StatusCommandTest.php
+++ b/tests/TestCase/Command/StatusCommandTest.php
@@ -120,9 +120,11 @@ class StatusCommandTest extends TestCase
         $this->exec('migrations status -c test --all');
         // App has unmigrated migrations, so the exit code signals pending.
         $this->assertExitCode(StatusCommand::CODE_STATUS_DOWN);
-        $this->assertOutputContains('App');
-        $this->assertOutputContains('Status');
-        $this->assertOutputContains('Migration ID');
+        // Default output is summary only — no per-section table.
+        $this->assertOutputContains('Summary:');
+        $this->assertOutputContains('App:');
+        $this->assertOutputContains('pending');
+        $this->assertOutputNotContains('Migration ID');
     }
 
     public function testAllIncludesLoadedPluginWithMigrations(): void
@@ -130,8 +132,20 @@ class StatusCommandTest extends TestCase
         $this->loadPlugins(['Migrator']);
         $this->exec('migrations status -c test --all');
         $this->assertExitCode(StatusCommand::CODE_STATUS_DOWN);
-        $this->assertOutputContains('App');
+        $this->assertOutputContains('Summary:');
+        $this->assertOutputContains('App:');
+        $this->assertOutputContains('Plugin: Migrator:');
+    }
+
+    public function testAllVerboseShowsPerSectionTables(): void
+    {
+        $this->loadPlugins(['Migrator']);
+        $this->exec('migrations status -c test --all -v');
+        $this->assertExitCode(StatusCommand::CODE_STATUS_DOWN);
+        $this->assertOutputContains('Migration ID');
         $this->assertOutputContains('Plugin: Migrator');
+        // Summary still rendered after the tables.
+        $this->assertOutputContains('Summary:');
     }
 
     public function testAllJsonOutput(): void


### PR DESCRIPTION
Refs #1075.

Adds an `--all` flag to `bin/cake migrations status` that prints status for the app plus every loaded plugin that ships a `config/Migrations/` directory.

## Motivation

Most non-trivial CakePHP apps end up with a custom composer/deploy script that loops over `Plugin::loaded()` and runs `migrations status -p <Plugin>` per plugin. The middleware (`PendingMigrationsMiddleware`) already does this iteration internally — `--all` brings the same convenience to the CLI so the status check is directly usable from CI and deploy pipelines.

This PR intentionally only covers `status`, not `migrate`. Read-only status carries no risk of running migrations on a plugin the user didn't realize had any, so it's a safe first step. A follow-up `migrate --all` can build on this once we've nailed down the opt-out / exclude story (also missing on the middleware today).

## Behavior

- `migrations status --all` iterates `Plugin::loaded()`, filters to plugins with a `config/<source>/` directory (so plugins without migrations are silently skipped), and prints app + each plugin under a clear section header.
- `--format json` returns `{"app": [...], "PluginName": [...]}` instead of a flat array.
- Exit code reflects state across all sections, with precedence `MISSING (2)` > `DOWN (3)` > `0`. The pre-existing constants `CODE_STATUS_MISSING` / `CODE_STATUS_DOWN` are reused. The single-section path is unchanged (still returns `CODE_SUCCESS`) so no existing CI breaks.
- `--all` cannot be combined with `--plugin` or `--cleanup`; both combinations error out with `CODE_ERROR` and a clear message.

## Notes

- Drafted as discussed in #1075. Happy to iterate on naming, JSON shape, or whether to also include an `--exclude` companion before merging.

## Example output

Default is a summary output:

```                                                                                                                                                                 
Summary: 2 of 2 sections require action:
  - APP: 2 pending                                                                                                                                                
  - Migrator: 1 pending       
```
This is useful for multiple plugins and long lists of migrations per namespace.

With -v (verbose) flag detailed report also added prior to summary:
```
  ==================================================                                                                                                                
  APP                                                                                                                                                               
  ==================================================
  using migration table phinxlog
                                                                                                                                                                    
  +--------+-----------------+------------------------+                                                                                                             
  | Status | Migration ID    | Migration Name         |                                                                                                             
  +--------+-----------------+------------------------+                                                                                                             
  | down   | 20150416223600  | MarkMigratedTest       |                                                                                                             
  | down   | 20240309223600  | MarkMigratedTestSecond |                                                                                                             
  +--------+-----------------+------------------------+                                                                                                             
                                                                                                                                                                    
  ==================================================                                                                                                                
  Migrator                                        
  ==================================================                                                                                                                
  using migration table migrator_phinxlog
                                                                                                                                                                    
  +--------+-----------------+----------------+                                                                                                                     
  | Status | Migration ID    | Migration Name |
  +--------+-----------------+----------------+                                                                                                                     
  | down   | 20211001000000  | Migrator       |           
  +--------+-----------------+----------------+

  Summary: 2 of 2 sections require action:                                                                                                                          
    - APP: 2 pending
    - Migrator: 1 pending  
```
