### PR TITLE
Do not auto-increment composite primary key columns in bake migration

### DIFF
--- a/src/Util/ColumnParser.php
+++ b/src/Util/ColumnParser.php
@@ -46,6 +46,7 @@ class ColumnParser
     public function parseFields(array $arguments): array
     {
         $fields = [];
+        $primaryKeys = [];
         $arguments = $this->validArguments($arguments);
         foreach ($arguments as $field) {
             preg_match($this->regexpParseColumn, $field, $matches);
@@ -90,8 +91,20 @@ class ColumnParser
                 }
             }
 
+            if ($isPrimaryKey) {
+                $primaryKeys[] = $field;
+            }
+
             if ($isPrimaryKey && $type === 'integer') {
                 $fields[$field]['options']['autoIncrement'] = true;
+            }
+        }
+
+        // A composite primary key (e.g. a join table) must not auto-increment.
+        // Only a single integer primary key column gets auto-increment.
+        if (count($primaryKeys) > 1) {
+            foreach ($primaryKeys as $field) {
+                unset($fields[$field]['options']['autoIncrement']);
             }
         }
 

--- a/tests/TestCase/Util/ColumnParserTest.php
+++ b/tests/TestCase/Util/ColumnParserTest.php
@@ -227,6 +227,40 @@ class ColumnParserTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    /**
+     * A composite primary key (e.g. a join table) must not auto-increment its
+     * integer columns, otherwise MySQL rejects the table with
+     * "there can be only one auto column".
+     *
+     * @return void
+     */
+    public function testParseFieldsCompositePrimaryKey(): void
+    {
+        $expected = [
+            'article_id' => [
+                'columnType' => 'integer',
+                'options' => [
+                    'null' => false,
+                    'default' => null,
+                    'limit' => 11,
+                ],
+            ],
+            'tag_id' => [
+                'columnType' => 'integer',
+                'options' => [
+                    'null' => false,
+                    'default' => null,
+                    'limit' => 11,
+                ],
+            ],
+        ];
+        $actual = $this->columnParser->parseFields([
+            'article_id:integer:primary',
+            'tag_id:integer:primary',
+        ]);
+        $this->assertEquals($expected, $actual);
+    }
+
     public function testParseIndexes(): void
     {
         $this->assertEquals(['UNIQUE_ID' => [


### PR DESCRIPTION
## Problem

Baking a join-table migration with a composite integer primary key, as the docs recommend:

```bash
bin/cake bake migration CreateArticlesTags article_id:integer:primary tag_id:integer:primary created modified
```

generates `'autoIncrement' => true` on **both** primary key columns. MySQL then rejects the table:

```
SQLSTATE[42000]: Syntax error or access violation: 1075 Incorrect table definition;
there can be only one auto column and it must be defined as a key
```

Reported in cakephp/cakephp#19524.

## Fix

By convention only a single integer primary key auto-increments; a composite primary key (the normal shape for join tables) must not. `ColumnParser::parseFields()` now only emits `autoIncrement` when there is exactly one primary key column. Single-PK behavior is unchanged.

Added `testParseFieldsCompositePrimaryKey` covering the regression.

Resolves https://github.com/cakephp/migrations/issues/1096