### PR TITLE
Add command descriptions to migration commands

### DIFF
--- a/src/Command/BakeMigrationDiffCommand.php
+++ b/src/Command/BakeMigrationDiffCommand.php
@@ -105,6 +105,14 @@ class BakeMigrationDiffCommand extends BakeSimpleMigrationCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create a migration containing the difference between the current schema and migration state.';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public static function defaultName(): string
     {
         return 'bake migration_diff';

--- a/src/Command/BakeMigrationSnapshotCommand.php
+++ b/src/Command/BakeMigrationSnapshotCommand.php
@@ -40,6 +40,14 @@ class BakeMigrationSnapshotCommand extends BakeSimpleMigrationCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create a migration snapshot of the current schema.';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public static function defaultName(): string
     {
         return 'bake migration_snapshot';

--- a/src/Command/BakeSeedCommand.php
+++ b/src/Command/BakeSeedCommand.php
@@ -45,6 +45,14 @@ class BakeSeedCommand extends SimpleBakeCommand
     /**
      * @inheritDoc
      */
+    public static function getDescription(): string
+    {
+        return 'Create a migration seed.';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public static function defaultName(): string
     {
         return 'bake seed';

--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -33,6 +33,14 @@ class DumpCommand extends Command
     protected string $connection;
 
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Create a migration state dump file.';
+    }
+
+    /**
      * The default name added to the application command list
      *
      * @return string

--- a/src/Command/MarkMigratedCommand.php
+++ b/src/Command/MarkMigratedCommand.php
@@ -27,6 +27,14 @@ use Migrations\Migration\ManagerFactory;
 class MarkMigratedCommand extends Command
 {
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Mark one or more migrations as run.';
+    }
+
+    /**
      * The default name added to the application command list
      *
      * @return string

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -32,6 +32,14 @@ class MigrateCommand extends Command
     use EventDispatcherTrait;
 
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Run un-applied migrations.';
+    }
+
+    /**
      * The default name added to the application command list
      *
      * @return string

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -37,6 +37,14 @@ class ResetCommand extends Command
     use EventDispatcherTrait;
 
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Reset database state by dropping tables, and re-running migrations.';
+    }
+
+    /**
      * The default name added to the application command list
      *
      * @return string

--- a/src/Command/RollbackCommand.php
+++ b/src/Command/RollbackCommand.php
@@ -33,6 +33,14 @@ class RollbackCommand extends Command
     use EventDispatcherTrait;
 
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Rollback reversible migrations.';
+    }
+
+    /**
      * The default name added to the application command list
      *
      * @return string

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -31,6 +31,14 @@ class SeedCommand extends Command
     use EventDispatcherTrait;
 
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Run migration seeds.';
+    }
+
+    /**
      * The default name added to the application command list
      *
      * @return string

--- a/src/Command/SeedResetCommand.php
+++ b/src/Command/SeedResetCommand.php
@@ -27,6 +27,14 @@ use Migrations\Util\Util;
 class SeedResetCommand extends Command
 {
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Reset the seed execution state.';
+    }
+
+    /**
      * The default name added to the application command list
      *
      * @return string

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -43,6 +43,14 @@ class StatusCommand extends Command
     public const CODE_STATUS_DOWN = 3;
 
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Display the state of migrations.';
+    }
+
+    /**
      * The default name added to the application command list
      *
      * @return string

--- a/src/Command/UpgradeCommand.php
+++ b/src/Command/UpgradeCommand.php
@@ -36,6 +36,14 @@ use Migrations\Migration\ManagerFactory;
 class UpgradeCommand extends Command
 {
     /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Upgrade migration storage to use <info>cake_migrations</info>.';
+    }
+
+    /**
      * The default name added to the application command list
      *
      * @return string


### PR DESCRIPTION
This improves the output of `cake` with no parameters.