### PR TITLE
5.next: Capability interfaces for reversible vs directional migrations

### DIFF
--- a/docs/.vitepress/toc_en.json
+++ b/docs/.vitepress/toc_en.json
@@ -37,7 +37,8 @@
       "collapsed": true,
       "items": [
         { "text": "Upgrading from 4.x to 5.x", "link": "/upgrades/upgrading-from-4-x" },
-        { "text": "Upgrading to the Builtin Backend", "link": "/upgrades/upgrading-to-builtin-backend" }
+        { "text": "Upgrading to the Builtin Backend", "link": "/upgrades/upgrading-to-builtin-backend" },
+        { "text": "Upgrading to Capability Interfaces", "link": "/upgrades/upgrading-to-capability-interfaces" }
       ]
     }
   ]

--- a/docs/en/guides/writing-migrations/migration-methods.md
+++ b/docs/en/guides/writing-migrations/migration-methods.md
@@ -1,5 +1,19 @@
 # Migration Methods
 
+A migration declares its style by implementing one of two capability interfaces:
+
+- `Migrations\ReversibleMigrationInterface` for migrations that define a
+  single `change()` method.
+- `Migrations\DirectionalMigrationInterface` for migrations that define
+  separate `up()` and `down()` methods.
+
+A migration implements **one** of the two, never both. Bake-generated
+migrations already include the right `implements` clause. Migrations from
+older versions of cakephp/migrations keep working without the interface
+through a `method_exists()` fallback; see
+[Upgrading to Capability Interfaces](/upgrades/upgrading-to-capability-interfaces)
+for the adoption path.
+
 ## The Change Method
 
 Migrations supports 'reversible migrations'. In many scenarios, you only need
@@ -10,8 +24,9 @@ rollback operations for you. For example:
 <?php
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class CreateUserLoginsTable extends BaseMigration
+class CreateUserLoginsTable extends BaseMigration implements ReversibleMigrationInterface
 {
     public function change(): void
     {
@@ -57,8 +72,9 @@ direction. For example:
 <?php
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class CreateUserLoginsTable extends BaseMigration
+class CreateUserLoginsTable extends BaseMigration implements ReversibleMigrationInterface
 {
     public function change(): void
     {
@@ -111,8 +127,9 @@ from within your database migration:
 <?php
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class MyNewMigration extends BaseMigration
+class MyNewMigration extends BaseMigration implements DirectionalMigrationInterface
 {
     public function up(): void
     {

--- a/docs/en/upgrades/upgrading-to-capability-interfaces.md
+++ b/docs/en/upgrades/upgrading-to-capability-interfaces.md
@@ -166,7 +166,8 @@ What the rule does:
 
 - For every class extending `Migrations\BaseMigration` (directly or transitively):
   - If the class defines `change()`, add `implements ReversibleMigrationInterface`.
-  - If the class defines `up()` or `down()`, add `implements DirectionalMigrationInterface`.
+  - If the class defines both `up()` and `down()`, add `implements DirectionalMigrationInterface`.
+- One-way migrations that define only `up()` or only `down()` are left untouched. They keep working through the `method_exists()` fallback; adding `DirectionalMigrationInterface` would make `Environment` call the missing direction unconditionally and turn a rollback no-op into a fatal error.
 - Classes that already implement either capability interface are skipped.
 - Classes that define both `change()` and `up()`/`down()` are skipped — these are user errors that need a deliberate decision.
 

--- a/docs/en/upgrades/upgrading-to-capability-interfaces.md
+++ b/docs/en/upgrades/upgrading-to-capability-interfaces.md
@@ -1,6 +1,6 @@
 # Upgrading to Capability Interfaces
 
-Starting with 5.next, cakephp/migrations ships two capability interfaces that let migrations declare their style explicitly:
+Starting with 5.2.0, cakephp/migrations ships two capability interfaces that let migrations declare their style explicitly:
 
 - `Migrations\ReversibleMigrationInterface` — for migrations that define a single reversible `change()` method.
 - `Migrations\DirectionalMigrationInterface` — for migrations that define separate `up()` and `down()` methods.

--- a/docs/en/upgrades/upgrading-to-capability-interfaces.md
+++ b/docs/en/upgrades/upgrading-to-capability-interfaces.md
@@ -1,0 +1,212 @@
+# Upgrading to Capability Interfaces
+
+Starting with 5.next, cakephp/migrations ships two capability interfaces that let migrations declare their style explicitly:
+
+- `Migrations\ReversibleMigrationInterface` — for migrations that define a single reversible `change()` method.
+- `Migrations\DirectionalMigrationInterface` — for migrations that define separate `up()` and `down()` methods.
+
+A migration implements **one** of the two interfaces, never both.
+
+## Why this exists
+
+Until now, `Environment` dispatched migrations through `method_exists()` checks against `change()`, `up()`, and `down()`. This works at runtime but has a few drawbacks:
+
+- A typo such as `function chnage()` silently no-ops at run time. The runtime cannot tell whether the migration is reversible or directional, so it just does nothing.
+- IDEs and static analyzers cannot resolve `change()` / `up()` / `down()` on a generic `MigrationInterface`, so refactoring tools and PHPStan narrowing do not work.
+- Custom runners that wrap `MigrationInterface` have to use reflection to figure out the migration style.
+
+The capability interfaces are a way out of this without breaking existing code:
+
+- `Environment` now dispatches via `instanceof` first and falls back to `method_exists()` for migrations that have not adopted the interfaces yet.
+- The interfaces declare their method contracts as PHPDoc `@method` tags (not as real abstract methods), which means adding `implements` to an existing migration is a **zero-friction** change — your method signature is not validated against an abstract.
+
+::: tip 5.x is a soft window
+The PHPDoc-only contract is intentional. The 6.x release is expected to promote the `@method` tags to real abstract method declarations, at which point a missing or mistyped `change()` / `up()` / `down()` becomes a static error. The 5.next release gives you a runway to adopt the interfaces without breakage; the 6.x release tightens the contract.
+:::
+
+## What changed for app developers
+
+If you do nothing, your existing migrations keep working. `Environment` retains a `method_exists()` fallback throughout the 5.x cycle.
+
+Adopting the interfaces now is recommended because:
+
+- New bakes already emit the right `implements` clause.
+- Static analysis and IDE autocomplete start working on your migrations.
+- Your app is upgrade-ready when 6.x lands.
+
+## Per-app upgrade — manual edits
+
+### Reversible migration (defines `change()`)
+
+Before:
+
+```php
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+class CreateProducts extends BaseMigration
+{
+    public function change(): void
+    {
+        $this->table('products')
+            ->addColumn('name', 'string')
+            ->create();
+    }
+}
+```
+
+After:
+
+```php
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
+
+class CreateProducts extends BaseMigration implements ReversibleMigrationInterface
+{
+    public function change(): void
+    {
+        $this->table('products')
+            ->addColumn('name', 'string')
+            ->create();
+    }
+}
+```
+
+### Directional migration (defines `up()` and `down()`)
+
+Before:
+
+```php
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+class BackfillOrderTotals extends BaseMigration
+{
+    public function up(): void
+    {
+        $this->execute('UPDATE orders SET total = ...');
+    }
+
+    public function down(): void
+    {
+        $this->execute('UPDATE orders SET total = NULL');
+    }
+}
+```
+
+After:
+
+```php
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
+
+class BackfillOrderTotals extends BaseMigration implements DirectionalMigrationInterface
+{
+    public function up(): void
+    {
+        $this->execute('UPDATE orders SET total = ...');
+    }
+
+    public function down(): void
+    {
+        $this->execute('UPDATE orders SET total = NULL');
+    }
+}
+```
+
+### Anonymous migrations
+
+Anonymous migrations get the same treatment:
+
+```php
+return new class extends BaseMigration implements ReversibleMigrationInterface
+{
+    public function change(): void
+    {
+    }
+};
+```
+
+## Automated upgrade with rector
+
+cakephp/migrations ships a rector rule that adds the right `implements` clause to every migration in your `config/Migrations/` folder.
+
+Add the following to your `rector.php`:
+
+```php
+use Migrations\Rector\AddMigrationCapabilityInterfaceRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/config/Migrations',
+    ])
+    ->withRules([
+        AddMigrationCapabilityInterfaceRector::class,
+    ]);
+```
+
+Then run rector:
+
+```bash
+vendor/bin/rector process --config=rector.php
+```
+
+What the rule does:
+
+- For every class extending `Migrations\BaseMigration` (directly or transitively):
+  - If the class defines `change()`, add `implements ReversibleMigrationInterface`.
+  - If the class defines `up()` or `down()`, add `implements DirectionalMigrationInterface`.
+- Classes that already implement either capability interface are skipped.
+- Classes that define both `change()` and `up()`/`down()` are skipped — these are user errors that need a deliberate decision.
+
+### Optional: combine with built-in rector rules
+
+If you also want to normalize visibility and return types on your migration methods (the shape 6.x will expect), compose with rector's built-in sets:
+
+```php
+use Migrations\Rector\AddMigrationCapabilityInterfaceRector;
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\SetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/config/Migrations',
+    ])
+    ->withRules([
+        AddMigrationCapabilityInterfaceRector::class,
+    ])
+    ->withSets([
+        SetList::TYPE_DECLARATION,
+    ]);
+```
+
+::: warning Only point rector at your migrations folder
+Migration paths use scoped rector configs by default; pointing rector at `src/` or `tests/` will apply unrelated transformations. Keep the path list narrow.
+:::
+
+## Manual work that remains after rector
+
+- **Migrations not on `BaseMigration`.** Anything still on a legacy Phinx `AbstractMigration` fork or a custom base that does not extend `BaseMigration` is skipped. Add the `implements` clause by hand.
+- **Dynamically generated migration classes** (eval'd test fixtures, factories). Rector cannot see them. Add the `implements` clause at the generation site.
+- **Custom base classes that themselves declare `change()` / `up()` / `down()`.** Rector adds the interface to the base class once. If the base lives in a third-party plugin you do not control, either implement the capability interface on the leaf class or PR the plugin upstream.
+- **Bake-generated migrations from older versions.** Bake templates emit the `implements` clause out of the box from 5.next; older bakes do not. Rector cleans those up in one pass.
+
+## Forward direction
+
+The 6.x release is expected to:
+
+- Promote the PHPDoc `@method` declarations on the capability interfaces to real abstract method declarations.
+- Remove the `method_exists()` fallback in `Environment`.
+
+Running rector now means the 6.x bump is a no-op for your migration files.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,12 @@ parameters:
     level: 8
     paths:
         - src/
+    excludePaths:
+        # rector/rector is installed on-demand via the rector-setup composer
+        # script, so PHPStan cannot resolve AbstractRector or the Symplify
+        # value objects during the main analysis run. The rule is autoloaded
+        # for downstream apps and type-checked by rector itself when invoked.
+        - src/Rector/
     bootstrapFiles:
         - tests/bootstrap.php
     ignoreErrors:

--- a/src/Command/BakeMigrationCommand.php
+++ b/src/Command/BakeMigrationCommand.php
@@ -245,7 +245,7 @@ TEXT;
     /**
      * @inheritDoc
      */
-    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser = parent::buildOptionParser($parser);
 

--- a/src/DirectionalMigrationInterface.php
+++ b/src/DirectionalMigrationInterface.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Migrations;
+
+/**
+ * Marker interface for migrations that define separate `up()` and `down()` methods.
+ *
+ * When implemented, `Migrations\Migration\Environment` dispatches the migration via
+ * `up()` or `down()` depending on the direction.
+ *
+ * In 5.x the method contracts are declared via PHPDoc only and are not enforced at
+ * the type system level — implementations are still discovered through `method_exists`
+ * for compatibility. The PHPDoc method tags exist so static analyzers and IDEs
+ * resolve `up()` / `down()` once the interface is asserted via `instanceof`. The
+ * 6.x release is expected to promote `up()` and `down()` to real abstract methods
+ * on this interface.
+ *
+ * A migration implements either this interface or {@see ReversibleMigrationInterface},
+ * never both.
+ *
+ * @method void up()   Apply the schema change.
+ * @method void down() Revert the schema change.
+ */
+interface DirectionalMigrationInterface extends MigrationInterface
+{
+}

--- a/src/Migration/Environment.php
+++ b/src/Migration/Environment.php
@@ -12,7 +12,9 @@ use Cake\Console\ConsoleIo;
 use Cake\Datasource\ConnectionManager;
 use Migrations\Db\Adapter\AdapterFactory;
 use Migrations\Db\Adapter\AdapterInterface;
+use Migrations\DirectionalMigrationInterface;
 use Migrations\MigrationInterface;
+use Migrations\ReversibleMigrationInterface;
 use Migrations\SeedInterface;
 use RuntimeException;
 
@@ -74,8 +76,15 @@ class Environment
         }
 
         if (!$fake) {
-            // Run the migration
-            if (method_exists($migration, MigrationInterface::CHANGE)) {
+            // Run the migration. Dispatch order: capability interfaces first
+            // (statically narrowable for IDEs and static analysis), then a
+            // method_exists fallback for migrations that haven't yet adopted
+            // either ReversibleMigrationInterface or DirectionalMigrationInterface.
+            $isReversible = $migration instanceof ReversibleMigrationInterface
+                || (!$migration instanceof DirectionalMigrationInterface
+                    && method_exists($migration, MigrationInterface::CHANGE));
+
+            if ($isReversible) {
                 if ($direction === MigrationInterface::DOWN) {
                     // Create an instance of the RecordingAdapter so we can record all
                     // of the migration commands for reverse playback
@@ -94,6 +103,8 @@ class Environment
                 } else {
                     $migration->{MigrationInterface::CHANGE}();
                 }
+            } elseif ($migration instanceof DirectionalMigrationInterface) {
+                $direction === MigrationInterface::UP ? $migration->up() : $migration->down();
             } elseif (method_exists($migration, $direction)) {
                 $migration->{$direction}();
             }

--- a/src/Rector/AddMigrationCapabilityInterfaceRector.php
+++ b/src/Rector/AddMigrationCapabilityInterfaceRector.php
@@ -1,0 +1,142 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Migrations\Rector;
+
+use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
+use Migrations\MigrationInterface;
+use Migrations\ReversibleMigrationInterface;
+use PhpParser\Node;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Reflection\ClassReflection;
+use Rector\PHPStan\ScopeFetcher;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Adds `implements ReversibleMigrationInterface` or `implements DirectionalMigrationInterface`
+ * to every class that extends {@see BaseMigration} based on the migration methods it defines.
+ *
+ * - Classes defining `change()` get {@see ReversibleMigrationInterface}.
+ * - Classes defining `up()` or `down()` get {@see DirectionalMigrationInterface}.
+ * - Classes defining both styles are skipped (the user must pick a style deliberately).
+ * - Classes already implementing either capability interface are skipped.
+ *
+ * This rule is meant to be run once during the upgrade from a pre-capability-interfaces
+ * 5.x version of cakephp/migrations to a version that ships the interfaces.
+ */
+final class AddMigrationCapabilityInterfaceRector extends AbstractRector
+{
+    /**
+     * @return \Symplify\RuleDocGenerator\ValueObject\RuleDefinition
+     */
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add ReversibleMigrationInterface / DirectionalMigrationInterface to migration classes based on the method they define',
+            [
+                new CodeSample(
+                    <<<'CODE_BEFORE'
+use Migrations\BaseMigration;
+
+class CreateProducts extends BaseMigration
+{
+    public function change(): void
+    {
+    }
+}
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
+
+class CreateProducts extends BaseMigration implements ReversibleMigrationInterface
+{
+    public function change(): void
+    {
+    }
+}
+CODE_AFTER,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<\PhpParser\Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $classReflection = ScopeFetcher::fetch($node)->getClassReflection();
+        if (!$classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        // Both abstract bases and anonymous migrations are valid targets: abstract
+        // bases propagate the interface to every leaf, and anonymous migrations are
+        // baked the same way concrete ones are. The only excluded type is
+        // BaseMigration itself, since it must remain style-agnostic.
+        if (
+            $classReflection->getName() === BaseMigration::class
+            || !$classReflection->isSubclassOf(BaseMigration::class)
+        ) {
+            return null;
+        }
+
+        $hasChange = $this->classHasMethod($node, MigrationInterface::CHANGE);
+        $hasDirection = $this->classHasMethod($node, MigrationInterface::UP)
+            || $this->classHasMethod($node, MigrationInterface::DOWN);
+
+        // Mixed style is user error. Leave it untouched so the developer picks deliberately.
+        if ($hasChange && $hasDirection) {
+            return null;
+        }
+
+        $targetInterface = null;
+        if ($hasChange && !$classReflection->implementsInterface(ReversibleMigrationInterface::class)) {
+            $targetInterface = ReversibleMigrationInterface::class;
+        } elseif ($hasDirection && !$classReflection->implementsInterface(DirectionalMigrationInterface::class)) {
+            $targetInterface = DirectionalMigrationInterface::class;
+        }
+
+        if ($targetInterface === null) {
+            return null;
+        }
+
+        $node->implements[] = new FullyQualified($targetInterface);
+
+        return $node;
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\Class_ $class Class node to inspect.
+     * @param string $methodName Method name to look for on the class itself.
+     * @return bool
+     */
+    private function classHasMethod(Class_ $class, string $methodName): bool
+    {
+        foreach ($class->getMethods() as $method) {
+            if ($this->getName($method) === $methodName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Rector/AddMigrationCapabilityInterfaceRector.php
+++ b/src/Rector/AddMigrationCapabilityInterfaceRector.php
@@ -26,7 +26,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * to every class that extends {@see BaseMigration} based on the migration methods it defines.
  *
  * - Classes defining `change()` get {@see ReversibleMigrationInterface}.
- * - Classes defining `up()` or `down()` get {@see DirectionalMigrationInterface}.
+ * - Classes defining both `up()` and `down()` get {@see DirectionalMigrationInterface}.
+ * - One-way migrations (only `up()` or only `down()`) are left untouched and keep
+ *   working through the Environment `method_exists()` fallback.
  * - Classes defining both styles are skipped (the user must pick a style deliberately).
  * - Classes already implementing either capability interface are skipped.
  *
@@ -99,19 +101,32 @@ CODE_AFTER,
             return null;
         }
 
-        $hasChange = $this->classHasMethod($node, MigrationInterface::CHANGE);
-        $hasDirection = $this->classHasMethod($node, MigrationInterface::UP)
-            || $this->classHasMethod($node, MigrationInterface::DOWN);
-
-        // Mixed style is user error. Leave it untouched so the developer picks deliberately.
-        if ($hasChange && $hasDirection) {
+        // Already annotated with either capability interface: leave it alone so the
+        // rule stays idempotent and never ends up adding the second, conflicting one.
+        if (
+            $classReflection->implementsInterface(ReversibleMigrationInterface::class)
+            || $classReflection->implementsInterface(DirectionalMigrationInterface::class)
+        ) {
             return null;
         }
 
+        $hasChange = $this->classHasMethod($node, MigrationInterface::CHANGE);
+        $hasUp = $this->classHasMethod($node, MigrationInterface::UP);
+        $hasDown = $this->classHasMethod($node, MigrationInterface::DOWN);
+
+        // Mixed style is user error. Leave it untouched so the developer picks deliberately.
+        if ($hasChange && ($hasUp || $hasDown)) {
+            return null;
+        }
+
+        // Only adopt the directional interface when BOTH methods are present. A one-way
+        // migration (only up() or only down()) must stay on the Environment method_exists()
+        // fallback: DirectionalMigrationInterface makes Environment call the missing
+        // direction unconditionally, turning a rollback no-op into a fatal error.
         $targetInterface = null;
-        if ($hasChange && !$classReflection->implementsInterface(ReversibleMigrationInterface::class)) {
+        if ($hasChange) {
             $targetInterface = ReversibleMigrationInterface::class;
-        } elseif ($hasDirection && !$classReflection->implementsInterface(DirectionalMigrationInterface::class)) {
+        } elseif ($hasUp && $hasDown) {
             $targetInterface = DirectionalMigrationInterface::class;
         }
 

--- a/src/ReversibleMigrationInterface.php
+++ b/src/ReversibleMigrationInterface.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Migrations;
+
+/**
+ * Marker interface for migrations that define a single reversible `change()` method.
+ *
+ * When implemented, `Migrations\Migration\Environment` dispatches the migration via
+ * `change()` and uses the recording adapter to invert commands for the down direction.
+ *
+ * In 5.x the method contract is declared via PHPDoc only and is not enforced at the
+ * type system level — implementations are still discovered through `method_exists`
+ * for compatibility. The PHPDoc method tag exists so static analyzers and IDEs
+ * resolve `change()` once the interface is asserted via `instanceof`. The 6.x
+ * release is expected to promote `change()` to a real abstract method on this
+ * interface.
+ *
+ * A migration implements either this interface or {@see DirectionalMigrationInterface},
+ * never both.
+ *
+ * @method void change() Reversible schema change. Use the recording adapter for down().
+ */
+interface ReversibleMigrationInterface extends MigrationInterface
+{
+}

--- a/templates/bake/config/diff.twig
+++ b/templates/bake/config/diff.twig
@@ -20,8 +20,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class {{ name }} extends BaseMigration
+class {{ name }} extends BaseMigration implements DirectionalMigrationInterface
 {
 {% if not autoId %}
     public bool $autoId = false;

--- a/templates/bake/config/skeleton-anonymous.twig
+++ b/templates/bake/config/skeleton-anonymous.twig
@@ -21,8 +21,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-return new class extends BaseMigration
+return new class extends BaseMigration implements ReversibleMigrationInterface
 {
 {% if tableMethod == 'create' and columns['primaryKey'] %}
         public bool $autoId = false;

--- a/templates/bake/config/skeleton.twig
+++ b/templates/bake/config/skeleton.twig
@@ -21,8 +21,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class {{ name }} extends BaseMigration
+class {{ name }} extends BaseMigration implements ReversibleMigrationInterface
 {
 {% if tableMethod == 'create' and columns['primaryKey'] %}
     public bool $autoId = false;

--- a/templates/bake/config/snapshot.twig
+++ b/templates/bake/config/snapshot.twig
@@ -23,8 +23,13 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+{% if useChange %}
+use Migrations\ReversibleMigrationInterface;
+{% else %}
+use Migrations\DirectionalMigrationInterface;
+{% endif %}
 
-class {{ name }} extends BaseMigration
+class {{ name }} extends BaseMigration implements {{ useChange ? 'ReversibleMigrationInterface' : 'DirectionalMigrationInterface' }}
 {
 {% if not autoId  %}
     public bool $autoId = false;

--- a/tests/TestCase/Migration/EnvironmentTest.php
+++ b/tests/TestCase/Migration/EnvironmentTest.php
@@ -9,8 +9,10 @@ use Migrations\BaseMigration;
 use Migrations\BaseSeed;
 use Migrations\Db\Adapter\AbstractAdapter;
 use Migrations\Db\Adapter\AdapterWrapper;
+use Migrations\DirectionalMigrationInterface;
 use Migrations\Migration\Environment;
 use Migrations\MigrationInterface;
+use Migrations\ReversibleMigrationInterface;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -278,6 +280,159 @@ class EnvironmentTest extends TestCase
 
         $this->environment->executeMigration($migration, MigrationInterface::DOWN);
         $this->assertTrue($migration->executed);
+    }
+
+    public function testExecutingAReversibleInterfaceMigrationUp(): void
+    {
+        $adapterStub = $this->getMockBuilder(AbstractAdapter::class)
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $adapterStub->expects($this->once())
+            ->method('migrated')
+            ->willReturn($adapterStub);
+
+        $this->environment->setAdapter($adapterStub);
+
+        $migration = new class (20260513120000) extends BaseMigration implements ReversibleMigrationInterface {
+            public bool $executed = false;
+
+            public function change(): void
+            {
+                $this->executed = true;
+            }
+        };
+
+        $this->environment->executeMigration($migration, MigrationInterface::UP);
+        $this->assertTrue($migration->executed);
+    }
+
+    public function testExecutingAReversibleInterfaceMigrationDown(): void
+    {
+        $adapterStub = $this->getMockBuilder(AbstractAdapter::class)
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $adapterStub->expects($this->once())
+            ->method('migrated')
+            ->willReturn($adapterStub);
+
+        $this->environment->setAdapter($adapterStub);
+
+        $migration = new class (20260513120000) extends BaseMigration implements ReversibleMigrationInterface {
+            public bool $executed = false;
+
+            public function change(): void
+            {
+                $this->executed = true;
+            }
+        };
+
+        $this->environment->executeMigration($migration, MigrationInterface::DOWN);
+        $this->assertTrue($migration->executed);
+    }
+
+    public function testExecutingADirectionalInterfaceMigrationUp(): void
+    {
+        $adapterStub = $this->getMockBuilder(AbstractAdapter::class)
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $adapterStub->expects($this->once())
+            ->method('migrated')
+            ->willReturn($adapterStub);
+
+        $this->environment->setAdapter($adapterStub);
+
+        $migration = new class (20260513120000) extends BaseMigration implements DirectionalMigrationInterface {
+            public bool $upExecuted = false;
+
+            public bool $downExecuted = false;
+
+            public function up(): void
+            {
+                $this->upExecuted = true;
+            }
+
+            public function down(): void
+            {
+                $this->downExecuted = true;
+            }
+        };
+
+        $this->environment->executeMigration($migration, MigrationInterface::UP);
+        $this->assertTrue($migration->upExecuted);
+        $this->assertFalse($migration->downExecuted);
+    }
+
+    public function testExecutingADirectionalInterfaceMigrationDown(): void
+    {
+        $adapterStub = $this->getMockBuilder(AbstractAdapter::class)
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $adapterStub->expects($this->once())
+            ->method('migrated')
+            ->willReturn($adapterStub);
+
+        $this->environment->setAdapter($adapterStub);
+
+        $migration = new class (20260513120000) extends BaseMigration implements DirectionalMigrationInterface {
+            public bool $upExecuted = false;
+
+            public bool $downExecuted = false;
+
+            public function up(): void
+            {
+                $this->upExecuted = true;
+            }
+
+            public function down(): void
+            {
+                $this->downExecuted = true;
+            }
+        };
+
+        $this->environment->executeMigration($migration, MigrationInterface::DOWN);
+        $this->assertTrue($migration->downExecuted);
+        $this->assertFalse($migration->upExecuted);
+    }
+
+    /**
+     * If a class declares DirectionalMigrationInterface, dispatch must use
+     * up()/down() even if the class happens to define a change() method —
+     * the interface declaration wins over the legacy method_exists check.
+     */
+    public function testDirectionalInterfaceWinsOverChangeMethod(): void
+    {
+        $adapterStub = $this->getMockBuilder(AbstractAdapter::class)
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $adapterStub->expects($this->once())
+            ->method('migrated')
+            ->willReturn($adapterStub);
+
+        $this->environment->setAdapter($adapterStub);
+
+        $migration = new class (20260513120000) extends BaseMigration implements DirectionalMigrationInterface {
+            public bool $upExecuted = false;
+
+            public bool $changeExecuted = false;
+
+            public function up(): void
+            {
+                $this->upExecuted = true;
+            }
+
+            public function down(): void
+            {
+            }
+
+            public function change(): void
+            {
+                $this->changeExecuted = true;
+            }
+        };
+
+        $this->environment->executeMigration($migration, MigrationInterface::UP);
+        $this->assertTrue($migration->upExecuted);
+        $this->assertFalse($migration->changeExecuted);
     }
 
     public function testExecutingAFakeMigration(): void

--- a/tests/comparisons/Create/TestCreateChange.php
+++ b/tests/comparisons/Create/TestCreateChange.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class TestCreateChange extends BaseMigration
+class TestCreateChange extends BaseMigration implements ReversibleMigrationInterface
 {
     /**
      * Change Method.

--- a/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
+++ b/tests/comparisons/Diff/addRemove/the_diff_add_remove_mysql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TheDiffAddRemoveMysql extends BaseMigration
+class TheDiffAddRemoveMysql extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Diff/addRemove/the_diff_add_remove_pgsql.php
+++ b/tests/comparisons/Diff/addRemove/the_diff_add_remove_pgsql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TheDiffAddRemovePgsql extends BaseMigration
+class TheDiffAddRemovePgsql extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Diff/decimalChange/initial_decimal_change_mysql.php
+++ b/tests/comparisons/Diff/decimalChange/initial_decimal_change_mysql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class InitialDecimalChangeMysql extends BaseMigration
+class InitialDecimalChangeMysql extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Diff/decimalChange/mysql/the_diff_decimal_change_mysql.php
+++ b/tests/comparisons/Diff/decimalChange/mysql/the_diff_decimal_change_mysql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TheDiffDecimalChangeMysql extends BaseMigration
+class TheDiffDecimalChangeMysql extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Diff/default/the_diff_default_mysql.php
+++ b/tests/comparisons/Diff/default/the_diff_default_mysql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TheDiffDefaultMysql extends BaseMigration
+class TheDiffDefaultMysql extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Diff/default/the_diff_default_pgsql.php
+++ b/tests/comparisons/Diff/default/the_diff_default_pgsql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TheDiffDefaultPgsql extends BaseMigration
+class TheDiffDefaultPgsql extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_mysql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TheDiffSimpleMysql extends BaseMigration
+class TheDiffSimpleMysql extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Diff/simple/the_diff_simple_pgsql.php
+++ b/tests/comparisons/Diff/simple/the_diff_simple_pgsql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TheDiffSimplePgsql extends BaseMigration
+class TheDiffSimplePgsql extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Diff/withAutoIdCompatibleSignedPrimaryKeys/the_diff_with_auto_id_compatible_signed_primary_keys_mysql.php
+++ b/tests/comparisons/Diff/withAutoIdCompatibleSignedPrimaryKeys/the_diff_with_auto_id_compatible_signed_primary_keys_mysql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TheDiffWithAutoIdCompatibleSignedPrimaryKeysMysql extends BaseMigration
+class TheDiffWithAutoIdCompatibleSignedPrimaryKeysMysql extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Diff/withAutoIdIncompatibleSignedPrimaryKeys/the_diff_with_auto_id_incompatible_signed_primary_keys_mysql.php
+++ b/tests/comparisons/Diff/withAutoIdIncompatibleSignedPrimaryKeys/the_diff_with_auto_id_incompatible_signed_primary_keys_mysql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TheDiffWithAutoIdIncompatibleSignedPrimaryKeysMysql extends BaseMigration
+class TheDiffWithAutoIdIncompatibleSignedPrimaryKeysMysql extends BaseMigration implements DirectionalMigrationInterface
 {
     public bool $autoId = false;
 

--- a/tests/comparisons/Diff/withAutoIdIncompatibleUnsignedPrimaryKeys/the_diff_with_auto_id_incompatible_unsigned_primary_keys_mysql.php
+++ b/tests/comparisons/Diff/withAutoIdIncompatibleUnsignedPrimaryKeys/the_diff_with_auto_id_incompatible_unsigned_primary_keys_mysql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TheDiffWithAutoIdIncompatibleUnsignedPrimaryKeysMysql extends BaseMigration
+class TheDiffWithAutoIdIncompatibleUnsignedPrimaryKeysMysql extends BaseMigration implements DirectionalMigrationInterface
 {
     public bool $autoId = false;
 

--- a/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_auto_id_disabled_pgsql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotAutoIdDisabledPgsql extends BaseMigration
+class TestSnapshotAutoIdDisabledPgsql extends BaseMigration implements DirectionalMigrationInterface
 {
     public bool $autoId = false;
 

--- a/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_not_empty_pgsql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotNotEmptyPgsql extends BaseMigration
+class TestSnapshotNotEmptyPgsql extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_plugin_blog_pgsql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotPluginBlogPgsql extends BaseMigration
+class TestSnapshotPluginBlogPgsql extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Migration/pgsql/test_snapshot_with_change_pgsql.php
+++ b/tests/comparisons/Migration/pgsql/test_snapshot_with_change_pgsql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class TestSnapshotWithChangePgsql extends BaseMigration
+class TestSnapshotWithChangePgsql extends BaseMigration implements ReversibleMigrationInterface
 {
     /**
      * Change Method.

--- a/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_auto_id_disabled_sqlite.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotAutoIdDisabledSqlite extends BaseMigration
+class TestSnapshotAutoIdDisabledSqlite extends BaseMigration implements DirectionalMigrationInterface
 {
     public bool $autoId = false;
 

--- a/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_not_empty_sqlite.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotNotEmptySqlite extends BaseMigration
+class TestSnapshotNotEmptySqlite extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_plugin_blog_sqlite.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotPluginBlogSqlite extends BaseMigration
+class TestSnapshotPluginBlogSqlite extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Migration/sqlite/test_snapshot_with_change_sqlite.php
+++ b/tests/comparisons/Migration/sqlite/test_snapshot_with_change_sqlite.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class TestSnapshotWithChangeSqlite extends BaseMigration
+class TestSnapshotWithChangeSqlite extends BaseMigration implements ReversibleMigrationInterface
 {
     /**
      * Change Method.

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_auto_id_disabled_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_auto_id_disabled_sqlserver.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration
+class TestSnapshotAutoIdDisabledSqlserver extends BaseMigration implements DirectionalMigrationInterface
 {
     public bool $autoId = false;
 

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_not_empty_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_not_empty_sqlserver.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotNotEmptySqlserver extends BaseMigration
+class TestSnapshotNotEmptySqlserver extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_plugin_blog_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_plugin_blog_sqlserver.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotPluginBlogSqlserver extends BaseMigration
+class TestSnapshotPluginBlogSqlserver extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Migration/sqlserver/test_snapshot_with_change_sqlserver.php
+++ b/tests/comparisons/Migration/sqlserver/test_snapshot_with_change_sqlserver.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class TestSnapshotWithChangeSqlserver extends BaseMigration
+class TestSnapshotWithChangeSqlserver extends BaseMigration implements ReversibleMigrationInterface
 {
     /**
      * Change Method.

--- a/tests/comparisons/Migration/testAddFieldWithReference.php
+++ b/tests/comparisons/Migration/testAddFieldWithReference.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class AddCategoryIdToProducts extends BaseMigration
+class AddCategoryIdToProducts extends BaseMigration implements ReversibleMigrationInterface
 {
     /**
      * Change Method.

--- a/tests/comparisons/Migration/testCreate.php
+++ b/tests/comparisons/Migration/testCreate.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class CreateUsers extends BaseMigration
+class CreateUsers extends BaseMigration implements ReversibleMigrationInterface
 {
     /**
      * Change Method.

--- a/tests/comparisons/Migration/testCreateDatetime.php
+++ b/tests/comparisons/Migration/testCreateDatetime.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class CreateUsers extends BaseMigration
+class CreateUsers extends BaseMigration implements ReversibleMigrationInterface
 {
     /**
      * Change Method.

--- a/tests/comparisons/Migration/testCreateDropMigration.php
+++ b/tests/comparisons/Migration/testCreateDropMigration.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class DropUsers extends BaseMigration
+class DropUsers extends BaseMigration implements ReversibleMigrationInterface
 {
     /**
      * Change Method.

--- a/tests/comparisons/Migration/testCreateFieldLength.php
+++ b/tests/comparisons/Migration/testCreateFieldLength.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class CreateUsers extends BaseMigration
+class CreateUsers extends BaseMigration implements ReversibleMigrationInterface
 {
     /**
      * Change Method.

--- a/tests/comparisons/Migration/testCreatePrimaryKey.php
+++ b/tests/comparisons/Migration/testCreatePrimaryKey.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class CreateUsers extends BaseMigration
+class CreateUsers extends BaseMigration implements ReversibleMigrationInterface
 {
     public bool $autoId = false;
 

--- a/tests/comparisons/Migration/testCreatePrimaryKeyUuid.php
+++ b/tests/comparisons/Migration/testCreatePrimaryKeyUuid.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class CreateUsers extends BaseMigration
+class CreateUsers extends BaseMigration implements ReversibleMigrationInterface
 {
     public bool $autoId = false;
 

--- a/tests/comparisons/Migration/testCreateWithReferences.php
+++ b/tests/comparisons/Migration/testCreateWithReferences.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class CreatePosts extends BaseMigration
+class CreatePosts extends BaseMigration implements ReversibleMigrationInterface
 {
     /**
      * Change Method.

--- a/tests/comparisons/Migration/testCreateWithReferencesCustomTable.php
+++ b/tests/comparisons/Migration/testCreateWithReferencesCustomTable.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class CreateArticles extends BaseMigration
+class CreateArticles extends BaseMigration implements ReversibleMigrationInterface
 {
     /**
      * Change Method.

--- a/tests/comparisons/Migration/testNoContents.php
+++ b/tests/comparisons/Migration/testNoContents.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class NoContents extends BaseMigration
+class NoContents extends BaseMigration implements ReversibleMigrationInterface
 {
     /**
      * Change Method.

--- a/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
+++ b/tests/comparisons/Migration/test_snapshot_auto_id_disabled.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotAutoIdDisabled extends BaseMigration
+class TestSnapshotAutoIdDisabled extends BaseMigration implements DirectionalMigrationInterface
 {
     public bool $autoId = false;
 

--- a/tests/comparisons/Migration/test_snapshot_not_empty.php
+++ b/tests/comparisons/Migration/test_snapshot_not_empty.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotNotEmpty extends BaseMigration
+class TestSnapshotNotEmpty extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Migration/test_snapshot_plugin_blog.php
+++ b/tests/comparisons/Migration/test_snapshot_plugin_blog.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotPluginBlog extends BaseMigration
+class TestSnapshotPluginBlog extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Migration/test_snapshot_postgres_timestamp_tz_pgsql.php
+++ b/tests/comparisons/Migration/test_snapshot_postgres_timestamp_tz_pgsql.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotPostgresTimestampTzPgsql extends BaseMigration
+class TestSnapshotPostgresTimestampTzPgsql extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_compatible_signed_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_compatible_signed_primary_keys.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotWithAutoIdCompatibleSignedPrimaryKeys extends BaseMigration
+class TestSnapshotWithAutoIdCompatibleSignedPrimaryKeys extends BaseMigration implements DirectionalMigrationInterface
 {
     public bool $autoId = false;
 

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_signed_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_signed_primary_keys.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotWithAutoIdIncompatibleSignedPrimaryKeys extends BaseMigration
+class TestSnapshotWithAutoIdIncompatibleSignedPrimaryKeys extends BaseMigration implements DirectionalMigrationInterface
 {
     public bool $autoId = false;
 

--- a/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_unsigned_primary_keys.php
+++ b/tests/comparisons/Migration/test_snapshot_with_auto_id_incompatible_unsigned_primary_keys.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotWithAutoIdIncompatibleUnsignedPrimaryKeys extends BaseMigration
+class TestSnapshotWithAutoIdIncompatibleUnsignedPrimaryKeys extends BaseMigration implements DirectionalMigrationInterface
 {
     public bool $autoId = false;
 

--- a/tests/comparisons/Migration/test_snapshot_with_change.php
+++ b/tests/comparisons/Migration/test_snapshot_with_change.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\ReversibleMigrationInterface;
 
-class TestSnapshotWithChange extends BaseMigration
+class TestSnapshotWithChange extends BaseMigration implements ReversibleMigrationInterface
 {
     /**
      * Change Method.

--- a/tests/comparisons/Migration/test_snapshot_with_non_default_collation.php
+++ b/tests/comparisons/Migration/test_snapshot_with_non_default_collation.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Migrations\BaseMigration;
+use Migrations\DirectionalMigrationInterface;
 
-class TestSnapshotWithNonDefaultCollation extends BaseMigration
+class TestSnapshotWithNonDefaultCollation extends BaseMigration implements DirectionalMigrationInterface
 {
     /**
      * Up Method.

--- a/tests/test_app/App/Command/CustomBakeMigrationDiffCommand.php
+++ b/tests/test_app/App/Command/CustomBakeMigrationDiffCommand.php
@@ -23,7 +23,7 @@ class CustomBakeMigrationDiffCommand extends BakeMigrationDiffCommand
     /**
      * @inheritDoc
      */
-    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         return parent::buildOptionParser($parser)
             ->addOption('test-target-folder')


### PR DESCRIPTION
Refs #1084.

Soft-introduces the capability interfaces proposed in #1084 in the 5.x cycle so the 6.x BC-breaking step lands on top of an already-adopted shape.

## What this changes

Two new marker interfaces under the `Migrations` namespace:

- `ReversibleMigrationInterface` — for migrations defining a single `change()` method.
- `DirectionalMigrationInterface` — for migrations defining separate `up()` and `down()` methods.

Method contracts are declared as PHPDoc method tags only (not real abstract methods):

```php
namespace Migrations;

/**
 * @method void change()
 */
interface ReversibleMigrationInterface extends MigrationInterface
{
}

/**
 * @method void up()
 * @method void down()
 */
interface DirectionalMigrationInterface extends MigrationInterface
{
}
```

`Migration\Environment::executeMigration` now dispatches via `instanceof` first and keeps the existing `method_exists()` fallback for migrations that have not adopted the interfaces yet:

```php
if ($migration instanceof ReversibleMigrationInterface) {
    // change() dispatch (with recording adapter for down)
} elseif ($migration instanceof DirectionalMigrationInterface) {
    $direction === MigrationInterface::UP ? $migration->up() : $migration->down();
} elseif (method_exists($migration, MigrationInterface::CHANGE)) {
    // legacy reversible fallback (5.x only)
} elseif (method_exists($migration, $direction)) {
    // legacy directional fallback (5.x only)
}
```

Bake templates (`skeleton`, `skeleton-anonymous`, `diff`, `snapshot`) now emit the matching `implements` clause for newly generated migrations.

A rector rule (`Migrations\Rector\AddMigrationCapabilityInterfaceRector`) is shipped for the upgrade — it walks every `BaseMigration` subclass in a user's `config/Migrations` folder and adds the right `implements` clause. Abstract bases and anonymous migration classes are both supported.

A dedicated upgrade guide at `docs/en/upgrades/upgrading-to-capability-interfaces.md` documents the motivation, per-app before/after examples, the rector-driven upgrade, manual residuals, and the 6.x direction.

## Framing note

- **Typo detection.** A user defining `function chnage()` still silently no-ops today; once 6.x promotes the PHPDoc method tags to real abstract methods this becomes a static error.
- **IDE and static analysis support.** Once narrowed via `instanceof`, IDEs and PHPStan resolve `change()` / `up()` / `down()` directly.
- **Semantic clarity.** A migration is either reversible or directional. Today both styles are dispatched through the same opaque `method_exists` lookup.
- **Custom runners** wrapping `MigrationInterface` no longer need reflection to figure out the migration style.

## Why marker interfaces with PHPDoc method tags only

This is the soft-window shape. Marker interfaces mean:

- No signature is forced on the implementer — `implements ReversibleMigrationInterface` works even on a migration whose `change()` has a non-matching signature. Zero BC pressure on existing code.
- Static analyzers and IDEs still resolve the methods via the PHPDoc tags once `instanceof` narrows the type.
- The 6.x step is mechanical: promote the method tags to real abstract method declarations and drop the `method_exists` fallback. The BC break in 6.x then only bites users who adopted the interface in 5.x but mistyped the method signature — a much smaller cohort than today's proposal.

## Per-app upgrade

For migrations defining `change()`:

```php
use Migrations\BaseMigration;
use Migrations\ReversibleMigrationInterface;

class CreateProducts extends BaseMigration implements ReversibleMigrationInterface
{
    public function change(): void { /* ... */ }
}
```

For migrations defining `up()` / `down()`:

```php
use Migrations\BaseMigration;
use Migrations\DirectionalMigrationInterface;

class BackfillOrderTotals extends BaseMigration implements DirectionalMigrationInterface
{
    public function up(): void { /* ... */ }
    public function down(): void { /* ... */ }
}
```

Or run rector once:

```bash
vendor/bin/rector process --config=rector.php
```

with a `rector.php` like:

```php
use Migrations\Rector\AddMigrationCapabilityInterfaceRector;
use Rector\Config\RectorConfig;

return RectorConfig::configure()
    ->withPaths([__DIR__ . '/config/Migrations'])
    ->withRules([AddMigrationCapabilityInterfaceRector::class]);
```

Full walkthrough including manual residuals (Phinx-style bases, dynamically generated classes, third-party plugins) is in the new upgrade guide.

## Forward direction (6.x)

A follow-up 6.x PR will:

- Promote the PHPDoc method tags on both interfaces to real abstract method declarations.
- Remove the `method_exists()` fallback in `Environment`.

Apps that ran rector during 5.x see the 6.x bump as a no-op for their migration files.

## Notes for reviewers

- The `Environment` dispatch order is `Reversible → Directional → legacy change → legacy up/down`. The directional interface check comes before the legacy `change` fallback so that a class implementing `DirectionalMigrationInterface` that *also* defines `change()` is dispatched via `up()`/`down()` — the interface declaration wins over method existence. Test coverage for this in `EnvironmentTest::testDirectionalInterfaceWinsOverChangeMethod`.
- All 43 comparison fixtures under `tests/comparisons/` were regenerated to match the new bake output. No content change beyond the new `implements` clause and matching `use` import.
- The PHPDoc method tags on the new interfaces are `void` returns. The 6.x abstract method declaration should match.
- The rector rule does not run as part of CI — it is upgrade tooling for downstream apps. It does respect abstract bases (so the interface propagates to leaves) and anonymous migration classes.
