### PR TITLE
Fix flaky testCreateTableIndexWithWhere position lookup

### DIFF
--- a/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/SqliteAdapterTest.php
@@ -378,7 +378,13 @@ class SqliteAdapterTest extends TestCase
               ->addIndex($index)
               ->save();
         $queries = $this->out->messages();
-        $indexQuery = $queries[2];
+        $indexQuery = '';
+        foreach ($queries as $query) {
+            if (str_contains($query, 'CREATE UNIQUE INDEX "table1_email_index"')) {
+                $indexQuery = $query;
+                break;
+            }
+        }
         $this->assertStringContainsString('CREATE UNIQUE INDEX "table1_email_index"', $indexQuery);
         $this->assertStringContainsString('("email" ASC) WHERE is_verified = true', $indexQuery);
     }


### PR DESCRIPTION
## Summary

The test was hardcoding `$queries[2]` to pluck the CREATE UNIQUE INDEX statement out of the dry-run message buffer. The buffer now contains a handful of phinxlog setup messages before the create-index call:

```
[1] DROP TABLE "phinxlog";
[2] ALTER TABLE "tmp_phinxlog" RENAME TO "phinxlog";
[3] INSERT INTO "tmp_phinxlog"() SELECT  FROM "phinxlog";
[4] DROP TABLE "phinxlog";
[5] ALTER TABLE "tmp_phinxlog" RENAME TO "phinxlog";
[6] CREATE TABLE "table1" (...);
[7] CREATE UNIQUE INDEX "table1_email_index" ON "table1" (...) WHERE is_verified = true;
```

So the test was failing locally with the assertion message:

```
Failed asserting that 'ALTER TABLE "tmp_phinxlog" RENAME TO "phinxlog";' contains "CREATE UNIQUE INDEX "table1_email_index"".
```

Found while reducing the PHPStan baseline in #1083; the failure is pre-existing and reproducible on master.

## Fix

Walk the message buffer and pick the matching query rather than indexing by position. The two assertions on the index DDL contents are unchanged.
