### PR TITLE
Render table level options when baking tables

### DIFF
--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -37,6 +37,11 @@ class MysqlAdapter extends AbstractAdapter
     protected const IDENTIFIER_MAX_LENGTH = 64;
 
     /**
+     * The storage engine applied to tables that do not specify one.
+     */
+    public const DEFAULT_ENGINE = 'InnoDB';
+
+    /**
      * @var string[]
      */
     protected static array $specificColumnTypes = [
@@ -285,7 +290,7 @@ class MysqlAdapter extends AbstractAdapter
     {
         // This method is based on the MySQL docs here: https://dev.mysql.com/doc/refman/5.1/en/create-index.html
         $defaultOptions = [
-            'engine' => 'InnoDB',
+            'engine' => self::DEFAULT_ENGINE,
         ];
 
         $collation = Configure::read('Migrations.default_collation');

--- a/src/View/Helper/MigrationHelper.php
+++ b/src/View/Helper/MigrationHelper.php
@@ -41,6 +41,20 @@ class MigrationHelper extends Helper
     protected array $schemas = [];
 
     /**
+     * Cached default collation of the database being baked from.
+     *
+     * @var string|null
+     */
+    protected ?string $defaultCollation = null;
+
+    /**
+     * Whether the default collation has already been resolved.
+     *
+     * @var bool
+     */
+    protected bool $defaultCollationResolved = false;
+
+    /**
      * Stores the status of the ``$this->table()`` statements issued while baking.
      * It helps prevent duplicate calls in case of complex conditions
      *
@@ -543,6 +557,111 @@ class MigrationHelper extends Helper
         ksort($attributes);
 
         return $attributes;
+    }
+
+    /**
+     * Returns the table level options to render in a ``$this->table()`` statement.
+     *
+     * Only options that would not be applied anyway when the migration runs are returned.
+     * Rendering a collation that already matches the database default would pin a
+     * server specific collation into the snapshot, so those are left out and the target
+     * server gets to apply its own default.
+     *
+     * Table options are only reflected for MySQL, other drivers report none.
+     *
+     * @param \Cake\Database\Schema\TableSchemaInterface|string $table Name of the table to retrieve options for
+     *  or a table schema object.
+     * @return array<string, mixed>
+     */
+    public function tableOptions(TableSchemaInterface|string $table): array
+    {
+        $tableSchema = $table;
+        if (!($tableSchema instanceof TableSchemaInterface)) {
+            $tableSchema = $this->schema($tableSchema);
+        }
+
+        $schemaOptions = $tableSchema->getOptions();
+        $options = [];
+
+        $collation = $schemaOptions['collation'] ?? null;
+        if ($collation && $collation !== $this->defaultCollation()) {
+            $options['collation'] = $collation;
+        }
+
+        $engine = $schemaOptions['engine'] ?? null;
+        if ($engine && $engine !== MysqlAdapter::DEFAULT_ENGINE) {
+            $options['engine'] = $engine;
+        }
+
+        return $options;
+    }
+
+    /**
+     * Returns the collation the database applies to tables that do not specify one.
+     *
+     * @return string|null
+     */
+    protected function defaultCollation(): ?string
+    {
+        if ($this->defaultCollationResolved) {
+            return $this->defaultCollation;
+        }
+        $this->defaultCollationResolved = true;
+
+        $configured = Configure::read('Migrations.default_collation');
+        if ($configured) {
+            $this->defaultCollation = (string)$configured;
+
+            return $this->defaultCollation;
+        }
+
+        $connection = $this->getConfig('connection');
+        assert($connection instanceof Connection);
+        if (!($connection->getDriver() instanceof Mysql)) {
+            return $this->defaultCollation;
+        }
+
+        $row = $connection->selectQuery()
+            ->select(['DEFAULT_COLLATION_NAME'])
+            ->from('INFORMATION_SCHEMA.SCHEMATA')
+            ->where(['SCHEMA_NAME' => $connection->config()['database']])
+            ->execute()
+            ->fetch('assoc');
+
+        if ($row) {
+            $this->defaultCollation = $row['DEFAULT_COLLATION_NAME'];
+        }
+
+        return $this->defaultCollation;
+    }
+
+    /**
+     * Returns the table options converted into a formatted single line string
+     *
+     * Unlike ``stringifyList()`` this keeps the options on one line, preserves insertion
+     * order so the primary key options keep leading the list, and omits the trailing comma.
+     * Sorting them like ``stringifyList()`` does would reorder the arguments of every
+     * existing ``$this->table()`` statement.
+     *
+     * @param array<string, mixed> $options The table options to stringify.
+     * @return string
+     */
+    public function stringifyTableOptions(array $options): string
+    {
+        $stringified = [];
+        foreach ($options as $name => $value) {
+            if (is_array($value)) {
+                $value = sprintf('[%s]', implode(', ', array_map(
+                    fn(mixed $item): string => (string)$this->value($item, true),
+                    $value,
+                )));
+            } else {
+                $value = (string)$this->value($value, true);
+            }
+            $stringified[] = sprintf("'%s' => %s", $name, $value);
+        }
+
+        return implode(', ', $stringified);
     }
 
     /**

--- a/templates/bake/element/create-tables.twig
+++ b/templates/bake/element/create-tables.twig
@@ -6,13 +6,17 @@
     {%~ set primaryKeysColumns = Migration.primaryKeysColumnsList(tableArgForMethods) %}
     {%~ set primaryKeys = Migration.primaryKeys(tableArgForMethods) %}
     {%~ set specialPk = primaryKeys and (primaryKeys|length > 1 or primaryKeys[0]['name'] != 'id' or primaryKeys[0]['info']['columnType'] != 'integer') and autoId %}
+    {%~ set tableOptions = Migration.tableOptions(tableArgForMethods) %}
+    {%~ if specialPk %}
+        {%~ set tableOptions = {'id': false, 'primary_key': Migration.extract(primaryKeys)}|merge(tableOptions) %}
+    {%~ elseif not primaryKeys and autoId %}
+        {%~ set tableOptions = {'id': false}|merge(tableOptions) %}
+    {%~ endif %}
     {%~ if loop.index > 1 %}
 
     {%~ endif -%}
-    {%~ if specialPk %}
-        $this->table('{{ tableArgForArray }}', ['id' => false, 'primary_key' => ['{{ Migration.extract(primaryKeys)|join("', '")|raw }}']])
-    {%~ elseif not primaryKeys and autoId %}
-        $this->table('{{ tableArgForArray }}', ['id' => false])
+    {%~ if tableOptions is not empty %}
+        $this->table('{{ tableArgForArray }}', [{{ Migration.stringifyTableOptions(tableOptions)|raw }}])
     {%~ else %}
         $this->table('{{ tableArgForArray }}')
     {%~ endif %}

--- a/tests/TestCase/Command/BakeMigrationSnapshotCommandTest.php
+++ b/tests/TestCase/Command/BakeMigrationSnapshotCommandTest.php
@@ -392,4 +392,39 @@ class BakeMigrationSnapshotCommandTest extends TestCase
         $this->runSnapshotTest('WithNonDefaultCollation', '-p SimpleSnapshot');
         $connection->execute('ALTER TABLE events MODIFY title VARCHAR(255)');
     }
+
+    /**
+     * Tests that non default table options are used in the initial snapshot.
+     *
+     * Tables that carry a collation or engine differing from the defaults must have
+     * them rendered, otherwise the snapshot recreates them with the connection defaults.
+     */
+    public function testSnapshotWithNonDefaultTableOptions(): void
+    {
+        $this->skipIf(env('DB') !== 'mysql');
+        $this->loadPlugins(['SimpleSnapshot']);
+
+        $this->migrationPath = ROOT . DS . 'Plugin' . DS . 'SimpleSnapshot' . DS . 'config' . DS . 'Migrations' . DS;
+
+        $connection = ConnectionManager::get('test');
+        assert($connection instanceof Connection);
+
+        $default = $connection
+            ->execute('SELECT @@character_set_database AS charset, @@collation_database AS collation')
+            ->fetch('assoc');
+
+        $connection->execute('ALTER TABLE events CONVERT TO CHARACTER SET utf8 COLLATE utf8mb3_hungarian_ci');
+        $connection->execute('ALTER TABLE parts ENGINE=MyISAM');
+
+        try {
+            $this->runSnapshotTest('WithNonDefaultTableOptions', '-p SimpleSnapshot');
+        } finally {
+            $connection->execute('ALTER TABLE parts ENGINE=InnoDB');
+            $connection->execute(sprintf(
+                'ALTER TABLE events CONVERT TO CHARACTER SET %s COLLATE %s',
+                $default['charset'],
+                $default['collation'],
+            ));
+        }
+    }
 }

--- a/tests/TestCase/MigrationsTest.php
+++ b/tests/TestCase/MigrationsTest.php
@@ -1151,6 +1151,7 @@ class MigrationsTest extends TestCase
                 [$path, 'test_snapshot_with_auto_id_incompatible_signed_primary_keys'],
                 [$path, 'test_snapshot_with_auto_id_incompatible_unsigned_primary_keys', ['unsigned_primary_keys' => false]],
                 [$path, 'test_snapshot_with_non_default_collation'],
+                [$path, 'test_snapshot_with_non_default_table_options'],
             ];
         }
 

--- a/tests/TestCase/View/Helper/MigrationHelperTest.php
+++ b/tests/TestCase/View/Helper/MigrationHelperTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
  */
 namespace Migrations\Test\TestCase\View\Helper;
 
+use Cake\Core\Configure;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Schema\Collection;
@@ -527,5 +528,85 @@ class MigrationHelperTest extends TestCase
         $result = $this->helper->getColumnOption($options);
 
         $this->assertSame(255, $result['limit']);
+    }
+
+    /**
+     * Test that table options the adapter would apply anyway are not rendered
+     */
+    public function testTableOptionsOmitsDefaults(): void
+    {
+        Configure::write('Migrations.default_collation', 'utf8mb4_general_ci');
+
+        $schema = new TableSchema('events');
+        $schema->addColumn('id', ['type' => 'integer']);
+        $schema->setOptions([
+            'collation' => 'utf8mb4_general_ci',
+            'engine' => MysqlAdapter::DEFAULT_ENGINE,
+        ]);
+
+        $this->assertSame([], $this->helper->tableOptions($schema));
+
+        Configure::delete('Migrations.default_collation');
+    }
+
+    /**
+     * Test that table options differing from the defaults are rendered
+     */
+    public function testTableOptionsIncludesNonDefaults(): void
+    {
+        Configure::write('Migrations.default_collation', 'utf8mb4_general_ci');
+
+        $schema = new TableSchema('events');
+        $schema->addColumn('id', ['type' => 'integer']);
+        $schema->setOptions([
+            'collation' => 'utf8_hungarian_ci',
+            'engine' => 'MyISAM',
+        ]);
+
+        $this->assertSame(
+            ['collation' => 'utf8_hungarian_ci', 'engine' => 'MyISAM'],
+            $this->helper->tableOptions($schema),
+        );
+
+        Configure::delete('Migrations.default_collation');
+    }
+
+    /**
+     * Test that drivers reflecting no table options render none
+     */
+    public function testTableOptionsWithoutReflectedOptions(): void
+    {
+        $schema = new TableSchema('events');
+        $schema->addColumn('id', ['type' => 'integer']);
+
+        $this->assertSame([], $this->helper->tableOptions($schema));
+    }
+
+    /**
+     * Test that table options are rendered inline, in insertion order
+     */
+    public function testStringifyTableOptions(): void
+    {
+        $this->assertSame('', $this->helper->stringifyTableOptions([]));
+
+        $this->assertSame(
+            "'id' => false, 'primary_key' => ['id', 'name'], 'collation' => 'utf8_hungarian_ci'",
+            $this->helper->stringifyTableOptions([
+                'id' => false,
+                'primary_key' => ['id', 'name'],
+                'collation' => 'utf8_hungarian_ci',
+            ]),
+        );
+    }
+
+    /**
+     * Test that quotes in a value cannot break out of the generated statement
+     */
+    public function testStringifyTableOptionsEscapesQuotes(): void
+    {
+        $this->assertSame(
+            "'primary_key' => ['it\\'s']",
+            $this->helper->stringifyTableOptions(['primary_key' => ["it's"]]),
+        );
     }
 }

--- a/tests/comparisons/Migration/test_snapshot_with_non_default_table_options.php
+++ b/tests/comparisons/Migration/test_snapshot_with_non_default_table_options.php
@@ -1,0 +1,386 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+class TestSnapshotWithNonDefaultTableOptions extends BaseMigration
+{
+    /**
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/migrations/5/guides/writing-migrations/migration-methods.html#the-up-method
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        $this->table('articles')
+            ->addColumn('title', 'string', [
+                'comment' => 'Article title',
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('note', 'string', [
+                'default' => '7.4',
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('counter', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('active', 'boolean', [
+                'default' => false,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('category_id')
+                    ->setName('articles_category_fk')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('articles_title_idx')
+            )
+            ->create();
+
+        $this->table('categories')
+            ->addColumn('parent_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('categories_slug_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('composite_pks', ['id' => false, 'primary_key' => ['id', 'name']])
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => '',
+                'limit' => 10,
+                'null' => false,
+            ])
+            ->create();
+
+        $this->table('events', ['collation' => 'utf8_hungarian_ci'])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('published', 'string', [
+                'default' => 'N',
+                'limit' => 1,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('orders')
+            ->addColumn('product_category', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('product_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addIndex(
+                $this->index([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setName('orders_product_category_idx')
+            )
+            ->create();
+
+        $this->table('parts', ['engine' => 'MyISAM'])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('number', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->create();
+
+        $this->table('products')
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('slug', 'string', [
+                'default' => null,
+                'limit' => 100,
+                'null' => true,
+            ])
+            ->addColumn('category_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('modified', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('slug')
+                    ->setName('products_slug_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setName('products_category_unique')
+                    ->setType('unique')
+            )
+            ->addIndex(
+                $this->index('title')
+                    ->setName('products_title_idx')
+                    ->setType('fulltext')
+            )
+            ->create();
+
+        $this->table('special_pks', ['id' => false, 'primary_key' => ['id']])
+            ->addColumn('id', 'uuid', [
+                'default' => 'a4950df3-515f-474c-be4c-6a027c1957e7',
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('name', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('special_tags')
+            ->addColumn('article_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('author_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('tag_id', 'integer', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('highlighted', 'boolean', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('highlighted_time', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                $this->index('article_id')
+                    ->setName('special_tags_article_unique')
+                    ->setType('unique')
+            )
+            ->create();
+
+        $this->table('texts', ['id' => false])
+            ->addColumn('title', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('description', 'text', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('users')
+            ->addColumn('username', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('password', 'string', [
+                'default' => null,
+                'limit' => 256,
+                'null' => true,
+            ])
+            ->addColumn('created', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addColumn('updated', 'timestamp', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+
+        $this->table('articles')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setDelete('NO_ACTION')
+                    ->setUpdate('NO_ACTION')
+                    ->setName('articles_category_fk')
+            )
+            ->update();
+
+        $this->table('orders')
+            ->addForeignKey(
+                $this->foreignKey([
+                        'product_category',
+                        'product_id',
+                    ])
+                    ->setReferencedTable('products')
+                    ->setReferencedColumns([
+                        'category_id',
+                        'id',
+                    ])
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
+                    ->setName('orders_product_fk')
+            )
+            ->update();
+
+        $this->table('products')
+            ->addForeignKey(
+                $this->foreignKey('category_id')
+                    ->setReferencedTable('categories')
+                    ->setReferencedColumns('id')
+                    ->setDelete('CASCADE')
+                    ->setUpdate('CASCADE')
+                    ->setName('products_category_fk')
+            )
+            ->update();
+    }
+
+    /**
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/migrations/5/guides/writing-migrations/migration-methods.html#the-down-method
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        $this->table('articles')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
+        $this->table('orders')
+            ->dropForeignKey(
+                [
+                    'product_category',
+                    'product_id',
+                ]
+            )->save();
+
+        $this->table('products')
+            ->dropForeignKey(
+                'category_id'
+            )->save();
+
+        $this->table('articles')->drop()->save();
+        $this->table('categories')->drop()->save();
+        $this->table('composite_pks')->drop()->save();
+        $this->table('events')->drop()->save();
+        $this->table('orders')->drop()->save();
+        $this->table('parts')->drop()->save();
+        $this->table('products')->drop()->save();
+        $this->table('special_pks')->drop()->save();
+        $this->table('special_tags')->drop()->save();
+        $this->table('texts')->drop()->save();
+        $this->table('users')->drop()->save();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1104.

`templates/bake/element/create-tables.twig` emitted only the primary key portion of the table options array, so the `collation` and `engine` reflected onto the `TableSchema` were dropped. A table created with a non-default collation or engine was regenerated **using the connection defaults** instead of its real ones.

This renders those options from the reflected schema. An option is only printed when leaving it out would change the table: if a table's collation or engine already matches what the migration would produce without it, printing it is redundant, so it is omitted.

## Major Changes

- **`MigrationHelper::tableOptions()`** — returns the reflected table options, minus any that `MysqlAdapter::createTable()` would apply on its own. It resolves the same two defaults the adapter does: `engine` falls back to `MysqlAdapter::DEFAULT_ENGINE`, while `collation` falls back to `Migrations.default_collation` when that is configured, and otherwise to the database's own default collation (resolved once and cached). Comparing against the wrong default would omit an option the migration then silently changes.
- **`MigrationHelper::stringifyTableOptions()`** — renders the options array inline. 
  - **NOTE:**`stringifyList()` cannot be reused here: it sorts the array, indents across multiple lines, and appends a trailing comma, which would reorder the arguments of every existing `$this->table()` statement. Table options are an ordered list, so `id` and `primary_key` keep leading it and existing output stays byte-identical.
- **`create-tables.twig`** — merges the table options into the `$this->table()` options array.

## Minor Changes

- **`MysqlAdapter::DEFAULT_ENGINE`** — the default engine was inlined in `createTable()`. Promoted to a constant so the bake helper and the adapter share one source of truth for which engine is applied when a table does not specify one.
- `create-tables.twig` is also rendered by `diff.twig`, so a diff that adds a table now carries its collation and engine as well.

## Backwards Compatibility Notes

Fully backwards compatible. The changes are additive: one new public constant on `MysqlAdapter` and two new public methods on `MigrationHelper`. No signatures changed.

Baked output is unchanged for any table whose collation and engine match the defaults — every existing comparison fixture passes untouched.

`encoding` is not rendered as a separate option: `MysqlAdapter::createTable()` derives `CHARACTER SET` from the collation prefix, so rendering `collation` restores the charset as well.

Table options are reflected for MySQL only; the other dialects return `[]` from `describeOptions()`, so their output is unaffected.
