### PR TITLE
Fix test suite and static analysis with CakePHP 5.4

### DIFF
--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -29,9 +29,6 @@ use Throwable;
  */
 class MigrateCommand extends Command
 {
-    /**
-     * @use \Cake\Event\EventDispatcherTrait<\Migrations\Command\MigrateCommand>
-     */
     use EventDispatcherTrait;
 
     /**

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -34,9 +34,6 @@ use Throwable;
  */
 class ResetCommand extends Command
 {
-    /**
-     * @use \Cake\Event\EventDispatcherTrait<\Migrations\Command\ResetCommand>
-     */
     use EventDispatcherTrait;
 
     /**

--- a/src/Command/RollbackCommand.php
+++ b/src/Command/RollbackCommand.php
@@ -30,9 +30,6 @@ use Throwable;
  */
 class RollbackCommand extends Command
 {
-    /**
-     * @use \Cake\Event\EventDispatcherTrait<\Migrations\Command\MigrateCommand>
-     */
     use EventDispatcherTrait;
 
     /**

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -28,9 +28,6 @@ use Throwable;
  */
 class SeedCommand extends Command
 {
-    /**
-     * @use \Cake\Event\EventDispatcherTrait<\Migrations\Command\MigrateCommand>
-     */
     use EventDispatcherTrait;
 
     /**

--- a/tests/TestCase/Command/EntryCommandTest.php
+++ b/tests/TestCase/Command/EntryCommandTest.php
@@ -56,6 +56,9 @@ class EntryCommandTest extends TestCase
         $this->exec('migrations derp');
 
         $this->assertExitError();
-        $this->assertErrorContains('Could not find migrations command named `derp`');
+        // CakePHP >= 5.4 rejects unknown subcommands before they reach EntryCommand,
+        // so only the parts both error messages have in common are asserted.
+        $this->assertErrorContains('derp');
+        $this->assertErrorContains('--help');
     }
 }


### PR DESCRIPTION
CakePHP 5.4.0 broke the 5.x build; this restores it.

- `Cake\Event\EventDispatcherTrait` is no longer generic, so the four `use` tag annotations in the command classes now fail PHPStan with `generics.notGeneric`.
- Unknown subcommands are rejected by the console runner before they reach `EntryCommand`, so `migrations derp` now errors with ``Unknown command `cake migrations derp`.`` instead of ``Could not find migrations command named `derp`.``. Since the plugin supports `^5.3.0`, the test only asserts the parts both messages have in common.

`EntryCommand::execute()` still produces its own message on 5.3 and is left untouched.
