### PR TITLE
Pin action image and reduce permissions

### DIFF
--- a/.github/workflows/deploy_docs_3x.yml
+++ b/.github/workflows/deploy_docs_3x.yml
@@ -7,6 +7,9 @@ on:
       - 3.x
   workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -17,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Push to dokku
-        uses: dokku/github-action@master
+        uses: dokku/github-action@cc7dec1d2b9fed249a14ae462bc953bba436f78c # v1.10.0
         with:
           git_remote_url: 'ssh://dokku@apps.cakephp.org:22/migrations-docs-3'
           ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}

--- a/.github/workflows/deploy_docs_4x.yml
+++ b/.github/workflows/deploy_docs_4x.yml
@@ -7,6 +7,9 @@ on:
       - 4.x
   workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -17,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Push to dokku
-        uses: dokku/github-action@master
+        uses: dokku/github-action@cc7dec1d2b9fed249a14ae462bc953bba436f78c # v1.10.0
         with:
           git_remote_url: 'ssh://dokku@apps.cakephp.org:22/migrations-docs-4'
           ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}

--- a/.github/workflows/deploy_docs_5x.yml
+++ b/.github/workflows/deploy_docs_5x.yml
@@ -7,6 +7,9 @@ on:
       - 5.x
   workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -17,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Push to dokku
-        uses: dokku/github-action@master
+        uses: dokku/github-action@cc7dec1d2b9fed249a14ae462bc953bba436f78c # v1.10.0
         with:
           git_remote_url: 'ssh://dokku@apps.cakephp.org:22/migrations-docs-5'
           ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
Pin the image revision used for dokku deployments and reduce permissions for deploy jobs. Pinning the image revision reduces the chances of supply chain attacks on images with access to real credentials.

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/migrations/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.