### PR TITLE
Quote constraint name in MySQL DROP FOREIGN KEY statement

### DIFF
--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -1061,7 +1061,7 @@ class MysqlAdapter extends AbstractAdapter
     {
         $alter = sprintf(
             'DROP FOREIGN KEY %s',
-            $constraint,
+            $this->quoteColumnName($constraint),
         );
 
         return new AlterInstructions([$alter]);

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -1848,6 +1848,32 @@ class MysqlAdapterTest extends TestCase
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), [], 'ref_table_fk_2'));
     }
 
+    public function testDropForeignKeyWithNameContainingWhitespace(): void
+    {
+        $refTable = new Table('ref_table', [], $this->adapter);
+        $refTable->addColumn('field1', 'string')->save();
+
+        $table = new Table('table', [], $this->adapter);
+        $key = (new ForeignKey())
+            ->setName('ref table fk')
+            ->setColumns(['ref_table_id'])
+            ->setReferencedTable('ref_table')
+            ->setReferencedColumns(['id']);
+        $table
+            ->addColumn('ref_table_id', 'integer', ['signed' => false])
+            ->addForeignKey($key)
+            ->save();
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), [], 'ref table fk'));
+
+        // The constraint name must be quoted in the DROP statement, otherwise
+        // names with whitespace (or numeric names auto-assigned by MariaDB 12)
+        // produce invalid SQL.
+        $this->adapter->dropForeignKey($table->getName(), [], 'ref table fk');
+
+        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), [], 'ref table fk'));
+    }
+
     public static function nonExistentForeignKeyColumnsProvider(): array
     {
         return [


### PR DESCRIPTION
The MySQL adapter built `DROP FOREIGN KEY <name>` without quoting the constraint identifier. Whenever the name is not a bare identifier, the resulting SQL is invalid. Two cases hit this:

- **Whitespace in the name** — `DROP FOREIGN KEY my fk` is a syntax error (cakephp/phinx#924).
- **Numeric names** — MariaDB 12.x auto-assigns numeric names (`1`, `2`, …) to foreign keys created without an explicit name, so a later drop emits `DROP FOREIGN KEY 1`, which fails.

The fix quotes the identifier via `quoteColumnName()`, bringing the MySQL adapter in line with the Postgres and SQL Server adapters, which already quote the dropped constraint name.

### Relation to phinx

This ports the relevant part of cakephp/phinx#2413 to the builtin backend. The other parts of that phinx PR — guarding against PHP int-casting numeric array keys during foreign-key introspection — do **not** apply to the builtin backend:

- Foreign-key reflection is delegated to CakePHP core's `MysqlSchemaDialect::describeForeignKeys()`, which returns `array_values(...)` with the name preserved as a string in each entry.
- `getDropForeignKeyByColumnsInstructions()` already iterates by value and reads `$key['name']`, so it never relies on the (int-castable) array key.

Only the missing identifier quoting in `getDropForeignKeyInstructions()` remained, which this PR addresses.

Includes a regression test that creates a foreign key whose name contains whitespace and drops it by name; on the previous code it fails with a SQL syntax error.
