### PR TITLE
Emit CHARACTER SET for columns with an explicit encoding

### DIFF
--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -466,8 +466,7 @@ class MysqlAdapter extends AbstractAdapter
      *
      * This method provides backwards compatibility for enum and set types
      * as userland migrations use those types, but they are not supported
-     * in cakephp/database. The `encoding` option is handled here for the
-     * same reason: cakephp/database has no per-column character set.
+     * in cakephp/database.
      *
      * @param \Cake\Database\Schema\SchemaDialect $dialect The dialect to use.
      * @param \Migrations\Db\Table\Column $column The column to get the SQL for.
@@ -497,47 +496,7 @@ class MysqlAdapter extends AbstractAdapter
             return $sql;
         }
 
-        $encoding = $column->getEncoding();
-        if ($encoding !== null) {
-            return $this->columnDefinitionSqlWithEncoding($dialect, $columnData, $encoding);
-        }
-
         return $dialect->columnDefinitionSql($this->mapColumnData($columnData));
-    }
-
-    /**
-     * Get the SQL fragment for a column that declares an explicit character set.
-     *
-     * cakephp/database renders no per-column character set, and MySQL requires
-     * `CHARACTER SET` to precede `COLLATE`, so the fragment cannot simply be appended
-     * to the generated definition. It is instead rendered with a placeholder collation,
-     * and the `CHARACTER SET`/`COLLATE` pair replaces the placeholder in that position.
-     *
-     * Types that cannot carry a character set never render a collation, so the
-     * placeholder is absent for them and their definition is returned unchanged.
-     *
-     * @param \Cake\Database\Schema\SchemaDialect $dialect The dialect to use.
-     * @param array<string, mixed> $columnData The column data to render.
-     * @param string $encoding The character set the column was declared with.
-     * @return string
-     */
-    protected function columnDefinitionSqlWithEncoding(
-        SchemaDialect $dialect,
-        array $columnData,
-        string $encoding,
-    ): string {
-        $collation = isset($columnData['collate']) ? (string)$columnData['collate'] : '';
-        $placeholder = '__migrations_encoding__';
-        $columnData['collate'] = $placeholder;
-
-        $sql = $dialect->columnDefinitionSql($this->mapColumnData($columnData));
-
-        $replacement = 'CHARACTER SET ' . $encoding;
-        if ($collation !== '') {
-            $replacement .= ' COLLATE ' . $collation;
-        }
-
-        return str_replace('COLLATE ' . $placeholder, $replacement, $sql);
     }
 
     /**

--- a/src/Db/Adapter/MysqlAdapter.php
+++ b/src/Db/Adapter/MysqlAdapter.php
@@ -466,7 +466,8 @@ class MysqlAdapter extends AbstractAdapter
      *
      * This method provides backwards compatibility for enum and set types
      * as userland migrations use those types, but they are not supported
-     * in cakephp/database.
+     * in cakephp/database. The `encoding` option is handled here for the
+     * same reason: cakephp/database has no per-column character set.
      *
      * @param \Cake\Database\Schema\SchemaDialect $dialect The dialect to use.
      * @param \Migrations\Db\Table\Column $column The column to get the SQL for.
@@ -496,7 +497,47 @@ class MysqlAdapter extends AbstractAdapter
             return $sql;
         }
 
+        $encoding = $column->getEncoding();
+        if ($encoding !== null) {
+            return $this->columnDefinitionSqlWithEncoding($dialect, $columnData, $encoding);
+        }
+
         return $dialect->columnDefinitionSql($this->mapColumnData($columnData));
+    }
+
+    /**
+     * Get the SQL fragment for a column that declares an explicit character set.
+     *
+     * cakephp/database renders no per-column character set, and MySQL requires
+     * `CHARACTER SET` to precede `COLLATE`, so the fragment cannot simply be appended
+     * to the generated definition. It is instead rendered with a placeholder collation,
+     * and the `CHARACTER SET`/`COLLATE` pair replaces the placeholder in that position.
+     *
+     * Types that cannot carry a character set never render a collation, so the
+     * placeholder is absent for them and their definition is returned unchanged.
+     *
+     * @param \Cake\Database\Schema\SchemaDialect $dialect The dialect to use.
+     * @param array<string, mixed> $columnData The column data to render.
+     * @param string $encoding The character set the column was declared with.
+     * @return string
+     */
+    protected function columnDefinitionSqlWithEncoding(
+        SchemaDialect $dialect,
+        array $columnData,
+        string $encoding,
+    ): string {
+        $collation = isset($columnData['collate']) ? (string)$columnData['collate'] : '';
+        $placeholder = '__migrations_encoding__';
+        $columnData['collate'] = $placeholder;
+
+        $sql = $dialect->columnDefinitionSql($this->mapColumnData($columnData));
+
+        $replacement = 'CHARACTER SET ' . $encoding;
+        if ($collation !== '') {
+            $replacement .= ' COLLATE ' . $collation;
+        }
+
+        return str_replace('COLLATE ' . $placeholder, $replacement, $sql);
     }
 
     /**

--- a/src/Db/Table/Column.php
+++ b/src/Db/Table/Column.php
@@ -920,6 +920,7 @@ class Column extends DatabaseColumn
             'unsigned' => $this->getUnsigned(),
             'fixed' => $this->getFixed(),
             'onUpdate' => $this->getUpdate(),
+            'charset' => $this->getEncoding(),
             'collate' => $this->getCollation(),
             'precision' => $precision,
             'srid' => $this->getSrid(),

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -895,10 +895,7 @@ class MysqlAdapterTest extends TestCase
     }
 
     /**
-     * Reads the character set MySQL actually stored for a column.
-     *
-     * `SHOW FULL COLUMNS` only exposes the collation, which cannot distinguish an
-     * explicit `CHARACTER SET` from one inherited from the table default.
+     * SHOW FULL COLUMNS only exposes the collation, so read the character set from information_schema.
      */
     protected function fetchColumnEncoding(string $table, string $column): ?string
     {

--- a/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/TestCase/Db/Adapter/MysqlAdapterTest.php
@@ -848,6 +848,70 @@ class MysqlAdapterTest extends TestCase
         $this->assertEquals('utf8mb4_unicode_ci', $rows[2]['Collation']);
     }
 
+    public function testCreateTableWithCustomEncoding(): void
+    {
+        $table = new Table('table_create_encoding', [], $this->adapter);
+        $table->addColumn('string_encoding_custom', 'string', ['encoding' => 'ascii'])
+              ->addColumn('text_encoding_custom', 'text', ['encoding' => 'ascii'])
+              ->save();
+
+        $this->assertEquals('ascii', $this->fetchColumnEncoding('table_create_encoding', 'string_encoding_custom'));
+        $this->assertEquals('ascii', $this->fetchColumnEncoding('table_create_encoding', 'text_encoding_custom'));
+    }
+
+    public function testAddStringColumnWithCustomEncoding(): void
+    {
+        $table = new Table('table_custom_encoding', [], $this->adapter);
+        $table->save();
+        $table->addColumn('string_encoding_custom', 'string', ['encoding' => 'ascii'])->save();
+        $table->addColumn('text_encoding_custom', 'text', ['encoding' => 'ascii'])->save();
+
+        $this->assertEquals('ascii', $this->fetchColumnEncoding('table_custom_encoding', 'string_encoding_custom'));
+        $this->assertEquals('ascii', $this->fetchColumnEncoding('table_custom_encoding', 'text_encoding_custom'));
+    }
+
+    public function testAddStringColumnWithCustomEncodingAndCollation(): void
+    {
+        $table = new Table('table_custom_encoding_collation', [], $this->adapter);
+        $table->save();
+        $table->addColumn('string_both', 'string', [
+            'encoding' => 'ascii',
+            'collation' => 'ascii_bin',
+        ])->save();
+
+        $rows = $this->adapter->fetchAll('SHOW FULL COLUMNS FROM table_custom_encoding_collation');
+        $this->assertEquals('ascii_bin', $rows[1]['Collation']);
+        $this->assertEquals('ascii', $this->fetchColumnEncoding('table_custom_encoding_collation', 'string_both'));
+    }
+
+    public function testChangeColumnWithCustomEncoding(): void
+    {
+        $table = new Table('table_change_encoding', [], $this->adapter);
+        $table->addColumn('string_column', 'string')->save();
+        $this->assertEquals('utf8mb4', $this->fetchColumnEncoding('table_change_encoding', 'string_column'));
+
+        $table->changeColumn('string_column', 'string', ['encoding' => 'ascii'])->save();
+        $this->assertEquals('ascii', $this->fetchColumnEncoding('table_change_encoding', 'string_column'));
+    }
+
+    /**
+     * Reads the character set MySQL actually stored for a column.
+     *
+     * `SHOW FULL COLUMNS` only exposes the collation, which cannot distinguish an
+     * explicit `CHARACTER SET` from one inherited from the table default.
+     */
+    protected function fetchColumnEncoding(string $table, string $column): ?string
+    {
+        $row = $this->adapter->fetchRow(sprintf(
+            'SELECT CHARACTER_SET_NAME FROM information_schema.COLUMNS ' .
+            "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' AND COLUMN_NAME = '%s'",
+            $table,
+            $column,
+        ));
+
+        return $row['CHARACTER_SET_NAME'] ?? null;
+    }
+
     public function testRenameColumn(): void
     {
         $table = new Table('t', [], $this->adapter);


### PR DESCRIPTION
Fixes #1113.

The per-column `encoding` option is accepted and documented but never reaches the SQL for anything other than `enum`/`set`. cakephp/cakephp#19614 adds a `charset` column attribute to `MysqlSchemaDialect`; this maps `encoding` onto it.

Depends on that PR and a `cakephp/database` bump once it ships. Tests read `information_schema` because `SHOW FULL COLUMNS` only exposes the collation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpXY8G8bDZdga92LvMaVho
