### PR TITLE
4.x - Add escaping to hasDatabase()

### DIFF
--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -984,8 +984,11 @@ class PostgresAdapter extends AbstractAdapter
      */
     public function hasDatabase(string $name): bool
     {
-        $sql = sprintf("SELECT count(*) FROM pg_database WHERE datname = '%s'", $this->quoteSchemaName($name));
-        $result = $this->fetchRow($sql);
+        $connection = $this->getConnection();
+        $result = $connection->execute(
+            'SELECT count(*) FROM pg_database WHERE datname = ?',
+            [$name]
+        )->fetch('assoc');
         if (!$result) {
             return false;
         }

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -984,7 +984,7 @@ class PostgresAdapter extends AbstractAdapter
      */
     public function hasDatabase(string $name): bool
     {
-        $sql = sprintf("SELECT count(*) FROM pg_database WHERE datname = '%s'", $name);
+        $sql = sprintf("SELECT count(*) FROM pg_database WHERE datname = '%s'", $this->quoteSchemaName($name));
         $result = $this->fetchRow($sql);
         if (!$result) {
             return false;

--- a/src/Db/Adapter/PostgresAdapter.php
+++ b/src/Db/Adapter/PostgresAdapter.php
@@ -987,7 +987,7 @@ class PostgresAdapter extends AbstractAdapter
         $connection = $this->getConnection();
         $result = $connection->execute(
             'SELECT count(*) FROM pg_database WHERE datname = ?',
-            [$name]
+            [$name],
         )->fetch('assoc');
         if (!$result) {
             return false;


### PR DESCRIPTION
We should escape this value to prevent it from being flagged by security researchers. 5.x is already ok, as we're using query builders in that branch.