### PR TITLE
Keep ON UPDATE clause when baking migrations

### DIFF
--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -373,6 +373,7 @@ class MigrationHelper extends Helper
             'after',
             'collate',
             'fixed',
+            'onUpdate',
         ]);
         $columnOptions = array_intersect_key($options, $wantedOptions);
         if (empty($columnOptions['comment'])) {
@@ -383,6 +384,9 @@ class MigrationHelper extends Helper
         }
         if (empty($columnOptions['collate'])) {
             unset($columnOptions['collate']);
+        }
+        if (empty($columnOptions['onUpdate'])) {
+            unset($columnOptions['onUpdate']);
         }
         // isset() returns false for null values, so this handles both missing and null cases
         if (!isset($columnOptions['fixed'])) {
@@ -404,6 +408,12 @@ class MigrationHelper extends Helper
             // Phinx uses 'collation' not 'collate'
             $columnOptions['collation'] = $columnOptions['collate'];
             unset($columnOptions['collate']);
+        }
+
+        if (!empty($columnOptions['onUpdate'])) {
+            // Phinx uses 'update' not 'onUpdate'
+            $columnOptions['update'] = $columnOptions['onUpdate'];
+            unset($columnOptions['onUpdate']);
         }
 
         // Handle precision/scale conversion between CakePHP's TableSchema format and SQL standard format.
@@ -491,6 +501,7 @@ class MigrationHelper extends Helper
             'signed', 'properties',
             'autoIncrement', 'unique',
             'collate', 'fixed',
+            'onUpdate',
         ];
 
         $attributes = [];
@@ -538,6 +549,10 @@ class MigrationHelper extends Helper
         $defaultCollation = $tableSchema->getOptions()['collation'] ?? null;
         if (empty($attributes['collate']) || $attributes['collate'] == $defaultCollation) {
             unset($attributes['collate']);
+        }
+
+        if (empty($attributes['onUpdate'])) {
+            unset($attributes['onUpdate']);
         }
 
         ksort($attributes);

--- a/tests/TestCase/Command/BakeMigrationSnapshotCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationSnapshotCommandTest.php
@@ -392,4 +392,25 @@ class BakeMigrationSnapshotCommandTest extends TestCase
         $this->runSnapshotTest('WithNonDefaultCollation', '-p SimpleSnapshot');
         $connection->execute('ALTER TABLE events MODIFY title VARCHAR(255)');
     }
+
+    /**
+     * Tests that an ON UPDATE clause is kept in the initial snapshot.
+     */
+    public function testSnapshotWithOnUpdate(): void
+    {
+        $this->skipIf(env('DB') !== 'mysql');
+        $this->loadPlugins(['SimpleSnapshot']);
+
+        $this->migrationPath = ROOT . DS . 'Plugin' . DS . 'SimpleSnapshot' . DS . 'config' . DS . 'Migrations' . DS;
+
+        $connection = ConnectionManager::get('test');
+        assert($connection instanceof Connection);
+
+        $connection->execute('ALTER TABLE users MODIFY updated TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP');
+        try {
+            $this->runSnapshotTest('WithOnUpdate', '-p SimpleSnapshot');
+        } finally {
+            $connection->execute('ALTER TABLE users MODIFY updated TIMESTAMP NULL DEFAULT NULL');
+        }
+    }
 }

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -460,6 +460,49 @@ class MigrationHelperTest extends TestCase
     }
 
     /**
+     * Test that getColumnOption converts onUpdate to update
+     *
+     * CakePHP reflects `ON UPDATE` clauses as 'onUpdate', but Phinx uses the
+     * 'update' column option, so this must be converted for the clause to
+     * survive a snapshot.
+     */
+    public function testGetColumnOptionConvertsOnUpdateToUpdate(): void
+    {
+        $options = [
+            'null' => true,
+            'default' => null,
+            'onUpdate' => 'CURRENT_TIMESTAMP',
+        ];
+
+        $result = $this->helper->getColumnOption($options);
+
+        $this->assertArrayNotHasKey('onUpdate', $result, 'onUpdate should be converted to update');
+        $this->assertArrayHasKey('update', $result, 'update should be set from onUpdate value');
+        $this->assertSame('CURRENT_TIMESTAMP', $result['update']);
+    }
+
+    /**
+     * Test that getColumnOption removes null onUpdate
+     *
+     * Column::toArray() always emits an 'onUpdate' key, so columns without an
+     * `ON UPDATE` clause carry a null. Column::setUpdate() is not nullable, so
+     * passing it through would be a TypeError.
+     */
+    public function testGetColumnOptionRemovesNullOnUpdate(): void
+    {
+        $options = [
+            'null' => true,
+            'default' => null,
+            'onUpdate' => null,
+        ];
+
+        $result = $this->helper->getColumnOption($options);
+
+        $this->assertArrayNotHasKey('onUpdate', $result, 'onUpdate => null should be removed');
+        $this->assertArrayNotHasKey('update', $result, 'update should not be set when onUpdate is null');
+    }
+
+    /**
      * Test that getColumnOption includes the fixed option for binary columns
      */
     public function testGetColumnOptionIncludesFixed(): void

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -381,6 +381,57 @@ class MigrationHelperTest extends TestCase
         $this->assertEquals($attributes, $result);
     }
 
+    /**
+     * Test that attributes() preserves the onUpdate attribute
+     *
+     * `onUpdate` is a first-class column key in CakePHP's TableSchema for datetime
+     * and timestamp types, so attributes() must not filter it out. The schema is
+     * built by hand rather than reflected so this holds for every driver.
+     */
+    public function testAttributesPreservesOnUpdate(): void
+    {
+        $tableSchema = new TableSchema('on_update_columns');
+        $tableSchema->addColumn('modified', [
+            'type' => 'datetime',
+            'null' => false,
+            'onUpdate' => 'CURRENT_TIMESTAMP',
+        ]);
+        $tableSchema->addColumn('plain', [
+            'type' => 'datetime',
+            'null' => true,
+        ]);
+
+        $modified = $this->helper->attributes($tableSchema, 'modified');
+        $this->assertArrayHasKey('onUpdate', $modified, 'onUpdate should survive attributes()');
+        $this->assertSame('CURRENT_TIMESTAMP', $modified['onUpdate']);
+
+        $plain = $this->helper->attributes($tableSchema, 'plain');
+        $this->assertArrayNotHasKey('onUpdate', $plain, 'columns without ON UPDATE should not gain the key');
+    }
+
+    /**
+     * Test that a column with an ON UPDATE clause bakes the Phinx `update` option
+     *
+     * Guards the whole snapshot path: attributes() must preserve `onUpdate` and
+     * getColumnOption() must translate it to Phinx's `update` option. Either half
+     * regressing silently drops the clause from generated migrations.
+     */
+    public function testColumnsRendersOnUpdateAsUpdateOption(): void
+    {
+        $tableSchema = new TableSchema('on_update_columns');
+        $tableSchema->addColumn('modified', [
+            'type' => 'datetime',
+            'null' => false,
+            'onUpdate' => 'CURRENT_TIMESTAMP',
+        ]);
+
+        $columns = $this->helper->columns($tableSchema);
+        $options = $this->helper->getColumnOption($columns['modified']['options']);
+
+        $this->assertArrayNotHasKey('onUpdate', $options);
+        $this->assertSame('CURRENT_TIMESTAMP', $options['update']);
+    }
+
     public function testStringifyList(): void
     {
         $this->assertSame('', $this->helper->stringifyList([]));

--- a/tests/comparisons/Migration/test_snapshot_with_on_update.php
+++ b/tests/comparisons/Migration/test_snapshot_with_on_update.php
@@ -1,0 +1,387 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+class TestSnapshotWithOnUpdate extends BaseMigration
+{
+    /**
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/migrations/5/guides/writing-migrations/migration-methods.html#the-up-method
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        $this->table('articles')
+            ->addColumn('title', 'string', [
+                'comment' => 'Article title',
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('category_id')
+                    ->setName('articles_category_fk')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('articles_title_idx')
+            )
+            ->create();
+
+        $this->table('categories')
+            ->addColumn('parent_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']])
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => '',
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->create();
+
+        $this->table('events')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('published', 'string', [
+                'default' => 'N',
+                'limit' => 1,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('orders')
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addIndex(
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
+            )
+            ->create();
+
+        $this->table('parts')
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('number', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->create();
+
+        $this->table('products')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('products_title_idx')
+                    ->setType('fulltext')
+            )
+            ->create();
+
+        $this->table('special_pks', ['id' => false, 'primary_key' => ['id']])
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('special_tags')
+            ->addColumn('article_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('author_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('tag_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('highlighted', 'boolean', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('highlighted_time', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('texts', ['id' => false])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('users')
+            ->addColumn('username', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('password', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('updated', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'update' => 'CURRENT_TIMESTAMP',
+            ])
+            ->create();
+
+        $this->table('articles')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
+            )
+            ->update();
+
+        $this->table('orders')
+            ->addForeignKey(
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
+                    ->setName('orders_product_fk')
+            )
+            ->update();
+
+        $this->table('products')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
+                    ->setName('products_category_fk')
+            )
+            ->update();
+    }
+
+    /**
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/migrations/5/guides/writing-migrations/migration-methods.html#the-down-method
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        $this->table('articles')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
+        $this->table('orders')
+            ->dropForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ]
+            )->save();
+
+        $this->table('products')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
+        $this->table('articles')->drop()->save();
+        $this->table('categories')->drop()->save();
+        $this->table('composite_pks')->drop()->save();
+        $this->table('events')->drop()->save();
+        $this->table('orders')->drop()->save();
+        $this->table('parts')->drop()->save();
+        $this->table('products')->drop()->save();
+        $this->table('special_pks')->drop()->save();
+        $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
+        $this->table('users')->drop()->save();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1102.

`bake migration_snapshot` dropped `ON UPDATE CURRENT_TIMESTAMP` from `datetime` / `timestamp` columns. CakePHP core reflects the clause correctly as an `onUpdate` column attribute; `MigrationHelper` filtered it out before it reached the template, so databases rebuilt from a snapshot silently lost the clause.

This lets the attribute through both of the helper's allowlists and translates it to Phinx's `update` column option at render time.

Verified end-to-end against real MySQL by baking a snapshot of a table with an `ON UPDATE` column, applying the generated migration to a fresh database, and reading back the DDL

## Major Changes

- `MigrationHelper::attributes()` — add `onUpdate` to `$validOptions` so the attribute survives the snapshot path, and drop it when empty so columns without the clause do not gain a null key.
- `MigrationHelper::getColumnOption()` — add `onUpdate` to `$wantedOptions`, drop it when empty, and translate it to Phinx's `update` option.

Both follow the pattern established by `fixed` (#1014, added to both allowlists; #1048, filtering the null case) and by the existing `collate` to `collation` translation in `getColumnOption()`.

## Minor Changes

- The empty-value guard is load-bearing rather than defensive. `Column::toArray()` always emits an `onUpdate` key (null when the column has no clause) and the diff path feeds those arrays straight into `getColumnOption()`, while `Column::setUpdate()` is typed `string`. Passing the null through would render `'update' => null` into generated migrations and fail. `Table::addTimestamps()` also uses `'update' => ''` to mean "no clause", and core's `columnSql()` guards on `!== ''`, so `empty()` is the correct test.

## Backwards Compatibility Notes

Fully backwards compatible. Both changed methods are public, but the change is **additive only** — a key appears solely for MySQL `datetime` / `timestamp` columns that genuinely carry an `ON UPDATE` clause. No key is removed or renamed, no existing output shape changes, and userland bake templates are unaffected. Existing migration files are untouched.